### PR TITLE
Remove impossible state class from boiler_operating_mode

### DIFF
--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -613,7 +613,6 @@ BIOMASS_BOILER_SENSOR_TYPES = [
     SolarfocusSensorEntityDescription(
         key="boiler_operating_mode",
         icon="mdi:format-list-bulleted",
-        state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.ENUM,
         options=list(range(0, 6)),
         unsupported_systems=[Systems.VAMPAIR, Systems.ECOTOP],

--- a/tests/test_sensor_descriptions.py
+++ b/tests/test_sensor_descriptions.py
@@ -1,0 +1,67 @@
+"""Invariants that sensor entity descriptions have to satisfy.
+
+Home Assistant validates some device_class/state_class combinations when an entity
+is added and logs a warning for the invalid ones (see issue #136). Asserting the
+invariant here catches it at build time instead of in a user's log.
+"""
+
+import pytest
+from homeassistant.components.sensor import SensorDeviceClass
+
+from custom_components.solarfocus import sensor
+
+ALL_SENSOR_TYPES = [
+    *sensor.HEATING_CIRCUIT_SENSOR_TYPES,
+    *sensor.BUFFER_SENSOR_TYPES,
+    *sensor.BOILER_SENSOR_TYPES,
+    *sensor.HEATPUMP_SENSOR_TYPES,
+    *sensor.PHOTOVOLTAIC_SENSOR_TYPES,
+    *sensor.BIOMASS_BOILER_SENSOR_TYPES,
+    *sensor.SOLAR_SENSOR_TYPES,
+    *sensor.FRESH_WATER_MODULE_SENSOR_TYPES,
+]
+
+ENUM_SENSOR_TYPES = [
+    d for d in ALL_SENSOR_TYPES if d.device_class is SensorDeviceClass.ENUM
+]
+
+
+def test_enum_sensors_exist() -> None:
+    """Guard the fixtures above against silently matching nothing."""
+    assert ENUM_SENSOR_TYPES
+
+
+@pytest.mark.parametrize(
+    "description", ENUM_SENSOR_TYPES, ids=lambda d: d.key
+)
+def test_enum_sensor_has_no_state_class(description) -> None:
+    """An enum is not a measurement, so it must not declare a state class.
+
+    Core rejects the combination with:
+        "is using state class 'measurement' which is impossible considering
+         device class ('enum') it is using; expected None"
+    """
+    assert description.state_class is None, (
+        f"sensor '{description.key}' declares device_class=ENUM together with "
+        f"state_class={description.state_class!r}; enum sensors must not set one."
+    )
+
+
+@pytest.mark.parametrize(
+    "description", ENUM_SENSOR_TYPES, ids=lambda d: d.key
+)
+def test_enum_sensor_declares_options(description) -> None:
+    """An enum sensor without options renders every state as a raw value."""
+    assert description.options, f"sensor '{description.key}' declares no options"
+
+
+@pytest.mark.parametrize(
+    "description", ALL_SENSOR_TYPES, ids=lambda d: d.key
+)
+def test_non_enum_sensor_declares_no_options(description) -> None:
+    """Core raises if options are provided without the enum device class."""
+    if description.device_class is not SensorDeviceClass.ENUM:
+        assert not description.options, (
+            f"sensor '{description.key}' provides options but its device class is "
+            f"{description.device_class!r} instead of 'enum'"
+        )


### PR DESCRIPTION
Fixes #136.

## Cause

```python
SolarfocusSensorEntityDescription(
    key="boiler_operating_mode",
    icon="mdi:format-list-bulleted",
    state_class=SensorStateClass.MEASUREMENT,   # <-- impossible with ENUM
    device_class=SensorDeviceClass.ENUM,
    options=list(range(0, 6)),
    unsupported_systems=[Systems.VAMPAIR, Systems.ECOTOP],
),
```

`MEASUREMENT` describes a continuously variable numeric quantity, which an enum is not, so core warns and expects `None`. Sweeping every entity description in the integration, this is the **only** occurrence — a one-line fix.

## Tests

`tests/test_sensor_descriptions.py` asserts three invariants across all sensor types rather than just this one entity:

1. enum sensors declare no `state_class` — the reported bug
2. enum sensors do declare `options` — without them every state renders raw
3. non-enum sensors declare no `options` — core raises `"is providing enum options, but is missing the enum device class"`

Verified the first catches the regression — restoring the `state_class` line fails exactly one case:

```
FAILED tests/test_sensor_descriptions.py::test_enum_sensor_has_no_state_class[boiler_operating_mode]
1 failed, 102 passed
```

With the fix: `103 passed`. `make check` unchanged from `main` (two pre-existing warnings: `sensor.py:177`, `config_flow.py:295`).

## Left out deliberately

While checking this I found `bb_boiler_operating_mode` has **no translation block at all** — it is absent from `strings.json`, `translations/en.json` and `translations/de.json`, so even with the warning gone the sensor displays a bare integer `0`–`5` instead of a mode name. Every other enum sensor has one.

I did not add it because that needs the real Solarfocus mode names for this register and I did not want to invent them. If you can confirm the labels I will follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
