### PR TITLE
Drop removed `WaterHeaterEntityEntityDescription` fallback

### DIFF
--- a/custom_components/solarfocus/water_heater.py
+++ b/custom_components/solarfocus/water_heater.py
@@ -5,15 +5,9 @@ import logging
 
 from homeassistant.components.water_heater import (
     WaterHeaterEntity,
+    WaterHeaterEntityDescription,
     WaterHeaterEntityFeature,
 )
-
-try:
-    from homeassistant.components.water_heater import WaterHeaterEntityDescription
-except ImportError:
-    from homeassistant.components.water_heater import (
-        WaterHeaterEntityEntityDescription as WaterHeaterEntityDescription,
-    )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_TEMPERATURE,


### PR DESCRIPTION
`WaterHeaterEntityEntityDescription` was renamed to `WaterHeaterEntityDescription` in HA 2025.1, and the old alias was [removed in 2026.1](https://developers.home-assistant.io/blog/2024/12/13/water-heater-entity-description). The `try`/`except ImportError` fallback in `water_heater.py` can therefore never resolve on any supported HA version — the integration already pins `homeassistant>=2025.1.0`.

This imports `WaterHeaterEntityDescription` directly alongside the other `water_heater` imports.

No behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)