### PR TITLE
Raise test coverage to 100% and fix the config entry migration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.0
+        with:
+          enable-cache: true
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Run tests
+        run: uv run pytest --cov=custom_components.solarfocus --cov-report=term-missing
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.0
+        with:
+          enable-cache: true
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Run ruff
+        run: make check-ruff
+
+      - name: Run pylint
+        run: make check-pylint

--- a/custom_components/solarfocus/__init__.py
+++ b/custom_components/solarfocus/__init__.py
@@ -115,11 +115,11 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 async def async_migrate_entry(hass, config_entry: ConfigEntry):
     """Migrate old entry."""
-    version = config_entry.version
+    _LOGGER.info("Migrating from version %s", config_entry.version)
 
-    _LOGGER.info("Migrating from version %s", version)
-
-    if version == 1:
+    # Every step re-reads config_entry.version so that an entry coming from an old
+    # version is migrated through all following steps in one go.
+    if config_entry.version == 1:
         # Config allows multiple heatings, buffers, and boilers
         # and differentiates system (vampair, therminator)
         new = {**config_entry.data}
@@ -134,7 +134,7 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
 
         hass.config_entries.async_update_entry(config_entry, data=new, version=2)
 
-    if version == 2:
+    if config_entry.version == 2:
         # Add option to configure solar
         new = {**config_entry.data}
 
@@ -142,7 +142,7 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
 
         hass.config_entries.async_update_entry(config_entry, data=new, version=3)
 
-    if version == 3:
+    if config_entry.version == 3:
         new_data = {**config_entry.data}
         new_options = {**config_entry.options}
 
@@ -160,7 +160,13 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         new_options[CONF_PHOTOVOLTAIC] = new_data[CONF_PHOTOVOLTAIC]
         new_options[CONF_SOLAR] = new_data[CONF_SOLAR]
         new_options[CONF_HEATPUMP] = new_data[CONF_HEATPUMP]
-        new_options[CONF_BIOMASS_BOILER] = new_data[CONF_BIOMASS_BOILER]
+
+        # The biomass boiler is still called "pelletsboiler" at this version, the
+        # rename happens in the next migration step.
+        biomass_boiler_key = (
+            "pelletsboiler" if "pelletsboiler" in new_data else CONF_BIOMASS_BOILER
+        )
+        new_options["pelletsboiler"] = new_data[biomass_boiler_key]
 
         # Remove moved data
         del new_data[CONF_HOST]
@@ -172,27 +178,28 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         del new_data[CONF_PHOTOVOLTAIC]
         del new_data[CONF_SOLAR]
         del new_data[CONF_HEATPUMP]
-        del new_data[CONF_BIOMASS_BOILER]
+        del new_data[biomass_boiler_key]
 
 
         hass.config_entries.async_update_entry(
             config_entry, data=new_data, options=new_options, version=4
         )
 
-    if version == 4:
+    if config_entry.version == 4:
         new_data = {**config_entry.data}
         new_options = {**config_entry.options}
 
         # Rename pelletsboiler to biomassboiler
-        new_options[CONF_BIOMASS_BOILER] = new_options["pelletsboiler"]
-        del new_options["pelletsboiler"]
+        new_options[CONF_BIOMASS_BOILER] = new_options.pop(
+            "pelletsboiler", new_options.get(CONF_BIOMASS_BOILER, False)
+        )
 
 
         hass.config_entries.async_update_entry(
             config_entry, data=new_data, options=new_options, version = 5
         )
 
-    if version == 5:
+    if config_entry.version == 5:
         new_data = {**config_entry.data}
         new_options = {**config_entry.options}
 

--- a/custom_components/solarfocus/config_flow.py
+++ b/custom_components/solarfocus/config_flow.py
@@ -285,6 +285,7 @@ class SolarfocusOptionsFlowHandler(config_entries.OptionsFlow):
         """Initialize Solarfocus options flow."""
 
         self._errors = {}
+        self.options: dict[str, Any] = {}
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/solarfocus/const.py
+++ b/custom_components/solarfocus/const.py
@@ -1,7 +1,5 @@
 """Constants for the Solarfocus integration."""
 
-from typing import Final
-
 DOMAIN = "solarfocus"
 UPDATE_LISTENER = "update-listener"
 DATA_COORDINATOR = "data-coordinator"

--- a/custom_components/solarfocus/coordinator.py
+++ b/custom_components/solarfocus/coordinator.py
@@ -33,7 +33,6 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator):
         if not self.api.connect():
             _LOGGER.error("Failed to connect to modbus")
 
-        self.name = entry.title
         self._entry = entry
         self.hass = hass
 

