### PR TITLE
add message string for biomass boiler message 0

### DIFF
--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -195,6 +195,7 @@
       },
       "bb_message_number" : {
         "state" : {
+          "0": "No Message",
           "1": "Internal memory is invalid",
           "3": "Container sensor possibly dusty",
           "5": "Flue gas temperature too low",

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -253,6 +253,7 @@
       },
       "bb_message_number" : {
         "state" : {
+          "0": "Keine Meldung",
           "1": "Interner Speicher ist ungültig",
           "3": "Behältersensor möglicherweise verstaubt",
           "5": "Abgastemperatur zu gering",

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -195,6 +195,7 @@
       },
       "bb_message_number" : {
         "state" : {
+          "0": "No Message",
           "1": "Internal memory is invalid",
           "3": "Container sensor possibly dusty",
           "5": "Flue gas temperature too low",


### PR DESCRIPTION
In the official documentation only the messages are documented starting from 1, 
Obviously 0 is "no message" which is more readable that "0"
![grafik](https://github.com/LavermanJJ/home-assistant-solarfocus/assets/72338417/38423c26-6bcf-4096-9727-7e84808b9034)

added 
```
      "bb_message_number" : {
        "state" : {
          "0": "No Message",
```