### PR TITLE
Fix AttributeError on buffer external_* sensors for Therminator/Ecotop

### DIFF
--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -319,7 +319,11 @@ BUFFER_SENSOR_TYPES = [
         icon="mdi:thermometer-high",
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        unsupported_systems=[Systems.VAMPAIR],
+        unsupported_systems=[
+            Systems.VAMPAIR,
+            Systems.PELLETELEGANCE,
+            Systems.OCTOPLUS,
+        ],
     ),
     SolarfocusSensorEntityDescription(
         key="external_top_temperature_x44",
@@ -329,6 +333,7 @@ BUFFER_SENSOR_TYPES = [
         state_class=SensorStateClass.MEASUREMENT,
         min_required_version="22.090",
         entity_registry_enabled_default=False,
+        unsupported_systems=[Systems.THERMINATOR, Systems.ECOTOP],
     ),
     SolarfocusSensorEntityDescription(
         key="external_middle_temperature_x36",
@@ -338,6 +343,7 @@ BUFFER_SENSOR_TYPES = [
         state_class=SensorStateClass.MEASUREMENT,
         min_required_version="22.090",
         entity_registry_enabled_default=False,
+        unsupported_systems=[Systems.THERMINATOR, Systems.ECOTOP],
     ),
     SolarfocusSensorEntityDescription(
         key="external_bottom_temperature_x35",
@@ -347,6 +353,7 @@ BUFFER_SENSOR_TYPES = [
         state_class=SensorStateClass.MEASUREMENT,
         min_required_version="22.090",
         entity_registry_enabled_default=False,
+        unsupported_systems=[Systems.THERMINATOR, Systems.ECOTOP],
     ),
 ]
 

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -1,0 +1,173 @@
+"""Verify entity descriptions against the components pysolarfocus actually exposes.
+
+Every entity description names a `key` that is read off a pysolarfocus component at
+runtime via `getattr`. If the component for a given Solarfocus system does not carry
+that attribute, the entity is still created and every coordinator refresh raises
+`AttributeError` -- see issue #163, where the buffer `external_*` sensors were declared
+for all systems although `TherminatorBuffer` does not have them.
+
+These tests walk every description in every platform and assert the attribute exists
+for each system the description is not explicitly excluded from.
+"""
+
+import pytest
+from pysolarfocus import ApiVersions, SolarfocusAPI, Systems
+
+from custom_components.solarfocus import (
+    binary_sensor,
+    button,
+    climate,
+    number,
+    select,
+    sensor,
+    switch,
+    water_heater,
+)
+from custom_components.solarfocus.const import (
+    BIOMASS_BOILER_COMPONENT,
+    BOILER_COMPONENT,
+    BUFFER_COMPONENT,
+    FRESH_WATER_MODULE_COMPONENT,
+    HEAT_PUMP_COMPONENT,
+    HEATING_CIRCUIT_COMPONENT,
+    PHOTOVOLTAIC_COMPONENT,
+    SOLAR_COMPONENT,
+)
+
+# Entity description list -> the SolarfocusAPI attribute it is read from.
+# Mirrors the wiring in each platform's async_setup_entry.
+DESCRIPTION_LISTS = [
+    (sensor.HEATING_CIRCUIT_SENSOR_TYPES, HEATING_CIRCUIT_COMPONENT),
+    (sensor.BUFFER_SENSOR_TYPES, BUFFER_COMPONENT),
+    (sensor.BOILER_SENSOR_TYPES, BOILER_COMPONENT),
+    (sensor.HEATPUMP_SENSOR_TYPES, HEAT_PUMP_COMPONENT),
+    (sensor.PHOTOVOLTAIC_SENSOR_TYPES, PHOTOVOLTAIC_COMPONENT),
+    (sensor.BIOMASS_BOILER_SENSOR_TYPES, BIOMASS_BOILER_COMPONENT),
+    (sensor.SOLAR_SENSOR_TYPES, SOLAR_COMPONENT),
+    (sensor.FRESH_WATER_MODULE_SENSOR_TYPES, FRESH_WATER_MODULE_COMPONENT),
+    (number.HEATING_CIRCUIT_NUMBER_TYPES, HEATING_CIRCUIT_COMPONENT),
+    (number.BOILER_NUMBER_TYPES, BOILER_COMPONENT),
+    (select.HEATPUMP_SELECT_TYPES, HEAT_PUMP_COMPONENT),
+    (select.HEATING_CIRCUIT_SELECT_TYPES, HEATING_CIRCUIT_COMPONENT),
+    (select.BOILER_SELECT_TYPES, BOILER_COMPONENT),
+    (switch.HEATPUMP_SWITCH_TYPES, HEAT_PUMP_COMPONENT),
+    (button.BOILER_BUTTON_TYPES, BOILER_COMPONENT),
+    (binary_sensor.HEATING_CIRCUIT_BINARY_SENSOR_TYPES, HEATING_CIRCUIT_COMPONENT),
+    (binary_sensor.BUFFER_BINARY_SENSOR_TYPES, BUFFER_COMPONENT),
+    (binary_sensor.HEATPUMP_BINARY_SENSOR_TYPES, HEAT_PUMP_COMPONENT),
+    (binary_sensor.BIOMASS_BOILER_BINARY_SENSOR_TYPES, BIOMASS_BOILER_COMPONENT),
+    (binary_sensor.PHOTOVOLTAIC_BINARY_SENSOR_TYPES, PHOTOVOLTAIC_COMPONENT),
+    (binary_sensor.FRESH_WATER_MODULE_BINARY_SENSOR_TYPES, FRESH_WATER_MODULE_COMPONENT),
+]
+
+# water_heater and climate are composite entities: their description key is only a
+# label ("domestic_hot_water", "thermostat") and the registers they touch are named
+# inline in the property implementations. Those names are listed here so they get the
+# same coverage as the key-based platforms.
+COMPOSITE_ITEMS = [
+    (
+        BOILER_COMPONENT,
+        water_heater.WATER_HEATER_TYPES,
+        ["temperature", "target_temperature", "mode", "holding_mode"],
+    ),
+    (
+        HEATING_CIRCUIT_COMPONENT,
+        climate.CLIMATE_TYPES,
+        ["cooling", "target_supply_temperature", "supply_temperature", "state", "mode"],
+    ),
+]
+
+# Highest version the installed pysolarfocus knows about, so that no register is
+# hidden behind a version gate while checking.
+LATEST_API_VERSION = list(ApiVersions)[-1]
+
+
+def _component(system: Systems, component: str):
+    """Return the pysolarfocus component instance for a system."""
+    api = SolarfocusAPI(
+        ip="127.0.0.1", system=system, api_version=LATEST_API_VERSION
+    )
+    comp = getattr(api, component)
+    return comp[0] if isinstance(comp, list) else comp
+
+
+def _cases():
+    """Yield (system, component, key) for every description/system combination."""
+    for descriptions, component in DESCRIPTION_LISTS:
+        for description in descriptions:
+            unsupported = description.unsupported_systems or []
+            for system in Systems:
+                if system in unsupported:
+                    continue
+                yield pytest.param(
+                    system,
+                    component,
+                    description.key,
+                    id=f"{system.name}-{component}-{description.key}",
+                )
+
+
+@pytest.mark.parametrize(("system", "component", "key"), list(_cases()))
+def test_description_key_exists_on_component(
+    system: Systems, component: str, key: str
+) -> None:
+    """Every entity key must exist on the component for every supported system."""
+    obj = _component(system, component)
+    assert hasattr(obj, key), (
+        f"{type(obj).__name__} (system {system.name}) has no attribute '{key}'. "
+        f"Either the key is wrong or the description needs "
+        f"unsupported_systems=[Systems.{system.name}]."
+    )
+
+
+def _composite_cases():
+    """Yield (system, component, item) for the composite entities."""
+    for component, descriptions, items in COMPOSITE_ITEMS:
+        unsupported = {
+            s for d in descriptions for s in (d.unsupported_systems or [])
+        }
+        for system in Systems:
+            if system in unsupported:
+                continue
+            for item in items:
+                yield pytest.param(
+                    system, component, item, id=f"{system.name}-{component}-{item}"
+                )
+
+
+@pytest.mark.parametrize(("system", "component", "item"), list(_composite_cases()))
+def test_composite_entity_item_exists_on_component(
+    system: Systems, component: str, item: str
+) -> None:
+    """Registers read inline by water_heater/climate must exist too."""
+    obj = _component(system, component)
+    assert hasattr(obj, item), (
+        f"{type(obj).__name__} (system {system.name}) has no attribute '{item}'"
+    )
+
+
+def test_buffer_external_sensors_excluded_for_therminator_buffer() -> None:
+    """Regression test for #163.
+
+    THERMINATOR and ECOTOP use TherminatorBuffer, which has no external_* registers.
+    """
+    external = [
+        d
+        for d in sensor.BUFFER_SENSOR_TYPES
+        if d.key.startswith("external_")
+    ]
+    assert external, "expected external_* buffer sensors to exist"
+
+    for description in external:
+        assert Systems.THERMINATOR in (description.unsupported_systems or [])
+        assert Systems.ECOTOP in (description.unsupported_systems or [])
+
+
+def test_buffer_x35_excluded_where_missing() -> None:
+    """x35_temperature only exists on TherminatorBuffer, not on the plain Buffer."""
+    description = next(
+        d for d in sensor.BUFFER_SENSOR_TYPES if d.key == "x35_temperature"
+    )
+    unsupported = description.unsupported_systems or []
+    for system in (Systems.VAMPAIR, Systems.PELLETELEGANCE, Systems.OCTOPLUS):
+        assert system in unsupported


### PR DESCRIPTION
Fixes #163.

## Cause

`pysolarfocus` has two buffer classes exposing different registers:

| Buffer class | Systems | `external_*_x44/x36/x35` | `x35_temperature` |
|---|---|---|---|
| `Buffer` | VAMPAIR, PELLETELEGANCE, OCTOPLUS | ✅ | ❌ |
| `TherminatorBuffer` | THERMINATOR, ECOTOP | ❌ | ✅ |

The three `external_*` sensors in `BUFFER_SENSOR_TYPES` declared no `unsupported_systems`, so on a Therminator or Ecotop they were created regardless and every coordinator refresh raised:

```
'TherminatorBuffer' object has no attribute 'external_top_temperature_x44'
```

The reporter saw 5241 occurrences. Note `entity_registry_enabled_default=False` does **not** protect against this — the entity is still constructed and still polled.

`x35_temperature` is the mirror image: it exists only on `TherminatorBuffer` but excluded only `VAMPAIR`, leaving the same defect for Pelletelegance and Octoplus. Not reachable today since the config flow offers only three systems (#139), but fixed here since it is the identical bug and the new test proves it.

## Test

`tests/test_entity_descriptions.py` walks every entity description across all eight platforms, for every system it is not explicitly excluded from, and asserts the register actually exists on the corresponding pysolarfocus component — 516 parametrized cases.

`water_heater` and `climate` are handled separately: their description keys (`domestic_hot_water`, `thermostat`) are labels rather than registers, and the registers they touch are named inline in the property bodies, so those names are listed explicitly and get the same coverage.

Verified the test catches the regression — reverting just the `external_*` change fails 7 cases:

```
FAILED ...[THERMINATOR-buffers-external_top_temperature_x44]
FAILED ...[ECOTOP-buffers-external_top_temperature_x44]
FAILED ...[THERMINATOR-buffers-external_middle_temperature_x36]
FAILED ...[ECOTOP-buffers-external_middle_temperature_x36]
FAILED ...[THERMINATOR-buffers-external_bottom_temperature_x35]
FAILED ...[ECOTOP-buffers-external_bottom_temperature_x35]
FAILED ...test_buffer_external_sensors_excluded_for_therminator_buffer
7 failed, 515 passed
```

With the fix: `516 passed`. `make check` unchanged from `main` (two pre-existing warnings: `sensor.py:177`, `config_flow.py:295`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
