### PR TITLE
Support cooling on the climate entity again

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,48 @@ There is currently support for the following device types within Home Assistant:
 
 
 ### Climate
-In a first version, the climate entity only supports heating. As some heat pump installations also support cooling, this may be added at a later point in time. However, as it is possible to use a heat pump system for cooling, which is not intent for that by the way it was built, damage to the building or system from condensate is possible. 
 
-Additionally, it is only possible to set the state (_preset_) but not setting the supply nor room temperature. This can be done using the `number` entities. A later version may add control as well. For now, we leave that to the programmed heating curve from Solarfocus. 
+The climate entity supports heating, cooling and switching the heating circuit off, and it
+sets the flow temperature (_target temperature_) as well as the state (_preset_).
+
+Section 6.2 of the Solarfocus Modbus specification requires all registers of a heating
+circuit to be written together whenever the mode changes, otherwise the controller can end
+up in an undefined state. Selecting a mode therefore writes:
+
+| Mode | 32600 flow setpoint | 32602 cooling | 32603 operating mode | 32608 circuit mode |
+|---|---|---|---|---|
+| Heat | setpoint | 0 | preset | 2 (heating + cooling) |
+| Cool | setpoint | 1 | preset | 2 (heating + cooling) |
+| Off | 0 | 0 | 3 (off) | 2 (heating + cooling) |
+
+The specification writes 0 (continuous operation) into 32603 for heating and cooling. The
+integration keeps the preset you configured instead and only switches a circuit that is off
+back on, so a comfort, eco or auto schedule is not discarded when you switch modes.
+
+Because switching off writes a flow setpoint of 0, the integration remembers the last
+setpoint per mode and restores it when the circuit is switched on again. It survives a
+Home Assistant restart.
+
+#### Cooling
+
+> **Warning**
+> Writing register 32602 **disables the dew point monitoring of the Solarfocus controller**.
+> From then on the flow temperature has to be kept above the dew point of every room by
+> Home Assistant. If it is not, condensate forms and can damage the building. A heat pump
+> system that was not built for cooling can also be damaged. Check with Solarfocus or your
+> installer whether cooling is supported by your installation before you use it.
+
+Cooling is only offered from api version 22.090 on, as register 32608 does not exist below
+it and the circuit cannot be switched to "heating + cooling" without it.
+
+The integration does not calculate the dew point for you - it logs a warning the first time
+a circuit is switched to cooling and otherwise leaves the responsibility with your
+automations. The heating circuit exposes `room_temperature` and `humidity` sensors you can
+build that on.
+
+Note that the "outdoor shutdown temperature heating" parameter on the control panel stays
+active for heating. If the outdoor temperature is above it, the circuit will not start
+heating regardless of what is written over Modbus; set the parameter to 45°C to disable it.
 
 ![example](img/example.png)
 

--- a/custom_components/solarfocus/climate.py
+++ b/custom_components/solarfocus/climate.py
@@ -2,6 +2,9 @@
 
 from dataclasses import dataclass
 import logging
