### PR TITLE
Stop enum sensors rejecting states they have translations for

### DIFF
--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -376,7 +376,8 @@ BOILER_SENSOR_TYPES = [
         key="single_charge",
         icon="mdi:pump",
         device_class=SensorDeviceClass.ENUM,
-        options=list(range(0, 2)),
+        # -1 ("Locked") is a valid reading, same as for circulation below
+        options=list(range(-1, 2)),
     ),
     SolarfocusSensorEntityDescription(
         key="circulation",
@@ -591,7 +592,10 @@ BIOMASS_BOILER_SENSOR_TYPES = [
         key="message_number",
         icon="mdi:message-text-outline",
         device_class=SensorDeviceClass.ENUM,
-        options=list(range(0, 88)),
+        # The 200-range mirrors the 0-range as "acknowledged", and 2010 is a
+        # standalone code. All three blocks are translated, so all three have to
+        # be listed or core rejects the state -- see issue #165.
+        options=list(range(0, 88)) + list(range(200, 288)) + [2010],
     ),
     SolarfocusSensorEntityDescription(
         key="cleaning",

--- a/tests/test_sensor_enum_options.py
+++ b/tests/test_sensor_enum_options.py
@@ -1,0 +1,112 @@
+"""Keep enum sensor `options` in sync with the translated states.
+
+For a sensor with `device_class=ENUM`, core raises
+
+    ValueError: Sensor <entity_id> provides state value '<x>',
+                which is not in the list of options provided
+
+whenever the device reports a value outside `options`, and the entity then stops
+updating entirely (issue #165).
+
+A translated state is the integration asserting "the device can report this", so
+every translated state must appear in `options`. The reverse is not required: an
+option without a translation merely renders as a raw number.
+"""
+
+import json
+import pathlib
+
+import pytest
+from homeassistant.components.sensor import SensorDeviceClass
+
+from custom_components.solarfocus import sensor
+from custom_components.solarfocus.const import (
+    BIOMASS_BOILER_COMPONENT_PREFIX,
+    BOILER_COMPONENT_PREFIX,
+    BUFFER_COMPONENT_PREFIX,
+    FRESH_WATER_MODULE_COMPONENT_PREFIX,
+    HEAT_PUMP_COMPONENT_PREFIX,
+    HEATING_CIRCUIT_COMPONENT_PREFIX,
+    PHOTOVOLTAIC_COMPONENT_PREFIX,
+    SOLAR_COMPONENT_PREFIX,
+)
+
+COMPONENT_DIR = pathlib.Path(sensor.__file__).parent
+
+# Entity list -> the translation-key prefix create_description() builds keys with.
+SENSOR_TYPES_BY_PREFIX = [
+    (sensor.HEATING_CIRCUIT_SENSOR_TYPES, HEATING_CIRCUIT_COMPONENT_PREFIX),
+    (sensor.BUFFER_SENSOR_TYPES, BUFFER_COMPONENT_PREFIX),
+    (sensor.BOILER_SENSOR_TYPES, BOILER_COMPONENT_PREFIX),
+    (sensor.HEATPUMP_SENSOR_TYPES, HEAT_PUMP_COMPONENT_PREFIX),
+    (sensor.PHOTOVOLTAIC_SENSOR_TYPES, PHOTOVOLTAIC_COMPONENT_PREFIX),
+    (sensor.BIOMASS_BOILER_SENSOR_TYPES, BIOMASS_BOILER_COMPONENT_PREFIX),
+    (sensor.SOLAR_SENSOR_TYPES, SOLAR_COMPONENT_PREFIX),
+    (sensor.FRESH_WATER_MODULE_SENSOR_TYPES, FRESH_WATER_MODULE_COMPONENT_PREFIX),
+]
+
+
+def _translations(filename: str) -> dict:
+    with (COMPONENT_DIR / filename).open(encoding="utf-8") as fh:
+        return json.load(fh)["entity"]["sensor"]
+
+
+def _cases():
+    """Yield (translation_key, options) for every enum sensor."""
+    for descriptions, prefix in SENSOR_TYPES_BY_PREFIX:
+        for description in descriptions:
+            if description.device_class is not SensorDeviceClass.ENUM:
+                continue
+            yield pytest.param(
+                f"{prefix}_{description.key}",
+                description.options,
+                id=f"{prefix}_{description.key}",
+            )
+
+
+CASES = list(_cases())
+
+
+@pytest.mark.parametrize(
+    "filename", ["strings.json", "translations/en.json", "translations/de.json"]
+)
+@pytest.mark.parametrize(("translation_key", "options"), CASES)
+def test_translated_states_are_valid_options(
+    filename: str, translation_key: str, options: list[int]
+) -> None:
+    """Every translated state must be an accepted option."""
+    entity = _translations(filename).get(translation_key)
+    if entity is None or "state" not in entity:
+        pytest.skip(f"{translation_key} has no states in {filename}")
+
+    translated = {int(state) for state in entity["state"]}
+    missing = sorted(translated - set(options))
+
+    assert not missing, (
+        f"{filename}: '{translation_key}' translates state(s) {missing} that are not "
+        f"in its options list. A device reporting one of these raises ValueError and "
+        f"the entity stops updating."
+    )
+
+
+def test_cases_cover_the_known_enum_sensors() -> None:
+    """Guard the parametrization against silently matching nothing."""
+    keys = {case.values[0] for case in CASES}
+    assert {"bb_message_number", "bo_single_charge", "bo_circulation"} <= keys
+
+
+def test_biomass_message_number_covers_acknowledged_range() -> None:
+    """Regression test for #165: the 200-range and 2010 must be selectable."""
+    description = next(
+        d for d in sensor.BIOMASS_BOILER_SENSOR_TYPES if d.key == "message_number"
+    )
+    for value in (201, 287, 2010):
+        assert value in description.options
+
+
+def test_single_charge_allows_locked_state() -> None:
+    """`-1` (Locked) is translated for single_charge, so it must be an option."""
+    description = next(
+        d for d in sensor.BOILER_SENSOR_TYPES if d.key == "single_charge"
+    )
+    assert -1 in description.options


### PR DESCRIPTION
Fixes #165.

## Cause

For a sensor with `device_class=ENUM`, core raises this whenever the device reports a value outside `options`, and the entity then stops updating entirely:

```
ValueError: Sensor sensor.solarfocus_heating_circuit_1_state provides state value '100',
which is not in the list of options provided
```

A **translated state is the integration asserting that the device can report that value**. So any state present in `strings.json` but absent from `options` is a latent dead entity. Comparing the two across every enum sensor found two:

| Sensor | `options` declared | Translated but rejected |
|---|---|---|
| `bb_message_number` | `range(0, 88)` | **201–287 (59 values) and 2010** |
| `bo_single_charge` | `[0, 1]` | **-1 ("Locked")** |

- `bb_message_number` — any biomass boiler raising a message in the acknowledged 200-range killed the entity.
- `bo_single_charge` — its sibling `bo_circulation` already declared `range(-1, 2)`, so two adjacent sensors disagreed about whether the same reading was possible.

## Test

`tests/test_sensor_enum_options.py` asserts the invariant — translated states ⊆ `options` — for every enum sensor against all three of `strings.json`, `translations/en.json` and `translations/de.json`, so the lists cannot drift apart again.

Verified it catches the regression — reverting both `options` changes fails 8 cases:

```
FAILED ...test_translated_states_are_valid_options[bo_single_charge-strings.json]
FAILED ...test_translated_states_are_valid_options[bo_single_charge-translations/en.json]
FAILED ...test_translated_states_are_valid_options[bo_single_charge-translations/de.json]
FAILED ...test_translated_states_are_valid_options[bb_message_number-strings.json]
FAILED ...test_translated_states_are_valid_options[bb_message_number-translations/en.json]
FAILED ...test_translated_states_are_valid_options[bb_message_number-translations/de.json]
FAILED ...test_biomass_message_number_covers_acknowledged_range
FAILED ...test_single_charge_allows_locked_state
8 failed, 34 passed, 3 skipped
```

With the fix: `42 passed, 3 skipped`. `make check` unchanged from `main` (two pre-existing warnings: `sensor.py:177`, `config_flow.py:295`).

The 3 skips are `bb_boiler_operating_mode`, which has no translation block in any of the three files — the separate gap noted in #136.

## Deliberately not asserted

The reverse direction (every option has a translation) is **not** enforced. Those only render as a raw number rather than failing, and adding them needs the real Solarfocus firmware labels which I did not want to invent. Currently in that category: `hc_state` (216), `bb_status` (11, 13–15, 211, 213–215), `so_state` (200, 202).

## Note on `-1`

Adding `-1` to `bo_single_charge` makes the reading representable, but `-1` is still an invalid Home Assistant translation key, which is the separate CI failure in #95. That needs a decision on how the state should be represented — see my comment there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
