### PR TITLE
Fix heating target-temperature range

### DIFF
--- a/custom_components/solarfocus/number.py
+++ b/custom_components/solarfocus/number.py
@@ -148,7 +148,7 @@ HEATING_CIRCUIT_NUMBER_TYPES = [
         entity_category=EntityCategory.CONFIG,
         native_unit_of_measurement=TEMP_CELSIUS,
         native_min_value=0.0,
-        native_max_value=35.0,
+        native_max_value=80.0,
         native_step=0.5,
     ),
 ]

--- a/custom_components/solarfocus/number.py
+++ b/custom_components/solarfocus/number.py
@@ -147,7 +147,7 @@ HEATING_CIRCUIT_NUMBER_TYPES = [
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.CONFIG,
         native_unit_of_measurement=TEMP_CELSIUS,
-        native_min_value=7.0,
+        native_min_value=0.0,
         native_max_value=35.0,
         native_step=0.5,
     ),


### PR DESCRIPTION
The specified range for controlling the heating-circuit is from 7°C (for cooling) up to max value heating curve. However, setting it to 0°C resets the heating controller (from Solarfocus) to automatic (calculating the values from the set curve).

The max value depends on the installation itself, hence, I took a max value of 80°C, as this is the max value of the boiler.

0.0°C -> Supply Temperature controlled by Solarfocus
7°C - 35°C -> valid range when cooling is activated
22°C - max. temperature of heating curve (depends on setup) -> valid range when heating is activated

❗ After this change is implemented, any value from 0 - 80 °C will be accepted, even if invalid in certain cases. 