### PR TITLE
Fix climate turn on/off and drop removed compatibility flag

### DIFF
--- a/custom_components/solarfocus/climate.py
+++ b/custom_components/solarfocus/climate.py
@@ -80,7 +80,6 @@ class SolarfocusClimateEntityDescription(
 class SolarfocusClimateEntity(SolarfocusEntity, ClimateEntity):
     """Representation of a Solarfocus number entity."""
 
-    _enable_turn_on_off_backwards_compatibility = False
     _attr_supported_features = (
         ClimateEntityFeature.PRESET_MODE
         | ClimateEntityFeature.TURN_ON
@@ -231,11 +230,11 @@ class SolarfocusClimateEntity(SolarfocusEntity, ClimateEntity):
 
     async def async_turn_on(self) -> None:
         """Turn on - by setting HVAC mode to HEAT."""
-        self.async_set_hvac_mode(HVACMode.HEAT)
+        await self.async_set_hvac_mode(HVACMode.HEAT)
 
     async def async_turn_off(self) -> None:
         """Turn on - by setting HVAC mode to OFF."""
-        self.async_set_hvac_mode(HVACMode.OFF)
+        await self.async_set_hvac_mode(HVACMode.OFF)
 
 
 CLIMATE_TYPES = [

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,93 @@
+"""Test the Solarfocus climate entity."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.solarfocus.climate import (
+    SolarfocusClimateEntity,
+    SolarfocusClimateEntityDescription,
+)
+from custom_components.solarfocus.const import (
+    HEATING_CIRCUIT_COMPONENT,
+    HEATING_CIRCUIT_COMPONENT_PREFIX,
+    HEATING_CIRCUIT_PREFIX,
+)
+from custom_components.solarfocus.entity import create_description
+from homeassistant.components.climate.const import HVACMode
+
+
+@pytest.fixture(name="climate")
+def climate_fixture() -> SolarfocusClimateEntity:
+    """Return a thermostat entity for heating circuit 1 with a mocked coordinator."""
+    coordinator = MagicMock()
+    coordinator._entry.title = "Solarfocus"
+
+    description = create_description(
+        HEATING_CIRCUIT_PREFIX,
+        HEATING_CIRCUIT_COMPONENT,
+        HEATING_CIRCUIT_COMPONENT_PREFIX,
+        "1",
+        SolarfocusClimateEntityDescription(key="thermostat"),
+    )
+
+    return SolarfocusClimateEntity(coordinator, description)
+
+
+async def test_turn_on_sets_heat_mode(climate: SolarfocusClimateEntity) -> None:
+    """Turning on writes the registers for HVACMode.HEAT."""
+    with (
+        patch.object(climate, "_set_native_value") as set_value,
+        patch.object(climate, "_get_native_value", return_value=0),
+    ):
+        await climate.async_turn_on()
+
+    # state 0 means the circuit is off, so it is switched back to mode "comfort"
+    assert set_value.call_args_list == [
+        (("mode", "0"),),
+        (("cooling", "0"),),
+    ]
+
+
+async def test_turn_on_while_running_only_disables_cooling(
+    climate: SolarfocusClimateEntity,
+) -> None:
+    """A circuit that is already running keeps its mode."""
+    with (
+        patch.object(climate, "_set_native_value") as set_value,
+        patch.object(climate, "_get_native_value", return_value=31),
+    ):
+        await climate.async_turn_on()
+
+    assert set_value.call_args_list == [(("cooling", "0"),)]
+
+
+async def test_turn_off_sets_off_mode(climate: SolarfocusClimateEntity) -> None:
+    """Turning off writes the register for HVACMode.OFF."""
+    with (
+        patch.object(climate, "_set_native_value") as set_value,
+        patch.object(climate, "_get_native_value", return_value=31),
+    ):
+        await climate.async_turn_off()
+
+    assert set_value.call_args_list == [(("mode", "3"),)]
+
+
+@pytest.mark.parametrize(
+    ("hvac_mode", "expected"),
+    [
+        (HVACMode.OFF, [(("mode", "3"),)]),
+        (HVACMode.HEAT, [(("cooling", "0"),)]),
+    ],
+)
+async def test_set_hvac_mode(
+    climate: SolarfocusClimateEntity, hvac_mode: HVACMode, expected: list
+) -> None:
+    """Setting the hvac mode directly writes the same registers."""
+    with (
+        patch.object(climate, "_set_native_value") as set_value,
+        patch.object(climate, "_get_native_value", return_value=31),
+    ):
+        await climate.async_set_hvac_mode(hvac_mode)
+
+    assert set_value.call_args_list == expected


### PR DESCRIPTION
Two changes to `climate.py`, both in the turn-on/turn-off code path:

**1. Drop `_enable_turn_on_off_backwards_compatibility`**

The flag was a transitional opt-out while [`ClimateEntityFeature.TURN_ON`/`TURN_OFF`](https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded) were being rolled out, and core removed it in 2025.1. `SolarfocusClimateEntity` already declares both features, so the attribute is dead weight and setting it has no effect.

**2. Actually await `async_set_hvac_mode`**

```python
async def async_turn_on(self) -> None:
    self.async_set_hvac_mode(HVACMode.HEAT)   # coroutine created, never awaited
```

`async_turn_on` and `async_turn_off` built a coroutine and dropped it, so calling `climate.turn_on` / `climate.turn_off` on the thermostat did nothing (aside from a "coroutine was never awaited" RuntimeWarning). Both now `await` the call, which is the behavioural fix in this PR.

`make check` shows no new findings (the `sensor.py:177` broad-except warning is pre-existing on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)