+from typing import Any
+
+from pysolarfocus import ApiVersions
 
 from homeassistant.components.climate import ClimateEntity, ClimateEntityDescription
 from homeassistant.components.climate.const import (
@@ -12,9 +15,10 @@ from homeassistant.components.climate.const import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
@@ -43,6 +47,43 @@ SOLARFOCUS_MODE_TO_PRESET = {
 PRESET_TO_SOLARFOCUS_MODE = {
     value: key for key, value in SOLARFOCUS_MODE_TO_PRESET.items()
 }
+
+# Section 6.2 of the Solarfocus Modbus specification, "Vorlaufsolltemperatur wird
+# an ecomanager-touch geschickt": the external controller takes over the heating
+# circuit and writes these four registers together.
+#
+#            32600 target_supply_temperature   32602 cooling
+#            32603 mode                        32608 heating_mode
+#
+# heating    setpoint  0  <preset>  2
+# cooling    setpoint  1  <preset>  2
+# off        0         0  3         2
+#
+# The specification writes 0 (continuous operation) into 32603 for heating and
+# cooling. We keep the preset the user has configured instead and only switch the
+# circuit back on when it is off, so that a comfort, eco or auto schedule is not
+# silently discarded.
+
+# Register 32602 "Kühlen"
+COOLING_OFF = 0
+COOLING_ON = 1
+
+# Register 32603 "Heizkreisbetriebsart"
+OPERATING_MODE_CONTINUOUS = 0
+OPERATING_MODE_OFF = 3
+
+# Register 32608 "Heizkreismodus"
+HEATING_MODE_HEATING_AND_COOLING = 2
+
+# Register 32608 only exists from this api version on. Without it the circuit
+# cannot be switched to "Heizen + Kühlen", so cooling is not offered below it.
+MIN_COOLING_API_VERSION = ApiVersions.V_22_090.value
+
+# Heating circuit states that mean the circuit is actively cooling.
+COOLING_STATES = [23, 24]
+
+# Used until the user has set a flow temperature for the mode themselves.
+DEFAULT_TARGET_TEMPERATURE = {HVACMode.HEAT: 30.0, HVACMode.COOL: 19.0}
 
 
 async def async_setup_entry(
@@ -77,14 +118,29 @@ class SolarfocusClimateEntityDescription(
     """Description of a Solarfocus number entity."""
 
 
-class SolarfocusClimateEntity(SolarfocusEntity, ClimateEntity):
+@dataclass
+class SolarfocusClimateExtraStoredData(ExtraStoredData):
+    """Flow setpoints the thermostat has to survive a restart with."""
+
+    target_temperatures: dict[str, float]
+    active_mode: str
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a serializable representation."""
+        return {
+            "target_temperatures": self.target_temperatures,
+            "active_mode": self.active_mode,
+        }
+
+
+class SolarfocusClimateEntity(SolarfocusEntity, RestoreEntity, ClimateEntity):
     """Representation of a Solarfocus number entity."""
 
     _attr_supported_features = (
         ClimateEntityFeature.PRESET_MODE
+        | ClimateEntityFeature.TARGET_TEMPERATURE
         | ClimateEntityFeature.TURN_ON
         | ClimateEntityFeature.TURN_OFF
-        # | ClimateEntityFeature.TARGET_TEMPERATURE
     )
 
     def __init__(
@@ -94,6 +150,51 @@ class SolarfocusClimateEntity(SolarfocusEntity, ClimateEntity):
     ) -> None:
         """Initialize the Solarfocus select entity."""
         super().__init__(coordinator, description)
+
+        # Switching the circuit off writes register 32600 to 0, so the setpoint
+        # has to be remembered to be able to switch the circuit back on.
+        self._target_temperatures: dict[HVACMode, float] = {}
+        self._active_mode = HVACMode.HEAT
+        self._dew_point_warning_logged = False
+
+    @property
+    def extra_restore_state_data(self) -> SolarfocusClimateExtraStoredData:
+        """Return the setpoints to restore after a restart."""
+        return SolarfocusClimateExtraStoredData(
+            target_temperatures={
+                mode.value: temperature
+                for mode, temperature in self._target_temperatures.items()
+            },
+            active_mode=self._active_mode.value,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the setpoints the user has set before the restart."""
+        await super().async_added_to_hass()
+
+        if (last_data := await self.async_get_last_extra_data()) is None:
+            return
+
+        restored = last_data.as_dict()
+
+        self._target_temperatures = {
+            HVACMode(mode): float(temperature)
+            for mode, temperature in restored.get("target_temperatures", {}).items()
+            if mode in (HVACMode.HEAT, HVACMode.COOL)
+        }
+
+        if (active_mode := restored.get("active_mode")) in (
+            HVACMode.HEAT,
+            HVACMode.COOL,
+        ):
+            self._active_mode = HVACMode(active_mode)
+
+    @property
+    def cooling_supported(self) -> bool:
+        """Return whether the circuit can be switched to "Heizen + Kühlen"."""
+        return self.coordinator.api.api_version.greater_or_equal(
+            MIN_COOLING_API_VERSION
+        )
 
     @property
     def max_temp(self) -> float:
@@ -112,8 +213,24 @@ class SolarfocusClimateEntity(SolarfocusEntity, ClimateEntity):
     @property
     def target_temperature(self) -> float:
         """Return target supply temperature."""
+        if value := self._get_native_value("target_supply_temperature"):
+            return round(float(value), 2)
+
+        # The circuit is switched off, register 32600 has been written to 0
+        return self._remembered_target_temperature(self._active_mode)
+
+    def _remembered_target_temperature(self, hvac_mode: HVACMode) -> float:
+        """Return the setpoint to write when switching the circuit to a mode."""
+        if (temperature := self._target_temperatures.get(hvac_mode)) is not None:
+            return temperature
+
+        # Only the setpoint of the mode the circuit currently runs in can be
+        # reused, a heating setpoint is far outside the cooling range.
         value = self._get_native_value("target_supply_temperature")
-        return round(float(value), 2)
+        if value and self.hvac_mode == hvac_mode:
+            return round(float(value), 2)
+
+        return DEFAULT_TARGET_TEMPERATURE[hvac_mode]
 
     @property
     def current_temperature(self) -> float:
@@ -129,9 +246,8 @@ class SolarfocusClimateEntity(SolarfocusEntity, ClimateEntity):
         if self._get_native_value("state") in [0]:
             return HVACMode.OFF
 
-        # value = self._get_native_value("cooling")
-        # if value:
-        #    return HVACMode.COOL
+        if self.cooling_supported and self._get_native_value("cooling"):
+            return HVACMode.COOL
 
         return HVACMode.HEAT
 
@@ -162,17 +278,16 @@ class SolarfocusClimateEntity(SolarfocusEntity, ClimateEntity):
             return HVACAction.OFF
         if state in [31]:
             return HVACAction.IDLE
-        # if state in [23, 24]:
-        #     return HVACAction.COOLING
+        if state in COOLING_STATES:
+            return HVACAction.COOLING
         return HVACAction.HEATING
 
     @property
     def hvac_modes(self):
         """Return the list of available operation modes."""
-        modes = []
-        modes.append(HVACMode.OFF)
-        # modes.append(HVACMode.COOL)
-        modes.append(HVACMode.HEAT)
+        modes = [HVACMode.OFF, HVACMode.HEAT]
+        if self.cooling_supported:
+            modes.append(HVACMode.COOL)
         return modes
 
     @property
@@ -203,18 +318,65 @@ class SolarfocusClimateEntity(SolarfocusEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target hvac mode."""
         _LOGGER.info("Set HVAC Mode: %s", hvac_mode)
+
         if hvac_mode == HVACMode.OFF:
-            self._set_native_value("mode", "3")
+            self._write_heating_circuit(
+                target_supply_temperature=0,
+                cooling=COOLING_OFF,
+                operating_mode=OPERATING_MODE_OFF,
+            )
+            return
 
-        # if hvac_mode == HVACMode.COOL:
-        #    if self._get_native_value("state") in [0]:
-        #        self._set_native_value("mode", "0")
-        #    self._set_native_value("cooling", "1")
+        if hvac_mode == HVACMode.COOL:
+            self._log_dew_point_warning()
 
-        if hvac_mode == HVACMode.HEAT:
-            if self._get_native_value("state") in [0]:
-                self._set_native_value("mode", "0")
-            self._set_native_value("cooling", "0")
+        self._active_mode = hvac_mode
+        self._write_heating_circuit(
+            target_supply_temperature=self._remembered_target_temperature(hvac_mode),
+            cooling=COOLING_ON if hvac_mode == HVACMode.COOL else COOLING_OFF,
+            operating_mode=self._operating_mode(),
+        )
+
+    def _operating_mode(self) -> int:
+        """Return the value for register 32603 "Heizkreisbetriebsart".
+
+        A circuit that is switched off has to be switched back on, any other
+        setting is the preset the user has configured and is kept.
+        """
+        mode = self._get_native_value("mode")
+        if mode == OPERATING_MODE_OFF:
+            return OPERATING_MODE_CONTINUOUS
+        return int(mode)
+
+    def _write_heating_circuit(
+        self, target_supply_temperature: float, cooling: int, operating_mode: int
+    ) -> None:
+        """Write the registers section 6.2 requires to be written together.
+
+        Writing only some of them can leave the controller in an undefined state.
+        Register 32608 does not exist below api version 22.090; a circuit that old
+        cannot cool anyway, so heating and off are written without it.
+        """
+        self._set_native_value("target_supply_temperature", target_supply_temperature)
+        self._set_native_value("cooling", cooling)
+        self._set_native_value("mode", operating_mode)
+
+        if self.cooling_supported:
+            self._set_native_value("heating_mode", HEATING_MODE_HEATING_AND_COOLING)
+
+    def _log_dew_point_warning(self) -> None:
+        """Warn that the controller stops watching the dew point, once."""
+        if self._dew_point_warning_logged:
+            return
+
+        self._dew_point_warning_logged = True
+        _LOGGER.warning(
+            "Heating circuit %s has been switched to cooling. Writing register 32602 "
+            "disables the dew point monitoring of the Solarfocus controller, so the "
+            "flow temperature has to be kept above the dew point of every room from "
+            "Home Assistant to avoid condensation damage to the building",
+            self.entity_description.component_idx,
+        )
 
     async def async_set_preset_mode(self, preset_mode):
         """Set new target preset mode."""
@@ -222,11 +384,24 @@ class SolarfocusClimateEntity(SolarfocusEntity, ClimateEntity):
         _LOGGER.info("Set Preset Mode: %s (mapped mode: %s)", preset_mode, mode)
         self._set_native_value("mode", mode)
 
-    # async def async_set_temperature(self, **kwargs):
-    #     """Set new target temperature."""
-    #     if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
-    #         _LOGGER.info("Set Temperature: %s", temp)
-    #         self._set_native_value("target_supply_temperature", temp)
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set the flow setpoint of the mode the circuit is running in."""
+        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
+            return
+
+        _LOGGER.info("Set Temperature: %s", temperature)
+        hvac_mode = self.hvac_mode
+
+        if hvac_mode == HVACMode.OFF:
+            # Register 32600 has to stay 0 while the circuit is switched off, so
+            # the setpoint is only remembered for the next time it is switched on.
+            self._target_temperatures[self._active_mode] = float(temperature)
+            self.async_write_ha_state()
+            return
+
+        self._active_mode = hvac_mode
+        self._target_temperatures[hvac_mode] = float(temperature)
+        self._set_native_value("target_supply_temperature", temperature)
 
     async def async_turn_on(self) -> None:
         """Turn on - by setting HVAC mode to HEAT."""

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,93 +1,503 @@
-"""Test the Solarfocus climate entity."""
+"""Test the Solarfocus climate entity against the Modbus specification.
+
+Section 6.2 of the specification ("Vorlaufsolltemperatur wird an ecomanager-touch
+geschickt") defines three complete register states for a heating circuit that is
+controlled externally, and requires all of the registers to be written on every
+transition - writing only some of them can leave the controller in an undefined
+state.
+
+    register                          heating    cooling    off
+    32600 target_supply_temperature   setpoint   setpoint   0
+    32602 cooling                     0          1          0
+    32603 mode                        <preset>   <preset>   3
+    32608 heating_mode                2          2          2
+
+The specification writes 0 (continuous operation) into 32603 for heating and
+cooling. This integration keeps the preset the user configured instead and only
+switches a circuit that is off back on, see the module docstring of climate.py.
+"""
 
 from unittest.mock import MagicMock, patch
 
+from pysolarfocus import ApiVersions
 import pytest
 
 from custom_components.solarfocus.climate import (
+    CLIMATE_TYPES,
+    DEFAULT_TARGET_TEMPERATURE,
+    PRESET_AUTO,
+    PRESET_OFF,
     SolarfocusClimateEntity,
-    SolarfocusClimateEntityDescription,
 )
 from custom_components.solarfocus.const import (
     HEATING_CIRCUIT_COMPONENT,
     HEATING_CIRCUIT_COMPONENT_PREFIX,
     HEATING_CIRCUIT_PREFIX,
 )
-from custom_components.solarfocus.entity import create_description
-from homeassistant.components.climate.const import HVACMode
+from custom_components.solarfocus.entity import SolarfocusEntity, create_description
+from homeassistant.components.climate.const import (
+    PRESET_COMFORT,
+    PRESET_ECO,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.core import State
+
+from pytest_homeassistant_custom_component.common import mock_restore_cache_with_extra_data
+
+from .conftest import build_api, build_config_entry, build_coordinator
+
+# The registers the specification requires to be written together.
+REGISTERS = ("target_supply_temperature", "cooling", "mode", "heating_mode")
+
+STATE_OFF = 0
+STATE_HEATING = 2
+STATE_COOLING = 23
+
+MODE_CONTINUOUS = 0
+MODE_AUTO = 2
+MODE_OFF = 3
+
+
+def build_climate(
+    api_version: ApiVersions = ApiVersions.V_23_020,
+    state: int = STATE_HEATING,
+    mode: int = MODE_CONTINUOUS,
+    cooling: int = 0,
+    target_supply_temperature: float = 38.0,
+) -> SolarfocusClimateEntity:
+    """Return a thermostat for heating circuit 1 over a mocked heating circuit."""
+    api = build_api()
+    api.api_version = api_version
+
+    circuit = api.heating_circuits[0]
+    circuit.state.scaled_value = state
+    circuit.mode.scaled_value = mode
+    circuit.cooling.scaled_value = cooling
+    circuit.target_supply_temperature.scaled_value = target_supply_temperature
+    circuit.supply_temperature.scaled_value = 36.5
+
+    entity = SolarfocusClimateEntity(
+        build_coordinator(build_config_entry(), api),
+        create_description(
+            HEATING_CIRCUIT_PREFIX,
+            HEATING_CIRCUIT_COMPONENT,
+            HEATING_CIRCUIT_COMPONENT_PREFIX,
+            "1",
+            CLIMATE_TYPES[0],
+        ),
+    )
+    entity.async_write_ha_state = MagicMock()
+    return entity
+
+
+def written(set_value: MagicMock) -> dict[str, float]:
+    """Return the registers a call wrote, keyed by their item name."""
+    return {call.args[0]: call.args[1] for call in set_value.call_args_list}
 
 
 @pytest.fixture(name="climate")
 def climate_fixture() -> SolarfocusClimateEntity:
-    """Return a thermostat entity for heating circuit 1 with a mocked coordinator."""
-    coordinator = MagicMock()
-    coordinator._entry.title = "Solarfocus"
-
-    description = create_description(
-        HEATING_CIRCUIT_PREFIX,
-        HEATING_CIRCUIT_COMPONENT,
-        HEATING_CIRCUIT_COMPONENT_PREFIX,
-        "1",
-        SolarfocusClimateEntityDescription(key="thermostat"),
-    )
-
-    return SolarfocusClimateEntity(coordinator, description)
+    """Return a thermostat of a circuit running in heating mode."""
+    return build_climate()
 
 
-async def test_turn_on_sets_heat_mode(climate: SolarfocusClimateEntity) -> None:
-    """Turning on writes the registers for HVACMode.HEAT."""
-    with (
-        patch.object(climate, "_set_native_value") as set_value,
-        patch.object(climate, "_get_native_value", return_value=0),
-    ):
-        await climate.async_turn_on()
-
-    # state 0 means the circuit is off, so it is switched back to mode "comfort"
-    assert set_value.call_args_list == [
-        (("mode", "0"),),
-        (("cooling", "0"),),
-    ]
+# --- the three register states of section 6.2 --------------------------------
 
 
-async def test_turn_on_while_running_only_disables_cooling(
-    climate: SolarfocusClimateEntity,
-) -> None:
-    """A circuit that is already running keeps its mode."""
-    with (
-        patch.object(climate, "_set_native_value") as set_value,
-        patch.object(climate, "_get_native_value", return_value=31),
-    ):
-        await climate.async_turn_on()
+async def test_heating_writes_every_register(climate) -> None:
+    """6.2.1, the circuit is switched to heating."""
+    with patch.object(climate, "_set_native_value") as set_value:
+        await climate.async_set_hvac_mode(HVACMode.HEAT)
 
-    assert set_value.call_args_list == [(("cooling", "0"),)]
+    assert written(set_value) == {
+        "target_supply_temperature": 38.0,
+        "cooling": 0,
+        "mode": MODE_CONTINUOUS,
+        "heating_mode": 2,
+    }
 
 
-async def test_turn_off_sets_off_mode(climate: SolarfocusClimateEntity) -> None:
-    """Turning off writes the register for HVACMode.OFF."""
-    with (
-        patch.object(climate, "_set_native_value") as set_value,
-        patch.object(climate, "_get_native_value", return_value=31),
-    ):
-        await climate.async_turn_off()
+async def test_cooling_writes_every_register(climate) -> None:
+    """6.2.2, the circuit is switched to cooling."""
+    with patch.object(climate, "_set_native_value") as set_value:
+        await climate.async_set_hvac_mode(HVACMode.COOL)
 
-    assert set_value.call_args_list == [(("mode", "3"),)]
+    assert written(set_value) == {
+        # No cooling setpoint has been set yet, a heating one must not be reused
+        "target_supply_temperature": DEFAULT_TARGET_TEMPERATURE[HVACMode.COOL],
+        "cooling": 1,
+        "mode": MODE_CONTINUOUS,
+        "heating_mode": 2,
+    }
+
+
+async def test_off_writes_every_register(climate) -> None:
+    """6.2.3, the circuit is switched off, including the setpoint of 0."""
+    with patch.object(climate, "_set_native_value") as set_value:
+        await climate.async_set_hvac_mode(HVACMode.OFF)
+
+    assert written(set_value) == {
+        "target_supply_temperature": 0,
+        "cooling": 0,
+        "mode": MODE_OFF,
+        "heating_mode": 2,
+    }
 
 
 @pytest.mark.parametrize(
-    ("hvac_mode", "expected"),
-    [
-        (HVACMode.OFF, [(("mode", "3"),)]),
-        (HVACMode.HEAT, [(("cooling", "0"),)]),
-    ],
+    "hvac_mode", [HVACMode.HEAT, HVACMode.COOL, HVACMode.OFF], ids=str
 )
-async def test_set_hvac_mode(
-    climate: SolarfocusClimateEntity, hvac_mode: HVACMode, expected: list
-) -> None:
-    """Setting the hvac mode directly writes the same registers."""
-    with (
-        patch.object(climate, "_set_native_value") as set_value,
-        patch.object(climate, "_get_native_value", return_value=31),
-    ):
+async def test_no_register_is_left_out(climate, hvac_mode: HVACMode) -> None:
+    """The specification requires all four registers on every transition."""
+    with patch.object(climate, "_set_native_value") as set_value:
         await climate.async_set_hvac_mode(hvac_mode)
 
-    assert set_value.call_args_list == expected
+    assert set(written(set_value)) == set(REGISTERS)
+
+
+# --- the preset deviation ----------------------------------------------------
+
+
+async def test_switching_on_keeps_the_configured_preset() -> None:
+    """A circuit on an auto schedule keeps it when the mode is switched."""
+    climate = build_climate(mode=MODE_AUTO)
+
+    with patch.object(climate, "_set_native_value") as set_value:
+        await climate.async_set_hvac_mode(HVACMode.COOL)
+
+    assert written(set_value)["mode"] == MODE_AUTO
+
+
+async def test_switching_on_a_circuit_that_is_off_selects_continuous() -> None:
+    """A circuit that is switched off has to be switched back on."""
+    climate = build_climate(state=STATE_OFF, mode=MODE_OFF)
+
+    with patch.object(climate, "_set_native_value") as set_value:
+        await climate.async_set_hvac_mode(HVACMode.HEAT)
+
+    assert written(set_value)["mode"] == MODE_CONTINUOUS
+
+
+# --- api versions ------------------------------------------------------------
+
+
+async def test_cooling_needs_api_version_22_090() -> None:
+    """Register 32608 does not exist below 22.090, so cooling is not offered."""
+    old = build_climate(api_version=ApiVersions.V_21_140)
+    new = build_climate(api_version=ApiVersions.V_22_090)
+
+    assert old.hvac_modes == [HVACMode.OFF, HVACMode.HEAT]
+    assert new.hvac_modes == [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL]
+
+
+async def test_heating_mode_is_not_written_below_22_090() -> None:
+    """Writing a register the api version does not have raises AttributeError."""
+    climate = build_climate(api_version=ApiVersions.V_21_140)
+
+    with patch.object(climate, "_set_native_value") as set_value:
+        await climate.async_set_hvac_mode(HVACMode.HEAT)
+
+    assert "heating_mode" not in written(set_value)
+
+
+async def test_a_cooling_circuit_reports_cooling() -> None:
+    """The cooling register decides between heating and cooling."""
+    assert build_climate(cooling=1).hvac_mode == HVACMode.COOL
+    assert build_climate(cooling=0).hvac_mode == HVACMode.HEAT
+    assert build_climate(state=STATE_OFF).hvac_mode == HVACMode.OFF
+
+
+async def test_an_old_circuit_never_reports_cooling() -> None:
+    """Below 22.090 the cooling register is not part of the mode."""
+    climate = build_climate(api_version=ApiVersions.V_21_140, cooling=1)
+
+    assert climate.hvac_mode == HVACMode.HEAT
+
+
+# --- the flow setpoint -------------------------------------------------------
+
+
+async def test_the_setpoint_survives_being_switched_off(climate) -> None:
+    """Switching off writes 0, switching back on restores the setpoint."""
+    with patch.object(climate, "_set_native_value"):
+        await climate.async_set_temperature(**{ATTR_TEMPERATURE: 41.5})
+
+    # The circuit is off, register 32600 reads 0
+    climate.coordinator.api.heating_circuits[0].target_supply_temperature.scaled_value = 0
+    climate.coordinator.api.heating_circuits[0].state.scaled_value = STATE_OFF
+
+    with patch.object(climate, "_set_native_value") as set_value:
+        await climate.async_set_hvac_mode(HVACMode.HEAT)
+
+    assert written(set_value)["target_supply_temperature"] == 41.5
+
+
+async def test_each_mode_keeps_its_own_setpoint(climate) -> None:
+    """A heating setpoint is far outside the cooling range and vice versa."""
+    with patch.object(climate, "_set_native_value"):
+        await climate.async_set_temperature(**{ATTR_TEMPERATURE: 41.5})
+
+    with patch.object(climate, "_set_native_value") as set_value:
+        await climate.async_set_hvac_mode(HVACMode.COOL)
+    assert written(set_value)["target_supply_temperature"] == 19.0
+
+    climate.coordinator.api.heating_circuits[0].cooling.scaled_value = 1
+    with patch.object(climate, "_set_native_value"):
+        await climate.async_set_temperature(**{ATTR_TEMPERATURE: 18.0})
+
+    climate.coordinator.api.heating_circuits[0].cooling.scaled_value = 0
+    with patch.object(climate, "_set_native_value") as set_value:
+        await climate.async_set_hvac_mode(HVACMode.COOL)
+
+    assert written(set_value)["target_supply_temperature"] == 18.0
+
+
+async def test_setting_a_temperature_while_off_only_remembers_it() -> None:
+    """Register 32600 has to stay 0 while the circuit is switched off."""
+    climate = build_climate(state=STATE_OFF, target_supply_temperature=0)
+
+    with patch.object(climate, "_set_native_value") as set_value:
+        await climate.async_set_temperature(**{ATTR_TEMPERATURE: 40.0})
+
+    assert not set_value.called
+    assert climate.target_temperature == 40.0
+
+
+async def test_setting_a_temperature_writes_the_setpoint(climate) -> None:
+    """A running circuit takes the setpoint immediately."""
+    with patch.object(climate, "_set_native_value") as set_value:
+        await climate.async_set_temperature(**{ATTR_TEMPERATURE: 42.0})
+
+    assert written(set_value) == {"target_supply_temperature": 42.0}
+
+
+async def test_a_call_without_a_temperature_writes_nothing(climate) -> None:
+    """The service can be called with other attributes only."""
+    with patch.object(climate, "_set_native_value") as set_value:
+        await climate.async_set_temperature(hvac_mode=HVACMode.HEAT)
+
+    assert not set_value.called
+
+
+async def test_the_setpoint_of_a_switched_off_circuit_is_the_remembered_one() -> None:
+    """Register 32600 reads 0 while off, which is not a usable setpoint."""
+    climate = build_climate(state=STATE_OFF, target_supply_temperature=0)
+
+    assert climate.target_temperature == DEFAULT_TARGET_TEMPERATURE[HVACMode.HEAT]
+
+
+# --- condensation ------------------------------------------------------------
+
+
+async def test_switching_to_cooling_warns_about_the_dew_point(
+    climate, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The controller stops watching the dew point once 32602 is written."""
+    with patch.object(climate, "_set_native_value"):
+        await climate.async_set_hvac_mode(HVACMode.COOL)
+
+    assert "dew point" in caplog.text
+    assert "condensation" in caplog.text
+
+
+async def test_the_dew_point_warning_is_logged_once(
+    climate, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A thermostat in cooling mode must not warn on every service call."""
+    with patch.object(climate, "_set_native_value"):
+        await climate.async_set_hvac_mode(HVACMode.COOL)
+        await climate.async_set_hvac_mode(HVACMode.COOL)
+
+    warnings = [record for record in caplog.records if record.levelname == "WARNING"]
+    assert len(warnings) == 1
+
+
+async def test_heating_does_not_warn(climate, caplog: pytest.LogCaptureFixture) -> None:
+    """Heating leaves the dew point monitoring of the controller alone."""
+    with patch.object(climate, "_set_native_value"):
+        await climate.async_set_hvac_mode(HVACMode.HEAT)
+
+    assert "dew point" not in caplog.text
+
+
+# --- what the thermostat reports ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        (STATE_OFF, HVACAction.OFF),
+        (11, HVACAction.OFF),
+        (228, HVACAction.OFF),
+        (31, HVACAction.IDLE),
+        (23, HVACAction.COOLING),
+        (24, HVACAction.COOLING),
+        (STATE_HEATING, HVACAction.HEATING),
+    ],
+)
+def test_hvac_action(state: int, expected: HVACAction) -> None:
+    """The device state maps to what the circuit is currently doing."""
+    assert build_climate(state=state).hvac_action == expected
+
+
+@pytest.mark.parametrize(
+    ("mode", "preset"),
+    [(0, PRESET_COMFORT), (1, PRESET_ECO), (2, PRESET_AUTO), (3, PRESET_OFF)],
+)
+def test_preset_mode(mode: int, preset: str) -> None:
+    """Every device mode has a preset."""
+    climate = build_climate(mode=mode)
+
+    assert climate.preset_mode == preset
+    assert preset in climate.preset_modes
+
+
+@pytest.mark.parametrize(
+    ("preset", "expected"),
+    [(PRESET_COMFORT, 0), (PRESET_ECO, 1), (PRESET_AUTO, 2), (PRESET_OFF, 3)],
+)
+async def test_set_preset_mode(climate, preset: str, expected: int) -> None:
+    """Selecting a preset writes the numeric mode."""
+    with patch.object(climate, "_set_native_value") as set_value:
+        await climate.async_set_preset_mode(preset)
+
+    assert set_value.call_args_list == [(("mode", expected),)]
+
+
+@pytest.mark.parametrize(
+    ("cooling", "min_temp", "max_temp"), [(0, 22.0, 45.0), (1, 7.0, 35.0)]
+)
+def test_temperature_range_follows_cooling(
+    cooling: int, min_temp: float, max_temp: float
+) -> None:
+    """A cooling circuit has a different valid range than a heating one."""
+    climate = build_climate(cooling=cooling)
+
+    assert climate.min_temp == min_temp
+    assert climate.max_temp == max_temp
+
+
+def test_temperatures() -> None:
+    """The thermostat works on the supply temperature."""
+    climate = build_climate(target_supply_temperature=40.123)
+
+    assert climate.current_temperature == 36.5
+    assert climate.target_temperature == 40.12
+    assert climate.temperature_unit == UnitOfTemperature.CELSIUS
+
+
+def test_supported_features_include_the_setpoint(climate) -> None:
+    """Writing register 32600 requires the target temperature feature."""
+    assert ClimateEntityFeature.TARGET_TEMPERATURE in climate.supported_features
+
+
+# --- restoring after a restart ------------------------------------------------
+
+
+async def test_setpoints_are_stored_for_a_restart(climate) -> None:
+    """The remembered setpoints are written to the restore state."""
+    with patch.object(climate, "_set_native_value"):
+        await climate.async_set_temperature(**{ATTR_TEMPERATURE: 41.5})
+
+    assert climate.extra_restore_state_data.as_dict() == {
+        "target_temperatures": {"heat": 41.5},
+        "active_mode": "heat",
+    }
+
+
+async def test_setpoints_are_restored_after_a_restart(climate) -> None:
+    """A restart must not lose the setpoint of a switched off circuit."""
+    restored = MagicMock()
+    restored.as_dict.return_value = {
+        "target_temperatures": {"heat": 41.5, "cool": 18.0},
+        "active_mode": "cool",
+    }
+
+    with (
+        patch.object(SolarfocusEntity, "async_added_to_hass"),
+        patch.object(climate, "async_get_last_extra_data", return_value=restored),
+    ):
+        await climate.async_added_to_hass()
+
+    assert climate._target_temperatures == {
+        HVACMode.HEAT: 41.5,
+        HVACMode.COOL: 18.0,
+    }
+    assert climate._active_mode == HVACMode.COOL
+
+
+async def test_a_first_start_has_nothing_to_restore(climate) -> None:
+    """Without stored data the defaults stay in place."""
+    with (
+        patch.object(SolarfocusEntity, "async_added_to_hass"),
+        patch.object(climate, "async_get_last_extra_data", return_value=None),
+    ):
+        await climate.async_added_to_hass()
+
+    assert climate._target_temperatures == {}
+    assert climate._active_mode == HVACMode.HEAT
+
+
+# --- turn on and off ---------------------------------------------------------
+
+
+async def test_turn_off(climate) -> None:
+    """Turning off is the off state of the specification."""
+    with patch.object(climate, "_set_native_value") as set_value:
+        await climate.async_turn_off()
+
+    assert written(set_value)["mode"] == MODE_OFF
+    assert written(set_value)["target_supply_temperature"] == 0
+
+
+async def test_turn_on_heats(climate) -> None:
+    """Turning on never starts cooling on its own."""
+    with patch.object(climate, "_set_native_value") as set_value:
+        await climate.async_turn_on()
+
+    assert written(set_value)["cooling"] == 0
+
+
+# --- wiring ------------------------------------------------------------------
+
+
+async def test_the_thermostat_restores_its_setpoint_from_storage(
+    hass, enable_custom_integrations, mock_api, api
+) -> None:
+    """A restart must not lose the setpoint of a circuit that is switched off.
+
+    Goes through the platform rather than calling async_added_to_hass directly,
+    so that the restore is exercised the way Home Assistant drives it.
+    """
+    circuit = api.heating_circuits[0]
+    circuit.state.scaled_value = STATE_OFF
+    circuit.mode.scaled_value = MODE_OFF
+    circuit.cooling.scaled_value = 0
+    # The circuit is switched off, so register 32600 reads 0
+    circuit.target_supply_temperature.scaled_value = 0
+    circuit.supply_temperature.scaled_value = 21.0
+
+    mock_restore_cache_with_extra_data(
+        hass,
+        (
+            (
+                State("climate.solarfocus_heating_circuit_1_thermostat", HVACMode.OFF),
+                {"target_temperatures": {"heat": 41.5}, "active_mode": "heat"},
+            ),
+        ),
+    )
+
+    entry = build_config_entry(heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    states = [state for state in hass.states.async_all() if state.domain == "climate"]
+    assert len(states) == 1
+    assert states[0].state == HVACMode.OFF
+    # Without the restore the thermostat would fall back to the default
+    assert states[0].attributes["temperature"] == 41.5

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -18,12 +18,6 @@ from custom_components.solarfocus.button import (
     BOILER_BUTTON_TYPES,
     SolarfocusButtonEntity,
 )
-from custom_components.solarfocus.climate import (
-    CLIMATE_TYPES,
-    PRESET_AUTO,
-    PRESET_OFF,
-    SolarfocusClimateEntity,
-)
 from custom_components.solarfocus.const import (
     BOILER_COMPONENT,
     BOILER_COMPONENT_PREFIX,
@@ -62,12 +56,6 @@ from custom_components.solarfocus.water_heater import (
     SOLARFOCUS_TEMP_WATER_MIN,
     WATER_HEATER_TYPES,
     SolarfocusWaterHeaterEntity,
-)
-from homeassistant.components.climate.const import (
-    PRESET_COMFORT,
-    PRESET_ECO,
-    HVACAction,
-    HVACMode,
 )
 from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, UnitOfTemperature
 
@@ -462,102 +450,6 @@ async def test_water_heater_turns_on_and_off(boiler_water_heater) -> None:
         (("holding_mode", SOLARFOCUS_MODE_ALWAYS_ON),),
         (("holding_mode", SOLARFOCUS_MODE_ALWAYS_OFF),),
     ]
-
-
-# --- climate ----------------------------------------------------------------
-
-
-@pytest.fixture(name="climate_entity")
-def climate_entity_fixture() -> SolarfocusClimateEntity:
-    """Return the thermostat of heating circuit 1."""
-    return _make(
-        SolarfocusClimateEntity,
-        CLIMATE_TYPES[0],
-        HEATING_CIRCUIT_PREFIX,
-        HEATING_CIRCUIT_COMPONENT,
-        HEATING_CIRCUIT_COMPONENT_PREFIX,
-    )
-
-
-@pytest.mark.parametrize(
-    ("state", "expected"),
-    [(0, HVACMode.OFF), (31, HVACMode.HEAT), (23, HVACMode.HEAT)],
-)
-def test_climate_hvac_mode(climate_entity, state: int, expected: HVACMode) -> None:
-    """State 0 means the circuit is switched off."""
-    climate_entity.coordinator.api.heating_circuits[0].state.scaled_value = state
-
-    assert climate_entity.hvac_mode == expected
-    assert climate_entity.hvac_modes == [HVACMode.OFF, HVACMode.HEAT]
-
-
-@pytest.mark.parametrize(
-    ("state", "expected"),
-    [
-        (0, HVACAction.OFF),
-        (11, HVACAction.OFF),
-        (228, HVACAction.OFF),
-        (31, HVACAction.IDLE),
-        (23, HVACAction.HEATING),
-    ],
-)
-def test_climate_hvac_action(
-    climate_entity, state: int, expected: HVACAction
-) -> None:
-    """The device state maps to what the circuit is currently doing."""
-    climate_entity.coordinator.api.heating_circuits[0].state.scaled_value = state
-
-    assert climate_entity.hvac_action == expected
-
-
-@pytest.mark.parametrize(
-    ("mode", "preset"),
-    [(0, PRESET_COMFORT), (1, PRESET_ECO), (2, PRESET_AUTO), (3, PRESET_OFF)],
-)
-def test_climate_preset_mode(climate_entity, mode: int, preset: str) -> None:
-    """Every device mode has a preset and every preset writes it back."""
-    climate_entity.coordinator.api.heating_circuits[0].mode.scaled_value = mode
-
-    assert climate_entity.preset_mode == preset
-    assert preset in climate_entity.preset_modes
-
-
-@pytest.mark.parametrize(
-    ("preset", "expected"),
-    [(PRESET_COMFORT, 0), (PRESET_ECO, 1), (PRESET_AUTO, 2), (PRESET_OFF, 3)],
-)
-async def test_climate_set_preset_mode(
-    climate_entity, preset: str, expected: int
-) -> None:
-    """Selecting a preset writes the numeric mode."""
-    with patch.object(climate_entity, "_set_native_value") as set_value:
-        await climate_entity.async_set_preset_mode(preset)
-
-    assert set_value.call_args_list == [(("mode", expected),)]
-
-
-@pytest.mark.parametrize(
-    ("cooling", "min_temp", "max_temp"), [(0, 22.0, 45.0), (1, 7.0, 35.0)]
-)
-def test_climate_temperature_range_follows_cooling(
-    climate_entity, cooling: int, min_temp: float, max_temp: float
-) -> None:
-    """A cooling circuit has a different valid range than a heating one."""
-    climate_entity.coordinator.api.heating_circuits[0].cooling.scaled_value = cooling
-
-    assert climate_entity.min_temp == min_temp
-    assert climate_entity.max_temp == max_temp
-
-
-def test_climate_temperatures(climate_entity) -> None:
-    """The thermostat works on the supply temperature."""
-    circuit = climate_entity.coordinator.api.heating_circuits[0]
-    circuit.supply_temperature.scaled_value = 38.4
-    circuit.target_supply_temperature.scaled_value = 40.123
-
-    assert climate_entity.current_temperature == 38.4
-    assert climate_entity.target_temperature == 40.12
-    assert climate_entity.temperature_unit == UnitOfTemperature.CELSIUS
 
 
 # --- writing ----------------------------------------------------------------


### PR DESCRIPTION
Closes #143.

`HVACMode.COOL` was commented out in `climate.py`, so the only way to cool was to drive the `cooling` select and the `target_supply_temperature` number from an automation, which is what @Vaszago is doing in the issue.

## What the specification requires

Section 6.2 ("Vorlaufsolltemperatur wird an ecomanager-touch geschickt") describes the heating circuit being controlled externally, and the ACHTUNG in 6.2.3 requires **all four registers to be written on every transition** — writing only some of them can leave the controller in an undefined state.

| Register | Heating | Cooling | Off |
| --- | --- | --- | --- |
| 32600 `target_supply_temperature` | setpoint | setpoint | 0 |
| 32602 `cooling` | 0 | 1 | 0 |
| 32603 `mode` | 0 | 0 | 3 |
| 32608 `heating_mode` | 2 | 2 | 2 |

The old code wrote at most two of them and never 32600 or 32608, so even the existing heating path did not follow this.

## What this does

Selecting a mode writes all four, with **one deliberate deviation**: 32603 keeps the preset the user configured rather than always being 0, and is only switched back to continuous operation when the circuit is off. Writing 0 unconditionally would silently discard a comfort, eco or auto schedule every time somebody switches mode.

Consequences that follow from the spec:

- **The entity owns the flow setpoint.** `ClimateEntityFeature.TARGET_TEMPERATURE` is enabled again, because 32600 has to be written on every transition.
- **Switching off writes 0**, which destroys the setpoint, so the entity remembers the last setpoint per mode and restores it when the circuit is switched back on. Separate values for heating and cooling, since a heating setpoint is far outside the cooling range. Survives a restart via `RestoreEntity`.
- **Cooling needs api version 22.090.** Register 32608 does not exist below it, so `HVACMode.COOL` is not offered and `heating_mode` is not written there.
- `HVACAction.COOLING` is reported for states 23 and 24.

## Condensation

Writing 32602 **disables the dew point monitoring of the Solarfocus controller** and moves that responsibility to Home Assistant. The README documents this with a warning, and the entity logs a warning the first time a circuit is switched to cooling.

The integration deliberately does not calculate the dew point itself — that would make it responsible for a building-safety calculation off a single room sensor. The circuit exposes `room_temperature` and `humidity` for automations to build on.

This is the concern the README already raised as the reason cooling was left out, so it is worth an explicit opinion during review.

## Tests

`tests/test_climate.py` is rewritten around the specification: one test per register state, one that asserts no register is left out on any transition, plus the preset deviation, the api version gate, setpoint memory, the dew point warning, and a restore that goes through the platform rather than calling `async_added_to_hass` directly.

The previous tests asserted the old partial writes and were replaced. 834 tests, coverage stays at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