--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -169,16 +169,10 @@ async def async_setup_entry(
             solar_count = 1 if solar_count else 0
 
         # For API versions < 25.030, limit to maximum 1 solar instance
-        try:
-            api_version = version.parse(
-                config_entry.options.get(CONF_API_VERSION, "21.140")
-            )
-            supports_multiple = api_version >= version.parse("25.030")
-        except Exception:
-            # Fallback if version parsing fails
-            supports_multiple = (
-                config_entry.options.get(CONF_API_VERSION, "21.140") >= "25.030"
-            )
+        api_version = version.parse(
+            config_entry.options.get(CONF_API_VERSION, "21.140")
+        )
+        supports_multiple = api_version >= version.parse("25.030")
 
         if not supports_multiple and solar_count > 1:
             solar_count = 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,124 @@
+"""Fixtures for the Solarfocus tests."""
+
+from unittest.mock import MagicMock, patch
+
+from pysolarfocus import ApiVersions, Systems
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.solarfocus.const import (
+    CONF_BIOMASS_BOILER,
+    CONF_BOILER,
+    CONF_BUFFER,
+    CONF_FRESH_WATER_MODULE,
+    CONF_HEATING_CIRCUIT,
+    CONF_HEATPUMP,
+    CONF_PHOTOVOLTAIC,
+    CONF_SOLAR,
+    CONF_SOLARFOCUS_SYSTEM,
+    DEFAULT_NAME,
+    DOMAIN,
+)
+from homeassistant.const import (
+    CONF_API_VERSION,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+)
+
+# The config entry version the integration currently migrates to.
+CURRENT_VERSION = 6
+
+
+def build_options(**overrides) -> dict:
+    """Return config entry options with all components off unless overridden."""
+    options = {
+        CONF_HOST: "solarfocus.local",
+        CONF_PORT: 502,
+        CONF_SCAN_INTERVAL: 10,
+        CONF_API_VERSION: ApiVersions.V_23_020.value,
+        CONF_HEATING_CIRCUIT: 0,
+        CONF_BUFFER: 0,
+        CONF_BOILER: 0,
+        CONF_FRESH_WATER_MODULE: 0,
+        CONF_SOLAR: 0,
+        CONF_HEATPUMP: False,
+        CONF_BIOMASS_BOILER: False,
+        CONF_PHOTOVOLTAIC: False,
+    }
+    options.update(overrides)
+    return options
+
+
+def build_config_entry(
+    system: Systems = Systems.VAMPAIR, **option_overrides
+) -> MockConfigEntry:
+    """Return a config entry in the layout the current version stores."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_NAME,
+        version=CURRENT_VERSION,
+        data={CONF_NAME: DEFAULT_NAME, CONF_SOLARFOCUS_SYSTEM: system},
+        options=build_options(**option_overrides),
+    )
+
+
+@pytest.fixture(name="config_entry")
+def config_entry_fixture() -> MockConfigEntry:
+    """Return a vampair config entry with one of every multi-instance component."""
+    return build_config_entry(
+        heating_circuit=1,
+        buffer=1,
+        boiler=1,
+        heatpump=True,
+    )
+
+
+def build_api(system: Systems = Systems.VAMPAIR) -> MagicMock:
+    """Return a mocked SolarfocusAPI that connects and updates successfully."""
+    api = MagicMock()
+    api.system = system
+    api.api_version = ApiVersions.V_23_020
+    api.connect.return_value = True
+    api.is_connected = True
+    for update in (
+        "update_heating",
+        "update_buffer",
+        "update_boiler",
+        "update_heatpump",
+        "update_photovoltaic",
+        "update_biomassboiler",
+        "update_solar",
+        "update_fresh_water_modules",
+    ):
+        getattr(api, update).return_value = True
+    return api
+
+
+@pytest.fixture(name="api")
+def api_fixture() -> MagicMock:
+    """Return a mocked SolarfocusAPI."""
+    return build_api()
+
+
+@pytest.fixture(name="mock_api")
+def mock_api_fixture(api: MagicMock):
+    """Patch SolarfocusAPI everywhere the integration constructs one."""
+    with (
+        patch(
+            "custom_components.solarfocus.SolarfocusAPI", return_value=api
+        ) as constructor,
+        patch("custom_components.solarfocus.config_flow.SolarfocusAPI", return_value=api),
+    ):
+        constructor.instance = api
+        yield constructor
+
+
+def build_coordinator(entry, api: MagicMock | None = None) -> MagicMock:
+    """Return a coordinator stub that entities can read from."""
+    coordinator = MagicMock()
+    coordinator._entry = entry
+    coordinator.api = api if api is not None else build_api()
+    coordinator.last_update_success = True
+    return coordinator

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,2 +1,408 @@
-"""Test the Solarfocus config flow."""
+"""Test the Solarfocus config flow.
 
+Covers the `config-flow-test-coverage` item of Home Assistant's integration
+quality scale (issue #125): every step, every error path and the options flow.
+"""
+
+from unittest.mock import patch
+
+from pysolarfocus import ApiVersions, Systems
+import pytest
+
+from custom_components.solarfocus.config_flow import (
+    CannotConnect,
+    InvalidAuth,
+    InvalidScanInterval,
+    validate_input,
+)
+from custom_components.solarfocus.const import (
+    CONF_BIOMASS_BOILER,
+    CONF_BOILER,
+    CONF_BUFFER,
+    CONF_FRESH_WATER_MODULE,
+    CONF_HEATING_CIRCUIT,
+    CONF_HEATPUMP,
+    CONF_PHOTOVOLTAIC,
+    CONF_SOLAR,
+    CONF_SOLARFOCUS_SYSTEM,
+    DEFAULT_NAME,
+    DOMAIN,
+)
+from homeassistant.const import (
+    CONF_API_VERSION,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import build_config_entry
+
+USER_INPUT = {
+    CONF_NAME: DEFAULT_NAME,
+    CONF_HOST: "solarfocus.local",
+    CONF_PORT: 502,
+    CONF_SCAN_INTERVAL: 10,
+    CONF_SOLARFOCUS_SYSTEM: Systems.VAMPAIR,
+    CONF_API_VERSION: ApiVersions.V_23_020.value,
+}
+
+VAMPAIR_COMPONENTS = {
+    CONF_HEATING_CIRCUIT: 2,
+    CONF_BUFFER: 1,
+    CONF_BOILER: 1,
+    CONF_FRESH_WATER_MODULE: 0,
+    CONF_HEATPUMP: True,
+    CONF_PHOTOVOLTAIC: False,
+    CONF_SOLAR: 0,
+}
+
+THERMINATOR_COMPONENTS = {
+    CONF_HEATING_CIRCUIT: 1,
+    CONF_BUFFER: 1,
+    CONF_BOILER: 1,
+    CONF_FRESH_WATER_MODULE: 1,
+    CONF_BIOMASS_BOILER: True,
+    CONF_PHOTOVOLTAIC: True,
+    CONF_SOLAR: 2,
+}
+
+
+async def _start_user_step(hass: HomeAssistant, user_input: dict) -> dict:
+    """Run the user step and return its result."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    return await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input
+    )
+
+
+async def test_form_shown_without_input(
+    hass: HomeAssistant, enable_custom_integrations
+) -> None:
+    """The flow starts by asking for the connection details."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] is None
+
+
+async def test_full_flow_vampair(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """A vampair system is stored with the heat pump enabled."""
+    result = await _start_user_step(hass, USER_INPUT)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "component"
+
+    with patch(
+        "custom_components.solarfocus.async_setup_entry", return_value=True
+    ) as setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], VAMPAIR_COMPONENTS
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == DEFAULT_NAME
+    assert result["data"] == {
+        CONF_NAME: DEFAULT_NAME,
+        CONF_SOLARFOCUS_SYSTEM: Systems.VAMPAIR,
+    }
+    assert result["options"] == {
+        CONF_HOST: "solarfocus.local",
+        CONF_PORT: 502,
+        CONF_SCAN_INTERVAL: 10,
+        CONF_API_VERSION: ApiVersions.V_23_020.value,
+        CONF_HEATING_CIRCUIT: 2,
+        CONF_BUFFER: 1,
+        CONF_BOILER: 1,
+        CONF_FRESH_WATER_MODULE: 0,
+        CONF_PHOTOVOLTAIC: False,
+        CONF_SOLAR: 0,
+        CONF_HEATPUMP: True,
+        # A heat pump system never has a biomass boiler
+        CONF_BIOMASS_BOILER: False,
+    }
+    assert len(setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize("system", [Systems.THERMINATOR, Systems.ECOTOP])
+async def test_full_flow_biomass_systems(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, system: Systems
+) -> None:
+    """Biomass systems are stored with the heat pump disabled."""
+    result = await _start_user_step(hass, {**USER_INPUT, CONF_SOLARFOCUS_SYSTEM: system})
+
+    assert result["step_id"] == "component"
+
+    with patch("custom_components.solarfocus.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], THERMINATOR_COMPONENTS
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_SOLARFOCUS_SYSTEM] == system
+    assert result["options"][CONF_BIOMASS_BOILER] is True
+    assert result["options"][CONF_HEATPUMP] is False
+    assert result["options"][CONF_SOLAR] == 2
+    assert result["options"][CONF_FRESH_WATER_MODULE] == 1
+
+
+async def test_form_cannot_connect(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """A device that does not answer keeps the user on the first step."""
+    api.connect.return_value = False
+
+    result = await _start_user_step(hass, USER_INPUT)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_recovers_after_connection_error(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """The user can retry once the device is reachable."""
+    api.connect.return_value = False
+    result = await _start_user_step(hass, USER_INPUT)
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    api.connect.return_value = True
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "component"
+
+
+async def test_form_invalid_auth(
+    hass: HomeAssistant, enable_custom_integrations
+) -> None:
+    """An authentication problem is reported on the form."""
+    with patch(
+        "custom_components.solarfocus.config_flow.validate_input",
+        side_effect=InvalidAuth,
+    ):
+        result = await _start_user_step(hass, USER_INPUT)
+
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_unknown_error(
+    hass: HomeAssistant, enable_custom_integrations
+) -> None:
+    """Any other exception is reported as an unknown error."""
+    with patch(
+        "custom_components.solarfocus.config_flow.validate_input",
+        side_effect=RuntimeError("boom"),
+    ):
+        result = await _start_user_step(hass, USER_INPUT)
+
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_form_scan_interval_below_minimum(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """A scan interval below 5 seconds is rejected as an unknown error."""
+    result = await _start_user_step(hass, {**USER_INPUT, CONF_SCAN_INTERVAL: 1})
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_validate_input_raises_cannot_connect(
+    hass: HomeAssistant, mock_api, api
+) -> None:
+    """Validate_input surfaces a failed connection."""
+    api.connect.return_value = False
+
+    with pytest.raises(CannotConnect):
+        await validate_input(hass, USER_INPUT)
+
+
+async def test_validate_input_raises_invalid_scan_interval(
+    hass: HomeAssistant, mock_api
+) -> None:
+    """Validate_input enforces the minimum scan interval."""
+    with pytest.raises(InvalidScanInterval):
+        await validate_input(hass, {**USER_INPUT, CONF_SCAN_INTERVAL: 4})
+
+
+async def test_validate_input_returns_title(hass: HomeAssistant, mock_api) -> None:
+    """Validate_input returns the entry title on success."""
+    assert await validate_input(hass, USER_INPUT) == {"title": DEFAULT_NAME}
+
+
+@pytest.mark.parametrize(
+    "system", [Systems.VAMPAIR, Systems.THERMINATOR, Systems.ECOTOP]
+)
+async def test_options_flow_form(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, system: Systems
+) -> None:
+    """Each system gets an options form prefilled from the stored options."""
+    entry = build_config_entry(system, heating_circuit=1, buffer=1, boiler=1)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert result["data_schema"] is not None
+
+
+async def test_options_flow_updates_options(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """Submitting the options form stores the new values."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with patch("custom_components.solarfocus.async_setup_entry", return_value=True):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "10.0.0.5",
+                CONF_PORT: 503,
+                CONF_SCAN_INTERVAL: 30,
+                CONF_API_VERSION: ApiVersions.V_25_030.value,
+                CONF_HEATING_CIRCUIT: 3,
+                CONF_BUFFER: 2,
+                CONF_BOILER: 1,
+                CONF_FRESH_WATER_MODULE: 1,
+                CONF_HEATPUMP: True,
+                CONF_PHOTOVOLTAIC: True,
+                CONF_SOLAR: 1,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_HOST] == "10.0.0.5"
+    assert result["data"][CONF_PORT] == 503
+    assert result["data"][CONF_SCAN_INTERVAL] == 30
+    assert result["data"][CONF_API_VERSION] == ApiVersions.V_25_030.value
+    assert result["data"][CONF_HEATING_CIRCUIT] == 3
+    assert result["data"][CONF_HEATPUMP] is True
+    assert result["data"][CONF_BIOMASS_BOILER] is False
+
+
+async def test_options_flow_biomass_system_disables_heatpump(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """A therminator keeps the biomass boiler flag and never enables the heat pump."""
+    entry = build_config_entry(Systems.THERMINATOR, heating_circuit=1, biomassboiler=True)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with patch("custom_components.solarfocus.async_setup_entry", return_value=True):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "solarfocus.local",
+                CONF_PORT: 502,
+                CONF_SCAN_INTERVAL: 10,
+                CONF_API_VERSION: ApiVersions.V_23_020.value,
+                CONF_HEATING_CIRCUIT: 1,
+                CONF_BUFFER: 1,
+                CONF_BOILER: 1,
+                CONF_FRESH_WATER_MODULE: 0,
+                CONF_BIOMASS_BOILER: True,
+                CONF_PHOTOVOLTAIC: False,
+                CONF_SOLAR: 0,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_BIOMASS_BOILER] is True
+    assert result["data"][CONF_HEATPUMP] is False
+
+
+async def test_options_flow_cannot_connect(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """A device that stops answering keeps the user on the options form."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    api.connect.return_value = False
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: "unreachable",
+            CONF_PORT: 502,
+            CONF_SCAN_INTERVAL: 10,
+            CONF_API_VERSION: ApiVersions.V_23_020.value,
+            CONF_HEATING_CIRCUIT: 1,
+            CONF_BUFFER: 0,
+            CONF_BOILER: 0,
+            CONF_FRESH_WATER_MODULE: 0,
+            CONF_HEATPUMP: True,
+            CONF_PHOTOVOLTAIC: False,
+            CONF_SOLAR: 0,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected"),
+    [(InvalidAuth, "invalid_auth"), (RuntimeError("boom"), "unknown")],
+)
+async def test_options_flow_errors(
+    hass: HomeAssistant,
+    enable_custom_integrations,
+    mock_api,
+    side_effect: Exception,
+    expected: str,
+) -> None:
+    """Auth and unexpected failures are reported on the options form."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with patch(
+        "custom_components.solarfocus.config_flow.validate_input",
+        side_effect=side_effect,
+    ):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "solarfocus.local",
+                CONF_PORT: 502,
+                CONF_SCAN_INTERVAL: 10,
+                CONF_API_VERSION: ApiVersions.V_23_020.value,
+                CONF_HEATING_CIRCUIT: 1,
+                CONF_BUFFER: 0,
+                CONF_BOILER: 0,
+                CONF_FRESH_WATER_MODULE: 0,
+                CONF_HEATPUMP: True,
+                CONF_PHOTOVOLTAIC: False,
+                CONF_SOLAR: 0,
+            },
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,169 @@
+"""Test the Solarfocus data update coordinator."""
+
+from datetime import timedelta
+import logging
+
+import pytest
+
+from custom_components.solarfocus.const import (
+    CONF_BIOMASS_BOILER,
+    CONF_BOILER,
+    CONF_BUFFER,
+    CONF_FRESH_WATER_MODULE,
+    CONF_HEATING_CIRCUIT,
+    CONF_HEATPUMP,
+    CONF_PHOTOVOLTAIC,
+    CONF_SOLAR,
+    DOMAIN,
+)
+from custom_components.solarfocus.coordinator import SolarfocusDataUpdateCoordinator
+from homeassistant.core import HomeAssistant
+
+from .conftest import build_api, build_config_entry
+
+# Config option -> the library call the coordinator has to make for it.
+COMPONENT_UPDATES = [
+    (CONF_HEATING_CIRCUIT, 1, "update_heating"),
+    (CONF_BUFFER, 1, "update_buffer"),
+    (CONF_BOILER, 1, "update_boiler"),
+    (CONF_HEATPUMP, True, "update_heatpump"),
+    (CONF_PHOTOVOLTAIC, True, "update_photovoltaic"),
+    (CONF_BIOMASS_BOILER, True, "update_biomassboiler"),
+    (CONF_SOLAR, 1, "update_solar"),
+    (CONF_FRESH_WATER_MODULE, 1, "update_fresh_water_modules"),
+]
+
+ALL_UPDATES = [update for _, _, update in COMPONENT_UPDATES]
+
+
+def _coordinator(hass: HomeAssistant, api, **options) -> SolarfocusDataUpdateCoordinator:
+    """Create a coordinator for an entry with the given options."""
+    entry = build_config_entry(**options)
+    entry.add_to_hass(hass)
+    return SolarfocusDataUpdateCoordinator(hass, entry, api)
+
+
+@pytest.mark.parametrize(("option", "value", "update"), COMPONENT_UPDATES)
+async def test_only_configured_components_are_polled(
+    hass: HomeAssistant, option: str, value, update: str
+) -> None:
+    """A component that is not configured must not be read from the device."""
+    api = build_api()
+    coordinator = _coordinator(hass, api, **{option: value})
+
+    await coordinator._async_update_data()
+
+    assert getattr(api, update).called
+    for other in ALL_UPDATES:
+        if other != update:
+            assert not getattr(api, other).called, f"{other} was polled unexpectedly"
+
+
+async def test_no_configured_components_polls_nothing(hass: HomeAssistant) -> None:
+    """An entry without components does not talk to the device at all."""
+    api = build_api()
+    coordinator = _coordinator(hass, api)
+
+    await coordinator._async_update_data()
+
+    for update in ALL_UPDATES:
+        assert not getattr(api, update).called
+
+
+async def test_all_components_are_polled(hass: HomeAssistant) -> None:
+    """Every configured component is refreshed on a single update."""
+    api = build_api()
+    coordinator = _coordinator(
+        hass, api, **{option: value for option, value, _ in COMPONENT_UPDATES}
+    )
+
+    await coordinator._async_update_data()
+
+    for update in ALL_UPDATES:
+        assert getattr(api, update).called
+
+
+async def test_scan_interval_is_taken_from_the_options(hass: HomeAssistant) -> None:
+    """The configured scan interval becomes the update interval."""
+    coordinator = _coordinator(hass, build_api(), scan_interval=42)
+
+    assert coordinator.update_interval == timedelta(seconds=42)
+
+
+async def test_coordinator_keeps_the_entry(hass: HomeAssistant) -> None:
+    """Entities read the options and the device name off the entry."""
+    entry = build_config_entry()
+    entry.add_to_hass(hass)
+
+    coordinator = SolarfocusDataUpdateCoordinator(hass, entry, build_api())
+
+    assert coordinator._entry is entry
+    # The coordinator is named after the integration, the device name entities
+    # use comes from `_entry.title`.
+    assert coordinator.name == DOMAIN
+    assert entry.title == "Solarfocus"
+
+
+async def test_reconnects_before_updating(hass: HomeAssistant) -> None:
+    """A dropped connection is re-established on the next refresh."""
+    api = build_api()
+    coordinator = _coordinator(hass, api, heating_circuit=1)
+
+    api.connect.reset_mock()
+    api.is_connected = False
+
+    await coordinator._async_update_data()
+
+    assert api.connect.called
+    assert api.update_heating.called
+
+
+async def test_does_not_reconnect_while_connected(hass: HomeAssistant) -> None:
+    """A healthy connection is reused."""
+    api = build_api()
+    coordinator = _coordinator(hass, api, heating_circuit=1)
+
+    api.connect.reset_mock()
+
+    await coordinator._async_update_data()
+
+    assert not api.connect.called
+
+
+async def test_initial_connection_failure_is_logged(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Constructing the coordinator against an unreachable device does not raise."""
+    api = build_api()
+    api.connect.return_value = False
+
+    _coordinator(hass, api, heating_circuit=1)
+
+    assert "Failed to connect to modbus" in caplog.text
+
+
+async def test_failing_component_update_is_logged(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A component that fails to update is reported."""
+    api = build_api()
+    api.update_heating.return_value = False
+    coordinator = _coordinator(hass, api, heating_circuit=1)
+
+    with caplog.at_level(logging.DEBUG):
+        await coordinator._async_update_data()
+
+    assert "Data updated failed" in caplog.text
+
+
+async def test_successful_update_is_logged(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A successful refresh is reported."""
+    api = build_api()
+    coordinator = _coordinator(hass, api, heating_circuit=1)
+
+    with caplog.at_level(logging.DEBUG):
+        await coordinator._async_update_data()
+
+    assert "Data updated successfully" in caplog.text

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,584 @@
+"""Test what the entity classes read from and write to the device.
+
+Every entity reads its value through `_get_native_value` and writes it through
+`_set_native_value`, which address a pysolarfocus component by name and index.
+These tests pin the mapping down for one entity of every platform.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pysolarfocus import ApiVersions, Systems
+import pytest
+
+from custom_components.solarfocus.binary_sensor import (
+    SolarfocusBinarySensorEntity,
+    SolarfocusBinarySensorEntityDescription,
+)
+from custom_components.solarfocus.button import (
+    BOILER_BUTTON_TYPES,
+    SolarfocusButtonEntity,
+)
+from custom_components.solarfocus.climate import (
+    CLIMATE_TYPES,
+    PRESET_AUTO,
+    PRESET_OFF,
+    SolarfocusClimateEntity,
+)
+from custom_components.solarfocus.const import (
+    BOILER_COMPONENT,
+    BOILER_COMPONENT_PREFIX,
+    BOILER_PREFIX,
+    DOMAIN,
+    HEAT_PUMP_COMPONENT,
+    HEAT_PUMP_COMPONENT_PREFIX,
+    HEAT_PUMP_PREFIX,
+    HEATING_CIRCUIT_COMPONENT,
+    HEATING_CIRCUIT_COMPONENT_PREFIX,
+    HEATING_CIRCUIT_PREFIX,
+)
+from custom_components.solarfocus.entity import create_description
+from custom_components.solarfocus.number import (
+    BOILER_NUMBER_TYPES,
+    SolarfocusNumberEntity,
+)
+from custom_components.solarfocus.select import (
+    HEATPUMP_SELECT_TYPES,
+    SolarfocusSelectEntity,
+)
+from custom_components.solarfocus.sensor import BOILER_SENSOR_TYPES, SolarfocusSensor
+from custom_components.solarfocus.switch import (
+    HEATPUMP_SWITCH_TYPES,
+    OFF,
+    ON,
+    SolarfocusSwitchEntity,
+)
+from custom_components.solarfocus.water_heater import (
+    HA_DISPLAY_MODE_ALWAYS_ON,
+    HA_DISPLAY_MODE_BLOCKWISE,
+    SOLARFOCUS_MODE_ALWAYS_OFF,
+    SOLARFOCUS_MODE_ALWAYS_ON,
+    SOLARFOCUS_MODE_BLOCKWISE,
+    SOLARFOCUS_TEMP_WATER_MAX,
+    SOLARFOCUS_TEMP_WATER_MIN,
+    WATER_HEATER_TYPES,
+    SolarfocusWaterHeaterEntity,
+)
+from homeassistant.components.climate.const import (
+    PRESET_COMFORT,
+    PRESET_ECO,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, UnitOfTemperature
+
+from .conftest import build_config_entry, build_coordinator
+
+
+def _make(entity_class, description, prefix, component, component_prefix, idx="1"):
+    """Create an entity of the given class on a mocked coordinator."""
+    coordinator = build_coordinator(build_config_entry())
+    entity = entity_class(
+        coordinator,
+        create_description(prefix, component, component_prefix, idx, description),
+    )
+    entity.async_write_ha_state = MagicMock()
+    return entity
+
+
+@pytest.fixture(name="boiler_water_heater")
+def boiler_water_heater_fixture() -> SolarfocusWaterHeaterEntity:
+    """Return the water heater of the second boiler."""
+    return _make(
+        SolarfocusWaterHeaterEntity,
+        WATER_HEATER_TYPES[0],
+        BOILER_PREFIX,
+        BOILER_COMPONENT,
+        BOILER_COMPONENT_PREFIX,
+        idx="2",
+    )
+
+
+# --- base entity ------------------------------------------------------------
+
+
+def test_unique_id_combines_the_device_name_and_the_key() -> None:
+    """The unique id has to stay stable, it identifies the entity in the registry."""
+    entity = _make(
+        SolarfocusSensor,
+        BOILER_SENSOR_TYPES[0],
+        BOILER_PREFIX,
+        BOILER_COMPONENT,
+        BOILER_COMPONENT_PREFIX,
+    )
+
+    assert entity.unique_id == f"Solarfocus_bo1_{BOILER_SENSOR_TYPES[0].key}"
+    assert entity.translation_key == f"bo_{BOILER_SENSOR_TYPES[0].key}"
+
+
+def test_device_info_describes_the_heating_system() -> None:
+    """All entities belong to a single device."""
+    entity = _make(
+        SolarfocusSensor,
+        BOILER_SENSOR_TYPES[0],
+        BOILER_PREFIX,
+        BOILER_COMPONENT,
+        BOILER_COMPONENT_PREFIX,
+    )
+
+    device_info = entity.device_info
+
+    assert device_info["identifiers"] == {(DOMAIN, "Solarfocus")}
+    assert device_info["manufacturer"] == "Solarfocus"
+    assert device_info["model"] == {Systems.VAMPAIR.value}
+    assert device_info["sw_version"] == {ApiVersions.V_23_020.value}
+
+
+def test_entity_is_unavailable_after_a_failed_update() -> None:
+    """A device that stopped answering must not keep reporting stale values."""
+    entity = _make(
+        SolarfocusSensor,
+        BOILER_SENSOR_TYPES[0],
+        BOILER_PREFIX,
+        BOILER_COMPONENT,
+        BOILER_COMPONENT_PREFIX,
+    )
+
+    assert entity.available is True
+
+    entity.coordinator.last_update_success = False
+
+    assert entity.available is False
+
+
+def test_indexed_components_are_addressed_by_position() -> None:
+    """Boiler 2 is the second entry of the component list, not the second boiler id."""
+    entity = _make(
+        SolarfocusSensor,
+        BOILER_SENSOR_TYPES[0],
+        BOILER_PREFIX,
+        BOILER_COMPONENT,
+        BOILER_COMPONENT_PREFIX,
+        idx="3",
+    )
+    boilers = [MagicMock() for _ in range(3)]
+    boilers[2].temperature.scaled_value = 55
+    entity.coordinator.api.boilers = boilers
+
+    assert entity._get_native_value("temperature") == 55
+
+
+def test_components_without_an_index_are_read_directly() -> None:
+    """The heat pump exists once, so it is not a list."""
+    entity = _make(
+        SolarfocusSwitchEntity,
+        HEATPUMP_SWITCH_TYPES[0],
+        HEAT_PUMP_PREFIX,
+        HEAT_PUMP_COMPONENT,
+        HEAT_PUMP_COMPONENT_PREFIX,
+        idx="",
+    )
+    entity.coordinator.api.heatpump.evu_lock.scaled_value = 1
+
+    assert entity._get_native_value("evu_lock") == 1
+
+
+async def test_async_update_requests_a_coordinator_refresh() -> None:
+    """Polling an entity refreshes the whole device."""
+    entity = _make(
+        SolarfocusSensor,
+        BOILER_SENSOR_TYPES[0],
+        BOILER_PREFIX,
+        BOILER_COMPONENT,
+        BOILER_COMPONENT_PREFIX,
+    )
+    entity.coordinator.async_request_refresh = AsyncMock()
+
+    await entity.async_update()
+
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_entity_follows_the_coordinator_while_added() -> None:
+    """The entity writes its state whenever the coordinator has new data."""
+    entity = _make(
+        SolarfocusSensor,
+        BOILER_SENSOR_TYPES[0],
+        BOILER_PREFIX,
+        BOILER_COMPONENT,
+        BOILER_COMPONENT_PREFIX,
+    )
+    remove_listener = MagicMock()
+    entity.coordinator.async_add_listener.return_value = remove_listener
+    entity.async_on_remove = MagicMock()
+
+    await entity.async_added_to_hass()
+
+    entity.coordinator.async_add_listener.assert_called_once_with(
+        entity.async_write_ha_state
+    )
+    # The listener is removed again when the entity goes away
+    entity.async_on_remove.assert_called_once_with(remove_listener)
+
+
+# --- sensor -----------------------------------------------------------------
+
+
+def test_sensor_reports_the_component_value() -> None:
+    """A sensor reads the item its description names."""
+    description = BOILER_SENSOR_TYPES[0]
+    entity = _make(
+        SolarfocusSensor,
+        description,
+        BOILER_PREFIX,
+        BOILER_COMPONENT,
+        BOILER_COMPONENT_PREFIX,
+    )
+    getattr(entity.coordinator.api.boilers[0], description.key).scaled_value = 42
+
+    assert entity.native_value == 42
+
+
+# --- binary sensor ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("on_state", "value", "expected"),
+    [("1", 1, True), ("1", 0, False), ("0", 0, True), ("0", 1, False)],
+)
+def test_binary_sensor_compares_against_its_on_state(
+    on_state: str, value: int, expected: bool
+) -> None:
+    """Some binary sensors are active on 0 (a problem) and some on 1 (running)."""
+    entity = _make(
+        SolarfocusBinarySensorEntity,
+        SolarfocusBinarySensorEntityDescription(key="pump", on_state=on_state),
+        HEATING_CIRCUIT_PREFIX,
+        HEATING_CIRCUIT_COMPONENT,
+        HEATING_CIRCUIT_COMPONENT_PREFIX,
+    )
+    entity.coordinator.api.heating_circuits[0].pump.scaled_value = value
+
+    assert entity.is_on is expected
+
+
+# --- number -----------------------------------------------------------------
+
+
+async def test_number_writes_the_value() -> None:
+    """Setting a number writes to the component it belongs to."""
+    entity = _make(
+        SolarfocusNumberEntity,
+        BOILER_NUMBER_TYPES[0],
+        BOILER_PREFIX,
+        BOILER_COMPONENT,
+        BOILER_COMPONENT_PREFIX,
+    )
+
+    with patch.object(entity, "_set_native_value") as set_value:
+        await entity.async_set_native_value(60)
+
+    assert set_value.call_args_list == [(("target_temperature", 60),)]
+
+
+def test_number_reads_the_value() -> None:
+    """A number reports the current value of its item."""
+    entity = _make(
+        SolarfocusNumberEntity,
+        BOILER_NUMBER_TYPES[0],
+        BOILER_PREFIX,
+        BOILER_COMPONENT,
+        BOILER_COMPONENT_PREFIX,
+    )
+    entity.coordinator.api.boilers[0].target_temperature.scaled_value = 55
+
+    assert entity.native_value == 55
+
+
+# --- select -----------------------------------------------------------------
+
+
+async def test_select_writes_and_reports_the_option() -> None:
+    """Selecting an option writes the raw value the device expects."""
+    entity = _make(
+        SolarfocusSelectEntity,
+        HEATPUMP_SELECT_TYPES[0],
+        HEAT_PUMP_PREFIX,
+        HEAT_PUMP_COMPONENT,
+        HEAT_PUMP_COMPONENT_PREFIX,
+        idx="",
+    )
+
+    assert entity.options == HEATPUMP_SELECT_TYPES[0].solarfocus_options
+
+    with patch.object(entity, "_set_native_value") as set_value:
+        await entity.async_select_option("3")
+
+    assert set_value.call_args_list == [(("smart_grid", "3"),)]
+
+    entity.coordinator.api.heatpump.smart_grid.scaled_value = 3
+    assert entity.current_option == "3"
+
+
+# --- switch -----------------------------------------------------------------
+
+
+async def test_switch_turns_the_lock_on_and_off() -> None:
+    """The switch writes 1 and 0."""
+    entity = _make(
+        SolarfocusSwitchEntity,
+        HEATPUMP_SWITCH_TYPES[0],
+        HEAT_PUMP_PREFIX,
+        HEAT_PUMP_COMPONENT,
+        HEAT_PUMP_COMPONENT_PREFIX,
+        idx="",
+    )
+
+    with patch.object(entity, "_set_native_value") as set_value:
+        await entity.async_turn_on()
+        await entity.async_turn_off()
+
+    assert set_value.call_args_list == [
+        (("evu_lock", ON),),
+        (("evu_lock", OFF),),
+    ]
+
+
+def test_switch_reports_its_state() -> None:
+    """The switch reads the same item it writes."""
+    entity = _make(
+        SolarfocusSwitchEntity,
+        HEATPUMP_SWITCH_TYPES[0],
+        HEAT_PUMP_PREFIX,
+        HEAT_PUMP_COMPONENT,
+        HEAT_PUMP_COMPONENT_PREFIX,
+        idx="",
+    )
+    entity.coordinator.api.heatpump.evu_lock.scaled_value = 1
+
+    assert entity.is_on == 1
+
+
+# --- button -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("description", BOILER_BUTTON_TYPES, ids=lambda d: d.key)
+async def test_button_triggers_its_item(description) -> None:
+    """Pressing a button writes True to the register it names."""
+    entity = _make(
+        SolarfocusButtonEntity,
+        description,
+        BOILER_PREFIX,
+        BOILER_COMPONENT,
+        BOILER_COMPONENT_PREFIX,
+    )
+
+    with patch.object(entity, "_set_native_value") as set_value:
+        await entity.async_press()
+
+    assert set_value.call_args_list == [((description.key, True),)]
+
+
+# --- water heater -----------------------------------------------------------
+
+
+def test_water_heater_reports_temperatures(boiler_water_heater) -> None:
+    """The water heater reads the boiler it belongs to."""
+    boiler = boiler_water_heater.coordinator.api.boilers[1]
+    boiler.temperature.scaled_value = 48.5
+    boiler.target_temperature.scaled_value = 55.0
+
+    assert boiler_water_heater.current_temperature == 48.5
+    assert boiler_water_heater.target_temperature == 55.0
+    assert boiler_water_heater.temperature_unit == UnitOfTemperature.CELSIUS
+    assert boiler_water_heater.min_temp == SOLARFOCUS_TEMP_WATER_MIN
+    assert boiler_water_heater.max_temp == SOLARFOCUS_TEMP_WATER_MAX
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        (SOLARFOCUS_MODE_ALWAYS_OFF, STATE_OFF),
+        (SOLARFOCUS_MODE_ALWAYS_ON, HA_DISPLAY_MODE_ALWAYS_ON),
+        (SOLARFOCUS_MODE_BLOCKWISE, HA_DISPLAY_MODE_BLOCKWISE),
+    ],
+)
+def test_water_heater_maps_the_device_mode(
+    boiler_water_heater, mode: int, expected: str
+) -> None:
+    """The numeric device mode is translated into the displayed operation."""
+    boiler_water_heater.coordinator.api.boilers[1].mode.scaled_value = mode
+
+    assert boiler_water_heater.current_operation == expected
+
+
+def test_water_heater_operation_list_covers_every_device_mode(
+    boiler_water_heater,
+) -> None:
+    """Every mode the device can report can also be selected."""
+    assert set(boiler_water_heater.operation_list) == {
+        STATE_OFF,
+        HA_DISPLAY_MODE_ALWAYS_ON,
+        HA_DISPLAY_MODE_BLOCKWISE,
+        "Montag - Sonntag",
+        "Tageweise",
+    }
+
+
+async def test_water_heater_sets_the_target_temperature(boiler_water_heater) -> None:
+    """Setting the temperature writes the boiler target temperature."""
+    with patch.object(boiler_water_heater, "_set_native_value") as set_value:
+        await boiler_water_heater.async_set_temperature(**{ATTR_TEMPERATURE: 52})
+
+    assert set_value.call_args_list == [(("target_temperature", 52),)]
+
+
+async def test_water_heater_ignores_a_call_without_a_temperature(
+    boiler_water_heater,
+) -> None:
+    """A service call without a temperature must not write anything."""
+    with patch.object(boiler_water_heater, "_set_native_value") as set_value:
+        await boiler_water_heater.async_set_temperature(operation_mode="auto")
+
+    assert not set_value.called
+
+
+async def test_water_heater_sets_the_operation_mode(boiler_water_heater) -> None:
+    """The displayed operation is written back as the numeric device mode."""
+    with patch.object(boiler_water_heater, "_set_native_value") as set_value:
+        await boiler_water_heater.async_set_operation_mode(HA_DISPLAY_MODE_BLOCKWISE)
+
+    assert set_value.call_args_list == [
+        (("holding_mode", SOLARFOCUS_MODE_BLOCKWISE),)
+    ]
+
+
+async def test_water_heater_turns_on_and_off(boiler_water_heater) -> None:
+    """On and off map to the always on and always off modes."""
+    with patch.object(boiler_water_heater, "_set_native_value") as set_value:
+        await boiler_water_heater.async_turn_on()
+        await boiler_water_heater.async_turn_off()
+
+    assert set_value.call_args_list == [
+        (("holding_mode", SOLARFOCUS_MODE_ALWAYS_ON),),
+        (("holding_mode", SOLARFOCUS_MODE_ALWAYS_OFF),),
+    ]
+
+
+# --- climate ----------------------------------------------------------------
+
+
+@pytest.fixture(name="climate_entity")
+def climate_entity_fixture() -> SolarfocusClimateEntity:
+    """Return the thermostat of heating circuit 1."""
+    return _make(
+        SolarfocusClimateEntity,
+        CLIMATE_TYPES[0],
+        HEATING_CIRCUIT_PREFIX,
+        HEATING_CIRCUIT_COMPONENT,
+        HEATING_CIRCUIT_COMPONENT_PREFIX,
+    )
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [(0, HVACMode.OFF), (31, HVACMode.HEAT), (23, HVACMode.HEAT)],
+)
+def test_climate_hvac_mode(climate_entity, state: int, expected: HVACMode) -> None:
+    """State 0 means the circuit is switched off."""
+    climate_entity.coordinator.api.heating_circuits[0].state.scaled_value = state
+
+    assert climate_entity.hvac_mode == expected
+    assert climate_entity.hvac_modes == [HVACMode.OFF, HVACMode.HEAT]
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        (0, HVACAction.OFF),
+        (11, HVACAction.OFF),
+        (228, HVACAction.OFF),
+        (31, HVACAction.IDLE),
+        (23, HVACAction.HEATING),
+    ],
+)
+def test_climate_hvac_action(
+    climate_entity, state: int, expected: HVACAction
+) -> None:
+    """The device state maps to what the circuit is currently doing."""
+    climate_entity.coordinator.api.heating_circuits[0].state.scaled_value = state
+
+    assert climate_entity.hvac_action == expected
+
+
+@pytest.mark.parametrize(
+    ("mode", "preset"),
+    [(0, PRESET_COMFORT), (1, PRESET_ECO), (2, PRESET_AUTO), (3, PRESET_OFF)],
+)
+def test_climate_preset_mode(climate_entity, mode: int, preset: str) -> None:
+    """Every device mode has a preset and every preset writes it back."""
+    climate_entity.coordinator.api.heating_circuits[0].mode.scaled_value = mode
+
+    assert climate_entity.preset_mode == preset
+    assert preset in climate_entity.preset_modes
+
+
+@pytest.mark.parametrize(
+    ("preset", "expected"),
+    [(PRESET_COMFORT, 0), (PRESET_ECO, 1), (PRESET_AUTO, 2), (PRESET_OFF, 3)],
+)
+async def test_climate_set_preset_mode(
+    climate_entity, preset: str, expected: int
+) -> None:
+    """Selecting a preset writes the numeric mode."""
+    with patch.object(climate_entity, "_set_native_value") as set_value:
+        await climate_entity.async_set_preset_mode(preset)
+
+    assert set_value.call_args_list == [(("mode", expected),)]
+
+
+@pytest.mark.parametrize(
+    ("cooling", "min_temp", "max_temp"), [(0, 22.0, 45.0), (1, 7.0, 35.0)]
+)
+def test_climate_temperature_range_follows_cooling(
+    climate_entity, cooling: int, min_temp: float, max_temp: float
+) -> None:
+    """A cooling circuit has a different valid range than a heating one."""
+    climate_entity.coordinator.api.heating_circuits[0].cooling.scaled_value = cooling
+
+    assert climate_entity.min_temp == min_temp
+    assert climate_entity.max_temp == max_temp
+
+
+def test_climate_temperatures(climate_entity) -> None:
+    """The thermostat works on the supply temperature."""
+    circuit = climate_entity.coordinator.api.heating_circuits[0]
+    circuit.supply_temperature.scaled_value = 38.4
+    circuit.target_supply_temperature.scaled_value = 40.123
+
+    assert climate_entity.current_temperature == 38.4
+    assert climate_entity.target_temperature == 40.12
+    assert climate_entity.temperature_unit == UnitOfTemperature.CELSIUS
+
+
+# --- writing ----------------------------------------------------------------
+
+
+def test_set_native_value_writes_and_refreshes_the_component() -> None:
+    """Writing commits the register and reads the component back."""
+    entity = _make(
+        SolarfocusNumberEntity,
+        BOILER_NUMBER_TYPES[0],
+        BOILER_PREFIX,
+        BOILER_COMPONENT,
+        BOILER_COMPONENT_PREFIX,
+    )
+    boiler = entity.coordinator.api.boilers[0]
+    boiler.target_temperature.value = 55
+    boiler.target_temperature.count = 1
+
+    entity._set_native_value("target_temperature", 55)
+
+    boiler.target_temperature.set_unscaled_value.assert_called_once_with(55)
+    boiler.target_temperature.commit.assert_called_once()
+    boiler.update.assert_called_once()
+    entity.async_write_ha_state.assert_called_once()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,398 @@
+"""Test setting up, unloading and migrating a Solarfocus config entry."""
+
+from unittest.mock import patch
+
+from pysolarfocus import ApiVersions, Systems
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.solarfocus import async_migrate_entry, async_reload_entry
+from custom_components.solarfocus.const import (
+    CONF_BIOMASS_BOILER,
+    CONF_BOILER,
+    CONF_BUFFER,
+    CONF_FRESH_WATER_MODULE,
+    CONF_HEATING_CIRCUIT,
+    CONF_HEATPUMP,
+    CONF_PHOTOVOLTAIC,
+    CONF_SOLAR,
+    CONF_SOLARFOCUS_SYSTEM,
+    DATA_COORDINATOR,
+    DEFAULT_NAME,
+    DOMAIN,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import (
+    CONF_API_VERSION,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+)
+from homeassistant.core import HomeAssistant
+
+from .conftest import build_config_entry
+
+
+async def test_setup_and_unload_entry(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, config_entry
+) -> None:
+    """A reachable device sets up the entry and unloading cleans up again."""
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert DATA_COORDINATOR in hass.data[DOMAIN][config_entry.entry_id]
+
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+    assert config_entry.entry_id not in hass.data[DOMAIN]
+
+
+async def test_setup_passes_component_counts_to_the_library(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """The configured component counts are handed to pysolarfocus."""
+    entry = build_config_entry(
+        Systems.THERMINATOR,
+        heating_circuit=3,
+        buffer=2,
+        boiler=1,
+        solar=2,
+        biomassboiler=True,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    kwargs = mock_api.call_args.kwargs
+    assert kwargs["heating_circuit_count"] == 3
+    assert kwargs["buffer_count"] == 2
+    assert kwargs["boiler_count"] == 1
+    assert kwargs["solar_count"] == 2
+    assert kwargs["system"] is Systems.THERMINATOR
+    assert kwargs["api_version"] is ApiVersions.V_23_020
+
+
+@pytest.mark.parametrize(
+    ("stored_solar", "expected_count"), [(True, 1), (False, 0), (0, 0), (4, 4)]
+)
+async def test_setup_accepts_legacy_boolean_solar_option(
+    hass: HomeAssistant,
+    enable_custom_integrations,
+    mock_api,
+    stored_solar,
+    expected_count: int,
+) -> None:
+    """Entries written before solar became a count still set up."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, solar=stored_solar)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_api.call_args.kwargs["solar_count"] == expected_count
+
+
+async def test_setup_retries_when_the_device_is_unreachable(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api, config_entry
+) -> None:
+    """A failing first refresh raises ConfigEntryNotReady."""
+    api.connect.return_value = False
+    api.is_connected = False
+    api.update_heating.side_effect = OSError("no route to host")
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_updating_options_reloads_the_entry(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, config_entry
+) -> None:
+    """The update listener reloads the entry so entities follow the new options."""
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_reload"
+    ) as async_reload:
+        hass.config_entries.async_update_entry(
+            config_entry, options={**config_entry.options, CONF_SCAN_INTERVAL: 60}
+        )
+        await hass.async_block_till_done()
+
+    assert async_reload.call_args_list == [((config_entry.entry_id,),)]
+
+
+async def test_unload_without_setup_is_a_noop(hass: HomeAssistant) -> None:
+    """Unloading an entry that never got set up must not raise."""
+    from custom_components.solarfocus import async_unload_entry
+
+    entry = build_config_entry()
+    entry.add_to_hass(hass)
+
+    assert await async_unload_entry(hass, entry) is True
+
+
+async def test_reload_entry(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, config_entry
+) -> None:
+    """Reloading tears the entry down and sets it up again."""
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await async_reload_entry(hass, config_entry)
+    await hass.async_block_till_done()
+
+    assert DATA_COORDINATOR in hass.data[DOMAIN][config_entry.entry_id]
+
+
+async def test_migration_from_version_1(hass: HomeAssistant) -> None:
+    """Version 1 stored booleans for the components and no system."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_NAME,
+        version=1,
+        data={
+            CONF_NAME: DEFAULT_NAME,
+            CONF_HOST: "solarfocus.local",
+            CONF_PORT: 502,
+            CONF_SCAN_INTERVAL: 10,
+            CONF_HEATING_CIRCUIT: True,
+            CONF_BUFFER: True,
+            CONF_BOILER: False,
+            CONF_HEATPUMP: True,
+            CONF_PHOTOVOLTAIC: False,
+            "pelletsboiler": False,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == 6
+    # Booleans became counts
+    assert entry.options[CONF_HEATING_CIRCUIT] == 1
+    assert entry.options[CONF_BUFFER] == 1
+    assert entry.options[CONF_BOILER] == 0
+    # Systems default to the heat pump the integration started out with
+    assert entry.data[CONF_SOLARFOCUS_SYSTEM] == Systems.VAMPAIR
+    # Connection details moved from data to options
+    assert entry.options[CONF_HOST] == "solarfocus.local"
+    assert entry.options[CONF_PORT] == 502
+    assert entry.options[CONF_SCAN_INTERVAL] == 10
+    assert CONF_HOST not in entry.data
+    # New options got a default
+    assert entry.options[CONF_API_VERSION] == "21.140"
+    assert entry.options[CONF_FRESH_WATER_MODULE] == 0
+    assert entry.options[CONF_SOLAR] == 0
+    # pelletsboiler was renamed
+    assert "pelletsboiler" not in entry.options
+    assert entry.options[CONF_BIOMASS_BOILER] is False
+    assert entry.data[CONF_NAME] == DEFAULT_NAME
+
+
+async def test_migration_from_version_3_moves_options(hass: HomeAssistant) -> None:
+    """Version 3 kept everything in data."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_NAME,
+        version=3,
+        data={
+            CONF_NAME: DEFAULT_NAME,
+            CONF_SOLARFOCUS_SYSTEM: Systems.THERMINATOR,
+            CONF_HOST: "10.0.0.2",
+            CONF_PORT: 502,
+            CONF_SCAN_INTERVAL: 15,
+            CONF_HEATING_CIRCUIT: 2,
+            CONF_BUFFER: 1,
+            CONF_BOILER: 1,
+            CONF_HEATPUMP: False,
+            CONF_PHOTOVOLTAIC: True,
+            CONF_SOLAR: True,
+            "pelletsboiler": True,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == 6
+    assert entry.data == {
+        CONF_NAME: DEFAULT_NAME,
+        CONF_SOLARFOCUS_SYSTEM: Systems.THERMINATOR,
+    }
+    assert entry.options[CONF_HOST] == "10.0.0.2"
+    assert entry.options[CONF_SCAN_INTERVAL] == 15
+    assert entry.options[CONF_HEATING_CIRCUIT] == 2
+    assert entry.options[CONF_BIOMASS_BOILER] is True
+    # Solar became a count on version 6
+    assert entry.options[CONF_SOLAR] == 1
+
+
+async def test_migration_from_version_5_converts_solar_to_a_count(
+    hass: HomeAssistant,
+) -> None:
+    """Version 5 stored solar as a boolean."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_NAME,
+        version=5,
+        data={CONF_NAME: DEFAULT_NAME, CONF_SOLARFOCUS_SYSTEM: Systems.VAMPAIR},
+        options={
+            CONF_HOST: "10.0.0.2",
+            CONF_PORT: 502,
+            CONF_SCAN_INTERVAL: 10,
+            CONF_API_VERSION: "23.020",
+            CONF_HEATING_CIRCUIT: 1,
+            CONF_BUFFER: 1,
+            CONF_BOILER: 1,
+            CONF_FRESH_WATER_MODULE: 0,
+            CONF_PHOTOVOLTAIC: False,
+            CONF_SOLAR: True,
+            CONF_HEATPUMP: True,
+            CONF_BIOMASS_BOILER: False,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == 6
+    assert entry.options[CONF_SOLAR] == 1
+
+
+async def test_migration_keeps_an_existing_solar_count(hass: HomeAssistant) -> None:
+    """A count written by a newer version survives the version 5 migration."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_NAME,
+        version=5,
+        data={CONF_NAME: DEFAULT_NAME, CONF_SOLARFOCUS_SYSTEM: Systems.VAMPAIR},
+        options={
+            CONF_HOST: "10.0.0.2",
+            CONF_PORT: 502,
+            CONF_SCAN_INTERVAL: 10,
+            CONF_API_VERSION: "25.030",
+            CONF_HEATING_CIRCUIT: 1,
+            CONF_BUFFER: 1,
+            CONF_BOILER: 1,
+            CONF_FRESH_WATER_MODULE: 0,
+            CONF_PHOTOVOLTAIC: False,
+            CONF_SOLAR: 3,
+            CONF_HEATPUMP: True,
+            CONF_BIOMASS_BOILER: False,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.options[CONF_SOLAR] == 3
+
+
+async def test_migration_from_version_4_renames_the_pellets_boiler(
+    hass: HomeAssistant,
+) -> None:
+    """Version 4 still called the biomass boiler "pelletsboiler"."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_NAME,
+        version=4,
+        data={CONF_NAME: DEFAULT_NAME, CONF_SOLARFOCUS_SYSTEM: Systems.ECOTOP},
+        options={
+            CONF_HOST: "10.0.0.2",
+            CONF_PORT: 502,
+            CONF_SCAN_INTERVAL: 10,
+            CONF_API_VERSION: "21.140",
+            CONF_HEATING_CIRCUIT: 1,
+            CONF_BUFFER: 1,
+            CONF_BOILER: 1,
+            CONF_FRESH_WATER_MODULE: 0,
+            CONF_PHOTOVOLTAIC: False,
+            CONF_SOLAR: False,
+            CONF_HEATPUMP: False,
+            "pelletsboiler": True,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == 6
+    assert "pelletsboiler" not in entry.options
+    assert entry.options[CONF_BIOMASS_BOILER] is True
+
+
+@pytest.mark.parametrize("version", [1, 2, 3, 4, 5])
+async def test_migrated_entries_can_be_set_up(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, version: int
+) -> None:
+    """Every supported old entry ends up in the layout async_setup_entry reads.
+
+    Migrating without reaching the current version leaves the entry half converted
+    and setup then fails on a missing option.
+    """
+    data = {
+        CONF_NAME: DEFAULT_NAME,
+        CONF_SOLARFOCUS_SYSTEM: Systems.THERMINATOR,
+        CONF_HOST: "10.0.0.2",
+        CONF_PORT: 502,
+        CONF_SCAN_INTERVAL: 10,
+        CONF_HEATING_CIRCUIT: 1,
+        CONF_BUFFER: 1,
+        CONF_BOILER: 1,
+        CONF_PHOTOVOLTAIC: False,
+        CONF_HEATPUMP: False,
+        "pelletsboiler": True,
+    }
+    options = {}
+
+    if version >= 2:
+        data[CONF_SOLAR] = False
+    if version >= 4:
+        options = {
+            CONF_API_VERSION: "21.140",
+            CONF_FRESH_WATER_MODULE: 0,
+            **{key: data.pop(key) for key in list(data) if key not in (CONF_NAME, CONF_SOLARFOCUS_SYSTEM)},
+        }
+    if version >= 5:
+        options[CONF_BIOMASS_BOILER] = options.pop("pelletsboiler")
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, title=DEFAULT_NAME, version=version, data=data, options=options
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.version == 6
+    assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_migration_of_a_current_entry_changes_nothing(
+    hass: HomeAssistant,
+) -> None:
+    """An entry already on the current version is left alone."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1)
+    entry.add_to_hass(hass)
+    data, options = dict(entry.data), dict(entry.options)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == 6
+    assert entry.data == data
+    assert entry.options == options

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -1,0 +1,309 @@
+"""Test which entities each platform creates for a given configuration.
+
+`async_setup_entry` of every platform turns the configured component counts into
+entities. Creating one entity too many means a broken entity in the UI, creating
+one too few means a silently missing entity, and both only show up once an entry
+is actually set up.
+"""
+
+from pysolarfocus import ApiVersions, Systems
+import pytest
+
+from custom_components.solarfocus import (
+    binary_sensor,
+    button,
+    climate,
+    number,
+    select,
+    sensor,
+    switch,
+    water_heater,
+)
+from custom_components.solarfocus.const import (
+    BOILER_COMPONENT_PREFIX,
+    BUFFER_COMPONENT_PREFIX,
+    DATA_COORDINATOR,
+    DOMAIN,
+    HEATING_CIRCUIT_COMPONENT_PREFIX,
+    SOLAR_COMPONENT_PREFIX,
+)
+from homeassistant.core import HomeAssistant
+
+from .conftest import build_config_entry, build_coordinator
+
+PLATFORMS = [
+    binary_sensor,
+    button,
+    climate,
+    number,
+    select,
+    sensor,
+    switch,
+    water_heater,
+]
+
+
+async def _setup(hass: HomeAssistant, platform, entry) -> list:
+    """Run a platform's async_setup_entry and return the created entities."""
+    entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        DATA_COORDINATOR: build_coordinator(entry)
+    }
+
+    added = []
+    await platform.async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    return added
+
+
+def _keys(entities) -> list[str]:
+    return [entity.entity_description.key for entity in entities]
+
+
+@pytest.mark.parametrize("platform", PLATFORMS, ids=lambda p: p.__name__.split(".")[-1])
+async def test_no_components_creates_no_entities(
+    hass: HomeAssistant, platform
+) -> None:
+    """An entry without any component must not create entities."""
+    entities = await _setup(hass, platform, build_config_entry())
+
+    assert entities == []
+
+
+@pytest.mark.parametrize("platform", PLATFORMS, ids=lambda p: p.__name__.split(".")[-1])
+async def test_entity_keys_are_unique(hass: HomeAssistant, platform) -> None:
+    """Duplicate keys would collide on the same unique id."""
+    entry = build_config_entry(
+        Systems.THERMINATOR,
+        api_version=ApiVersions.V_26_020.value,
+        heating_circuit=3,
+        buffer=2,
+        boiler=2,
+        fresh_water_module=2,
+        solar=2,
+        biomassboiler=True,
+        photovoltaic=True,
+    )
+
+    keys = _keys(await _setup(hass, platform, entry))
+
+    assert len(keys) == len(set(keys))
+
+
+@pytest.mark.parametrize("count", [1, 2, 8])
+async def test_one_climate_entity_per_heating_circuit(
+    hass: HomeAssistant, count: int
+) -> None:
+    """Every configured heating circuit gets its own thermostat."""
+    entry = build_config_entry(heating_circuit=count)
+
+    entities = await _setup(hass, climate, entry)
+
+    assert _keys(entities) == [
+        f"{HEATING_CIRCUIT_COMPONENT_PREFIX}{i + 1}_thermostat" for i in range(count)
+    ]
+
+
+@pytest.mark.parametrize("count", [1, 4])
+async def test_one_water_heater_per_boiler(hass: HomeAssistant, count: int) -> None:
+    """Every configured boiler gets a water heater."""
+    entry = build_config_entry(boiler=count)
+
+    entities = await _setup(hass, water_heater, entry)
+
+    assert _keys(entities) == [
+        f"{BOILER_COMPONENT_PREFIX}{i + 1}_domestic_hot_water" for i in range(count)
+    ]
+
+
+async def test_buttons_are_created_per_boiler(hass: HomeAssistant) -> None:
+    """Each boiler gets the single charge and circulation buttons."""
+    entry = build_config_entry(boiler=2)
+
+    entities = await _setup(hass, button, entry)
+
+    assert _keys(entities) == [
+        f"{BOILER_COMPONENT_PREFIX}1_single_charge",
+        f"{BOILER_COMPONENT_PREFIX}1_circulation",
+        f"{BOILER_COMPONENT_PREFIX}2_single_charge",
+        f"{BOILER_COMPONENT_PREFIX}2_circulation",
+    ]
+
+
+async def test_switches_need_a_heatpump(hass: HomeAssistant) -> None:
+    """The only switch belongs to the heat pump."""
+    assert await _setup(hass, switch, build_config_entry(heatpump=False)) == []
+
+    entities = await _setup(hass, switch, build_config_entry(heatpump=True))
+
+    assert _keys(entities) == ["hp_evu_lock"]
+
+
+async def test_sensors_are_created_per_component_instance(
+    hass: HomeAssistant,
+) -> None:
+    """The number of sensors scales with the configured instances."""
+    single = await _setup(hass, sensor, build_config_entry(buffer=1))
+    double = await _setup(hass, sensor, build_config_entry(buffer=2))
+
+    assert single
+    assert len(double) == 2 * len(single)
+    assert all(key.startswith(BUFFER_COMPONENT_PREFIX) for key in _keys(double))
+    assert {key.split("_", 1)[0] for key in _keys(double)} == {
+        f"{BUFFER_COMPONENT_PREFIX}1",
+        f"{BUFFER_COMPONENT_PREFIX}2",
+    }
+
+
+async def test_sensors_of_a_disabled_component_are_not_created(
+    hass: HomeAssistant,
+) -> None:
+    """A therminator has no heat pump sensors."""
+    entry = build_config_entry(Systems.THERMINATOR, biomassboiler=True, heatpump=False)
+
+    keys = _keys(await _setup(hass, sensor, entry))
+
+    assert keys
+    assert not any(key.startswith("hp_") for key in keys)
+
+
+async def test_version_specific_entities_are_filtered(hass: HomeAssistant) -> None:
+    """An entity newer than the configured api version is not created."""
+    old = _keys(
+        await _setup(
+            hass,
+            number,
+            build_config_entry(photovoltaic=True, api_version="25.030"),
+        )
+    )
+    new = _keys(
+        await _setup(
+            hass,
+            number,
+            build_config_entry(photovoltaic=True, api_version="26.020"),
+        )
+    )
+
+    assert "pv_hems_target_electrical_power" not in old
+    assert "pv_hems_target_electrical_power" in new
+
+
+async def test_system_specific_entities_are_filtered(hass: HomeAssistant) -> None:
+    """Entities excluded for a system are not created for it (issue #163)."""
+    unsupported = {
+        description.key
+        for description in sensor.BUFFER_SENSOR_TYPES
+        if description.unsupported_systems
+        and Systems.THERMINATOR in description.unsupported_systems
+    }
+    assert unsupported, "expected at least one system specific buffer sensor"
+
+    vampair = _keys(await _setup(hass, sensor, build_config_entry(buffer=1)))
+    therminator = _keys(
+        await _setup(hass, sensor, build_config_entry(Systems.THERMINATOR, buffer=1))
+    )
+
+    for item in unsupported:
+        assert f"{BUFFER_COMPONENT_PREFIX}1_{item}" in vampair
+        assert f"{BUFFER_COMPONENT_PREFIX}1_{item}" not in therminator
+
+
+async def test_single_solar_instance_keeps_the_unnumbered_key(
+    hass: HomeAssistant,
+) -> None:
+    """A single solar keeps its pre-multi-instance entity id."""
+    entry = build_config_entry(solar=1, api_version="25.030")
+
+    entities = await _setup(hass, sensor, entry)
+
+    assert entities
+    for entity in entities:
+        assert entity.entity_description.key.startswith(f"{SOLAR_COMPONENT_PREFIX}_")
+        assert " 1 " not in entity.entity_description.name
+        # The index is still needed to address the component in the library
+        assert entity.entity_description.component_idx == "1"
+
+
+async def test_multiple_solar_instances_are_numbered(hass: HomeAssistant) -> None:
+    """From api version 25.030 on, several solar circuits can be configured."""
+    entry = build_config_entry(solar=3, api_version="25.030")
+
+    entities = await _setup(hass, sensor, entry)
+
+    assert len(entities) == 3 * len(sensor.SOLAR_SENSOR_TYPES)
+    assert {entity.entity_description.component_idx for entity in entities} == {
+        "1",
+        "2",
+        "3",
+    }
+
+
+async def test_older_api_versions_are_limited_to_one_solar(
+    hass: HomeAssistant,
+) -> None:
+    """Before 25.030 the device only exposes a single solar circuit."""
+    entry = build_config_entry(solar=3, api_version="23.020")
+
+    entities = await _setup(hass, sensor, entry)
+
+    assert len(entities) == len(sensor.SOLAR_SENSOR_TYPES)
+    assert all(
+        entity.entity_description.key.startswith(f"{SOLAR_COMPONENT_PREFIX}_")
+        for entity in entities
+    )
+
+
+async def test_legacy_boolean_solar_option_creates_one_instance(
+    hass: HomeAssistant,
+) -> None:
+    """An entry that still stores solar as a boolean must not break setup."""
+    entry = build_config_entry(solar=True, api_version="25.030")
+
+    entities = await _setup(hass, sensor, entry)
+
+    assert len(entities) == len(sensor.SOLAR_SENSOR_TYPES)
+
+
+async def test_selects_cover_all_configured_components(hass: HomeAssistant) -> None:
+    """Selects exist for heating circuits, boilers and the heat pump."""
+    entry = build_config_entry(heating_circuit=1, boiler=1, heatpump=True)
+
+    keys = _keys(await _setup(hass, select, entry))
+
+    assert any(key.startswith(HEATING_CIRCUIT_COMPONENT_PREFIX) for key in keys)
+    assert any(key.startswith(BOILER_COMPONENT_PREFIX) for key in keys)
+    assert "hp_smart_grid" in keys
+
+
+async def test_binary_sensors_cover_all_configured_components(
+    hass: HomeAssistant,
+) -> None:
+    """Binary sensors exist for every component that has one."""
+    entry = build_config_entry(
+        Systems.THERMINATOR,
+        # The fresh water module binary sensors need at least 23.040
+        api_version=ApiVersions.V_26_020.value,
+        heating_circuit=1,
+        buffer=1,
+        fresh_water_module=1,
+        biomassboiler=True,
+        photovoltaic=True,
+    )
+
+    keys = _keys(await _setup(hass, binary_sensor, entry))
+
+    for prefix in ("hc1_", "bu1_", "bb_", "pv_", "fm1_"):
+        assert any(key.startswith(prefix) for key in keys), prefix
+
+
+async def test_entities_read_the_coordinator(hass: HomeAssistant) -> None:
+    """Created entities are wired to the coordinator of their entry."""
+    entry = build_config_entry(boiler=1)
+    entry.add_to_hass(hass)
+    coordinator = build_coordinator(entry)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {DATA_COORDINATOR: coordinator}
+
+    added: list = []
+    await water_heater.async_setup_entry(hass, entry, added.extend)
+
+    assert added
+    assert all(entity.coordinator is coordinator for entity in added)


### PR DESCRIPTION
Works towards #125: the Bronze `config-flow-test-coverage` item and the Silver `test-coverage` item (above 95%).

Coverage of `custom_components/solarfocus` goes from **45% to 100%**, 672 -> 812 tests.

| Module | Before | After |
| --- | --- | --- |
| `config_flow.py` | 0% | 100% |
| `__init__.py` | 18% | 100% |
| `coordinator.py` | 25% | 100% |
| `sensor.py` | 31% | 100% |
| remaining platforms | 41-76% | 100% |

## Two bugs the migration tests found

**Migrations did not chain.** `async_migrate_entry` read `config_entry.version` once into a local variable, so once the version 1 step had bumped the entry to 2, every following step was skipped. The function still returned `True`, so Home Assistant went on to set up a half migrated entry and failed on `entry.options[CONF_HOST]`.

**The version 3 step used the wrong key.** It read `new_data[CONF_BIOMASS_BOILER]`, but at version 3 the option was still called `pelletsboiler`; the rename only happens in the version 4 step. Migrating a genuine version 3 entry raised a `KeyError`.

Together these meant **config entries from versions 1 to 4 could not be set up at all**. `test_migrated_entries_can_be_set_up` covers every old version end to end; 7 of the new tests fail against the previous code.

## What else is in here

- Removed a `try`/`except` around `version.parse` in the solar setup. `filterVersionAndSystem` parses the same value a few lines later without a guard, so the fallback never changed the outcome.
- Removed `self.name = entry.title` in the coordinator, overwritten by `DataUpdateCoordinator.__init__` two statements later. Entities read `_entry.title`.
- Declared the options flow `options` attribute in `__init__` and dropped an unused import. `make check` passes now; it used to report the pylint failure and never reach ruff, which is how the unused import stayed hidden.
- A CI workflow running pytest and the linters on `main` and on pull requests. The lint job calls the Makefile targets so it cannot drift from `make check`.

## Review notes

The commits are meant to be read in order and each one is green on its own. The bulk of the diff is the four new test files; the behaviour change is confined to `async_migrate_entry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)