### PR TITLE
Store the coordinator on the config entry

### DIFF
--- a/custom_components/solarfocus/__init__.py
+++ b/custom_components/solarfocus/__init__.py
@@ -27,11 +27,9 @@ from .const import (
     CONF_PHOTOVOLTAIC,
     CONF_SOLAR,
     CONF_SOLARFOCUS_SYSTEM,
-    DATA_COORDINATOR,
-    DOMAIN,
     solar_count,
 )
-from .coordinator import SolarfocusDataUpdateCoordinator
+from .coordinator import SolarfocusConfigEntry, SolarfocusDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -47,11 +45,8 @@ PLATFORMS: list[Platform] = [
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -> bool:
     """Set up Solarfocus from a config entry."""
-    if hass.data.get(DOMAIN) is None:
-        hass.data.setdefault(DOMAIN, {})
-
     api = SolarfocusAPI(
         ip=entry.options[CONF_HOST],
         port=entry.options[CONF_PORT],
@@ -75,44 +70,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             f"{entry.options[CONF_HOST]}:{entry.options[CONF_PORT]}"
         ) from coordinator.last_exception
 
-    hass.data[DOMAIN][entry.entry_id] = {
-        DATA_COORDINATOR: coordinator,
-        # UPDATE_LISTENER: unsub_options_update_listener,
-    }
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # Registers update listener to update config entry when options are updated.
     entry.async_on_unload(entry.add_update_listener(async_update_options))
-    # unsub_options_update_listener = entry.add_update_listener(async_update_options)
-    # Store a reference to the unsubscribe function to cleanup if an entry is unloaded.
 
     return True
 
 
-async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def async_update_options(
+    hass: HomeAssistant, entry: SolarfocusConfigEntry
+) -> None:
     """Update options from user interface."""
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
+async def async_unload_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -> bool:
+    """Unload a config entry.
 
-    solarfocus_module = hass.data.get(DOMAIN)
-
-    if not solarfocus_module:
-        #  if not loaded directly return
-        return True
-
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    _LOGGER.info("Async_unload_entry is getting called! unload_ok: %s", unload_ok)
-
-    return unload_ok
+    The coordinator lives on the entry, so unloading the platforms is all there
+    is to clean up.
+    """
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def async_reload_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -> None:
     """Reload config entry."""
     await async_unload_entry(hass, entry)
     await async_setup_entry(hass, entry)

--- a/custom_components/solarfocus/binary_sensor.py
+++ b/custom_components/solarfocus/binary_sensor.py
@@ -10,7 +10,6 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -28,8 +27,6 @@ from .const import (
     CONF_HEATING_CIRCUIT,
     CONF_HEATPUMP,
     CONF_PHOTOVOLTAIC,
-    DATA_COORDINATOR,
-    DOMAIN,
     FRESH_WATER_MODULE_COMPONENT,
     FRESH_WATER_MODULE_COMPONENT_PREFIX,
     FRESH_WATER_MODULE_PREFIX,
@@ -43,6 +40,7 @@ from .const import (
     PHOTOVOLTAIC_COMPONENT_PREFIX,
     PHOTOVOLTAIC_PREFIX,
 )
+from .coordinator import SolarfocusConfigEntry
 from .entity import (
     SolarfocusEntity,
     SolarfocusEntityDescription,
@@ -55,11 +53,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: SolarfocusConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Solarfocus config entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
+    coordinator = config_entry.runtime_data
     entities = []
 
     for i in range(config_entry.options[CONF_HEATING_CIRCUIT]):

--- a/custom_components/solarfocus/button.py
+++ b/custom_components/solarfocus/button.py
@@ -4,19 +4,12 @@ from dataclasses import dataclass
 import logging
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import (
-    BOILER_COMPONENT,
-    BOILER_COMPONENT_PREFIX,
-    BOILER_PREFIX,
-    CONF_BOILER,
-    DATA_COORDINATOR,
-    DOMAIN,
-)
+from .const import BOILER_COMPONENT, BOILER_COMPONENT_PREFIX, BOILER_PREFIX, CONF_BOILER
+from .coordinator import SolarfocusConfigEntry
 from .entity import (
     SolarfocusEntity,
     SolarfocusEntityDescription,
@@ -29,11 +22,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: SolarfocusConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Solarfocus config entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
+    coordinator = config_entry.runtime_data
     entities = []
 
     for i in range(config_entry.options[CONF_BOILER]):

--- a/custom_components/solarfocus/climate.py
+++ b/custom_components/solarfocus/climate.py
@@ -14,7 +14,6 @@ from homeassistant.components.climate.const import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -23,12 +22,11 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     CONF_HEATING_CIRCUIT,
-    DATA_COORDINATOR,
-    DOMAIN,
     HEATING_CIRCUIT_COMPONENT,
     HEATING_CIRCUIT_COMPONENT_PREFIX,
     HEATING_CIRCUIT_PREFIX,
 )
+from .coordinator import SolarfocusConfigEntry
 from .entity import SolarfocusEntity, SolarfocusEntityDescription, create_description
 
 _LOGGER = logging.getLogger(__name__)
@@ -88,11 +86,11 @@ DEFAULT_TARGET_TEMPERATURE = {HVACMode.HEAT: 30.0, HVACMode.COOL: 19.0}
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: SolarfocusConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Solarfocus config entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
+    coordinator = config_entry.runtime_data
     entities = []
 
     for i in range(config_entry.options[CONF_HEATING_CIRCUIT]):

--- a/custom_components/solarfocus/const.py
+++ b/custom_components/solarfocus/const.py
@@ -8,8 +8,6 @@ from packaging import version
 from homeassistant.const import CONF_API_VERSION
 
 DOMAIN = "solarfocus"
-UPDATE_LISTENER = "update-listener"
-DATA_COORDINATOR = "data-coordinator"
 
 """Default values for configuration"""
 DEFAULT_HOST = "solarfocus"

--- a/custom_components/solarfocus/coordinator.py
+++ b/custom_components/solarfocus/coordinator.py
@@ -5,6 +5,7 @@ import logging
 
 from pysolarfocus import SolarfocusAPI
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -109,3 +110,8 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator):
             )
         else:
             _LOGGER.info("Reading all components of %s works again", self._address)
+
+
+# The coordinator of an entry lives on the entry itself, this spells that out
+# for the platforms reading it back.
+SolarfocusConfigEntry = ConfigEntry[SolarfocusDataUpdateCoordinator]

--- a/custom_components/solarfocus/number.py
+++ b/custom_components/solarfocus/number.py
@@ -9,7 +9,6 @@ from homeassistant.components.number import (
     NumberEntityDescription,
     NumberMode,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, UnitOfPower, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
@@ -23,8 +22,6 @@ from .const import (
     CONF_BOILER,
     CONF_HEATING_CIRCUIT,
     CONF_PHOTOVOLTAIC,
-    DATA_COORDINATOR,
-    DOMAIN,
     HEATING_CIRCUIT_COMPONENT,
     HEATING_CIRCUIT_COMPONENT_PREFIX,
     HEATING_CIRCUIT_PREFIX,
@@ -32,6 +29,7 @@ from .const import (
     PHOTOVOLTAIC_COMPONENT_PREFIX,
     PHOTOVOLTAIC_PREFIX,
 )
+from .coordinator import SolarfocusConfigEntry
 from .entity import (
     SolarfocusEntity,
     SolarfocusEntityDescription,
@@ -44,11 +42,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: SolarfocusConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Solarfocus config entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
+    coordinator = config_entry.runtime_data
     entities = []
 
     for i in range(config_entry.options[CONF_HEATING_CIRCUIT]):

--- a/custom_components/solarfocus/select.py
+++ b/custom_components/solarfocus/select.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 import logging
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -19,8 +18,6 @@ from .const import (
     CONF_BOILER,
     CONF_HEATING_CIRCUIT,
     CONF_HEATPUMP,
-    DATA_COORDINATOR,
-    DOMAIN,
     HEAT_PUMP_COMPONENT,
     HEAT_PUMP_COMPONENT_PREFIX,
     HEAT_PUMP_PREFIX,
@@ -28,6 +25,7 @@ from .const import (
     HEATING_CIRCUIT_COMPONENT_PREFIX,
     HEATING_CIRCUIT_PREFIX,
 )
+from .coordinator import SolarfocusConfigEntry
 from .entity import (
     SolarfocusEntity,
     SolarfocusEntityDescription,
@@ -40,11 +38,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: SolarfocusConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Solarfocus config entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
+    coordinator = config_entry.runtime_data
     entities = []
 
     for i in range(config_entry.options[CONF_HEATING_CIRCUIT]):

--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     REVOLUTIONS_PER_MINUTE,
@@ -42,8 +41,6 @@ from .const import (
     CONF_HEATPUMP,
     CONF_PHOTOVOLTAIC,
     CONF_SOLAR,
-    DATA_COORDINATOR,
-    DOMAIN,
     FRESH_WATER_MODULE_COMPONENT,
     FRESH_WATER_MODULE_COMPONENT_PREFIX,
     FRESH_WATER_MODULE_PREFIX,
@@ -61,7 +58,7 @@ from .const import (
     SOLAR_PREFIX,
     solar_count,
 )
-from .coordinator import SolarfocusDataUpdateCoordinator
+from .coordinator import SolarfocusConfigEntry, SolarfocusDataUpdateCoordinator
 from .entity import (
     SolarfocusEntity,
     SolarfocusEntityDescription,
@@ -73,10 +70,10 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
+    hass: HomeAssistant, config_entry: SolarfocusConfigEntry, async_add_entities
 ):
     """Initialize sensor platform from config entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
+    coordinator = config_entry.runtime_data
     entities = []
 
     _LOGGER.debug("Sensor async_setup_entry: %s", config_entry.data)

--- a/custom_components/solarfocus/switch.py
+++ b/custom_components/solarfocus/switch.py
@@ -8,19 +8,17 @@ from homeassistant.components.switch import (
     SwitchEntity,
     SwitchEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     CONF_HEATPUMP,
-    DATA_COORDINATOR,
-    DOMAIN,
     HEAT_PUMP_COMPONENT,
     HEAT_PUMP_COMPONENT_PREFIX,
     HEAT_PUMP_PREFIX,
 )
+from .coordinator import SolarfocusConfigEntry
 from .entity import (
     SolarfocusEntity,
     SolarfocusEntityDescription,
@@ -36,11 +34,11 @@ OFF = 0
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: SolarfocusConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Solarfocus config entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
+    coordinator = config_entry.runtime_data
     entities = []
 
     if config_entry.options[CONF_HEATPUMP]:

--- a/custom_components/solarfocus/water_heater.py
+++ b/custom_components/solarfocus/water_heater.py
@@ -8,7 +8,6 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntityDescription,
     WaterHeaterEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     PRECISION_TENTHS,
@@ -19,14 +18,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import (
-    BOILER_COMPONENT,
-    BOILER_COMPONENT_PREFIX,
-    BOILER_PREFIX,
-    CONF_BOILER,
-    DATA_COORDINATOR,
-    DOMAIN,
-)
+from .const import BOILER_COMPONENT, BOILER_COMPONENT_PREFIX, BOILER_PREFIX, CONF_BOILER
+from .coordinator import SolarfocusConfigEntry
 from .entity import SolarfocusEntity, SolarfocusEntityDescription, create_description
 
 _LOGGER = logging.getLogger(__name__)
@@ -61,11 +54,11 @@ SOLARFOCUS_TEMP_WATER_MAX = 80
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: SolarfocusConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Solarfocus config entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
+    coordinator = config_entry.runtime_data
     entities = []
 
     for i in range(config_entry.options[CONF_BOILER]):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,7 +17,6 @@ from custom_components.solarfocus.const import (
     CONF_PHOTOVOLTAIC,
     CONF_SOLAR,
     CONF_SOLARFOCUS_SYSTEM,
-    DATA_COORDINATOR,
     DEFAULT_NAME,
     DOMAIN,
 )
@@ -44,13 +43,12 @@ async def test_setup_and_unload_entry(
     await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.LOADED
-    assert DATA_COORDINATOR in hass.data[DOMAIN][config_entry.entry_id]
+    assert config_entry.runtime_data is not None
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.NOT_LOADED
-    assert config_entry.entry_id not in hass.data[DOMAIN]
 
 
 async def test_setup_passes_component_counts_to_the_library(
@@ -190,7 +188,7 @@ async def test_reload_entry(
     await async_reload_entry(hass, config_entry)
     await hass.async_block_till_done()
 
-    assert DATA_COORDINATOR in hass.data[DOMAIN][config_entry.entry_id]
+    assert config_entry.runtime_data is not None
 
 
 async def test_migration_from_version_1(hass: HomeAssistant) -> None:

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -22,8 +22,6 @@ from custom_components.solarfocus import (
 from custom_components.solarfocus.const import (
     BOILER_COMPONENT_PREFIX,
     BUFFER_COMPONENT_PREFIX,
-    DATA_COORDINATOR,
-    DOMAIN,
     HEATING_CIRCUIT_COMPONENT_PREFIX,
     SOLAR_COMPONENT_PREFIX,
 )
@@ -46,9 +44,7 @@ PLATFORMS = [
 async def _setup(hass: HomeAssistant, platform, entry) -> list:
     """Run a platform's async_setup_entry and return the created entities."""
     entry.add_to_hass(hass)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        DATA_COORDINATOR: build_coordinator(entry)
-    }
+    entry.runtime_data = build_coordinator(entry)
 
     added = []
     await platform.async_setup_entry(hass, entry, lambda entities: added.extend(entities))
@@ -300,7 +296,7 @@ async def test_entities_read_the_coordinator(hass: HomeAssistant) -> None:
     entry = build_config_entry(boiler=1)
     entry.add_to_hass(hass)
     coordinator = build_coordinator(entry)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {DATA_COORDINATOR: coordinator}
+    entry.runtime_data = coordinator
 
     added: list = []
     await water_heater.async_setup_entry(hass, entry, added.extend)


### PR DESCRIPTION
Closes the `runtime-data` item of the Bronze tier in #125.

The coordinator was kept in a hand-rolled `hass.data[DOMAIN][entry_id]` dictionary under a string key, with every platform reaching back through three levels of lookup to get it. `ConfigEntry.runtime_data` is what Home Assistant provides for exactly this, and it is typed:

```python
SolarfocusConfigEntry = ConfigEntry[SolarfocusDataUpdateCoordinator]
```

so `config_entry.runtime_data` in a platform is a coordinator rather than `Any`.

Unloading no longer has to clean the bucket up — Home Assistant drops the runtime data with the entry — which takes the `if not loaded directly return` guard and the leftover commented-out update-listener code with it.

`DATA_COORDINATOR` and `UPDATE_LISTENER` only existed as keys of that dictionary and are removed.

Mechanical change, no behaviour difference; coverage stays at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)