### PR TITLE
Document configuration, functionality, limits and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ The first step of the setup asks for:
 
 | Parameter | Default | Description |
 |---|---|---|
-| Name | `Solarfocus` | Name of the entry. It becomes part of the entity ids, so changing it later renames the entities. |
+| Name | `Solarfocus` | Name of the entry, and the name every entity of it is identified by. Pick a distinct one per system and do not change it afterwards, see [Known Limitations](#known-limitations). |
 | Host | `solarfocus` | Hostname or IP address of the eco<sup>manager-touch</sup>. |
 | Port | `502` | Modbus TCP port of the controller. |
 | Polling interval (s) | `10` | Seconds between two reads of the heating system. Values below 5 are rejected. |
@@ -237,7 +237,7 @@ immediately.
 | Buffer | 0 - 4 | Number of buffer cylinders (_Puffer_). |
 | Boiler | 0 - 4 | Number of boilers (_Boiler_). |
 | Fresh water module | 0 - 4 | Number of fresh water modules (_Frischwassermodule_), from version `23.020`. |
-| Solar | 0 - 4 | Number of solar circuits. More than one requires version `25.030`; below that the count is capped at 1. |
+| Solar | 0 - 4 | Number of solar circuits. More than one requires version `25.030`; below that only the first one is built, whatever the count says. |
 | Heat Pump | on / off | vampair systems only. |
 | Biomass boiler | on / off | Therminator and EcoTop systems only. |
 | Photovoltaic | on / off | Photovoltaic sensors and the `number` entities used to feed values back, see [Photovoltaic](#photovoltaic). |
@@ -306,7 +306,10 @@ _polling interval_ seconds (10 by default). Every entity of the entry is updated
 read, so raising the number of components does not raise the number of round trips per
 interval. The connection is opened once and re-established automatically if it drops.
 
-If a read fails, the entities of the entry become unavailable until the next successful poll.
+If the heating system cannot be read at all, the entities of the entry become unavailable until
+the next successful poll, and the failure is logged once rather than once per interval. If a
+single component cannot be read while the others can, only that one keeps its last value and
+the rest carry on; the log names it.
 
 Writes go the other way and take effect immediately: setting a target temperature, pressing a
 button or changing a select writes the register, re-reads the component it belongs to and
@@ -343,6 +346,10 @@ These are properties of the integration or the Modbus interface, not bugs:
   controller can read and write the same registers.
 - **The system type cannot be changed.** Switching between vampair, Therminator and EcoTop means
   deleting the entry and setting it up again.
+- **The name of an entry is part of the identity of its entities.** Renaming the config entry
+  after setup gives the entities new unique ids: the old ones are orphaned and a duplicate set
+  appears with a `_2` suffix. Rename the entities or the device instead, both of which are safe.
+  For the same reason two entries cannot share a name, and the setup rejects one that is taken.
 - **Register coverage follows the specification of the selected version.** Features the
   eco<sup>manager-touch</sup> only offers on its display, and registers added after `26.020`,
   are not available.
@@ -364,10 +371,17 @@ eco<sup>manager-touch</sup>. The controller accepts only a small number of conne
 time, so close other Modbus clients pointing at it.
 
 **All entities are unavailable.**
-The last poll failed. The log says why, once per outage rather than once per interval. Common
-causes are the controller being restarted, a DHCP address change (fix it in the options, see
-[Configuration Options](#configuration-options)) or another Modbus client holding the
-connection.
+The heating system could not be read at all on the last poll. The log says why, once per outage
+rather than once per interval. Common causes are the controller being restarted, a DHCP address
+change (fix it in the options, see [Configuration Options](#configuration-options)) or another
+Modbus client holding the connection.
+
+**One component is stuck on old values while the rest updates.**
+That component could not be read. The log names it, with a warning when it starts failing and
+another when it recovers. If it fails on every poll, the registers of that component are
+probably not answered by your software version - lower the API version under
+[Configuration Options](#configuration-options) or set the component to 0 if your installation
+does not have it.
 
 **Entities I expect are missing.**
 Either the component is set to 0 in the options, or the entity needs a newer API version than

--- a/README.md
+++ b/README.md
@@ -28,9 +28,17 @@
    - [HACS Installation](#hacs-installation)
    - [Manual Installation](#manual-installation)
    - [Integration Setup](#integration-setup)
-5. [Contribution](#contribution)
-6. [Localization](#localization)
-   
+   - [Installation Parameters](#installation-parameters)
+   - [Configuration Options](#configuration-options)
+   - [Removing the Integration](#removing-the-integration)
+5. [Supported Functionality](#supported-functionality)
+6. [How Data Is Updated](#how-data-is-updated)
+7. [Use Cases](#use-cases)
+8. [Known Limitations](#known-limitations)
+9. [Troubleshooting](#troubleshooting)
+10. [Contribution](#contribution)
+11. [Localization](#localization)
+
 </details>
 
 
@@ -45,16 +53,10 @@ The project uses the Python library [pysolarfocus](https://github.com/LavermanJJ
 
 ## Home Assistant Device Types
 
-There is currently support for the following device types within Home Assistant:
-
-- Sensors
-- Binary Sensors
-- Numbers
-- Buttons
-- Selects
-- Water Heater
-- Climate
-
+The integration provides `sensor`, `binary_sensor`, `number`, `button`, `select`, `switch`,
+`water_heater` and `climate` entities. [Supported Functionality](#supported-functionality)
+lists which of them each component gets; the sections below describe the ones that need more
+than a line.
 
 ### Climate
 
@@ -178,7 +180,10 @@ The eco<sup>manager-touch</sup> can integrate the following heating systems
 
 ### Prerequisites
 
-Home Assistant v2024.1.2 or above.
+- Home Assistant v2025.1.0 or above.
+- An eco<sup>manager-touch</sup> reachable over the network, with Modbus TCP enabled on its
+  display. The integration reads and writes registers over Modbus TCP; there is no cloud
+  account and no authentication involved.
 
 ### HACS Installation
 
@@ -195,6 +200,204 @@ You can find it in the default HACS repo. Just search `Solarfocus`.
 ### Integration Setup
 
 [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=solarfocus) 
+
+Setup runs in two steps: first the connection details, then the components your installation
+has. The connection is tested before the second step is shown, so a wrong address is reported
+right away.
+
+### Installation Parameters
+
+The first step of the setup asks for:
+
+| Parameter | Default | Description |
+|---|---|---|
+| Name | `Solarfocus` | Name of the entry. It becomes part of the entity ids, so changing it later renames the entities. |
+| Host | `solarfocus` | Hostname or IP address of the eco<sup>manager-touch</sup>. |
+| Port | `502` | Modbus TCP port of the controller. |
+| Polling interval (s) | `10` | Seconds between two reads of the heating system. Values below 5 are rejected. |
+| Solarfocus System | `Heat pump vampair` | `vampair`, `Therminator II` or `EcoTop`. This decides which components the second step offers and which entities exist, and it is the one setting that cannot be changed afterwards. |
+| Solarfocus API Version | `23.020` | Software version of your eco<sup>manager-touch</sup>, see [Software](#software). Entities that need a newer version than the one selected are not created. |
+
+The second step asks which components your installation has. Everything here can be changed
+later, see below.
+
+### Configuration Options
+
+All of the following can be changed at any time via **Settings → Devices & Services →
+Solarfocus → Configure**. Saving reloads the integration, so entities appear or disappear
+immediately.
+
+| Option | Range | Description |
+|---|---|---|
+| Host | | Address of the controller, e.g. after a DHCP change. |
+| Port | | Modbus TCP port. |
+| Polling interval (s) | ≥ 5 | Seconds between two reads. |
+| Solarfocus API Version | `21.140` - `26.020` | Raise this after a software update of the heating system to get the entities that version added. |
+| Heating Circuit | 0 - 8 | Number of heating circuits (_Heizkreise_) to read. |
+| Buffer | 0 - 4 | Number of buffer cylinders (_Puffer_). |
+| Boiler | 0 - 4 | Number of boilers (_Boiler_). |
+| Fresh water module | 0 - 4 | Number of fresh water modules (_Frischwassermodule_), from version `23.020`. |
+| Solar | 0 - 4 | Number of solar circuits. More than one requires version `25.030`; below that the count is capped at 1. |
+| Heat Pump | on / off | vampair systems only. |
+| Biomass boiler | on / off | Therminator and EcoTop systems only. |
+| Photovoltaic | on / off | Photovoltaic sensors and the `number` entities used to feed values back, see [Photovoltaic](#photovoltaic). |
+
+Setting a count to 0 (or a switch to off) stops that component from being polled and removes
+its entities.
+
+### Removing the Integration
+
+Go to **Settings → Devices & Services → Solarfocus**, open the three-dot menu of the entry
+and choose **Delete**. This removes the config entry, the device and all of its entities, and
+stops the polling. Nothing is left behind on the heating system - the integration only reads
+registers and writes the ones you changed from Home Assistant.
+
+If the integration was installed manually rather than through HACS, also delete the
+`custom_components/solarfocus/` directory from your Home Assistant configuration folder and
+restart. Through HACS, remove it from the HACS integrations list instead.
+
+Values that were written to the heating system (for example a target temperature, or the
+photovoltaic registers) stay at the value last written. Set them back on the display of the
+eco<sup>manager-touch</sup> if you do not want to keep them.
+
+## Supported Functionality
+
+The integration creates a single device per config entry, with the entities of every
+configured component. Multi-instance components are numbered (`Heating circuit 2 ...`).
+
+| Platform | Component | Entities |
+|---|---|---|
+| `sensor` | Heating circuit | Supply and room temperature, humidity, mixer valve, state |
+| `sensor` | Buffer | Top and bottom temperature, state, mode, external sensors X35 / X36 / X44 |
+| `sensor` | Boiler | Temperature, state, mode, single charge, circulation |
+| `sensor` | Heat pump | Outdoor, supply and return temperature, flow rate, compressor speed, electrical and thermal energy and power, COP and overall performance, state |
+| `sensor` | Biomass boiler | Temperature, status, message number, cleaning, ash container, outdoor temperature, operating mode, log wood, pellet usage, heat energy |
+| `sensor` | Solar | Collector, supply, return and buffer temperatures, flow, current power, yields, state |
+| `sensor` | Photovoltaic | Power, house consumption, heat pump consumption, grid import and export |
+| `sensor` | Fresh water module | State, supply and target temperature, flow rate |
+| `binary_sensor` | Heating circuit | Limit thermostat, circulator pump |
+| `binary_sensor` | Buffer | Pump |
+| `binary_sensor` | Heat pump | EVU lock active, defrost active, boiler charge |
+| `binary_sensor` | Biomass boiler | Door contact |
+| `binary_sensor` | Photovoltaic | Overcharge possible, overcharge active |
+| `binary_sensor` | Fresh water module | Valve |
+| `climate` | Heating circuit | One thermostat per circuit, see [Climate](#climate) |
+| `water_heater` | Boiler | Domestic hot water |
+| `number` | Heating circuit | Target supply and room temperature, external room temperature and humidity |
+| `number` | Boiler | Target temperature |
+| `number` | Photovoltaic | Smart meter, photovoltaic, grid import/export, HEMS target power, see [Photovoltaic](#photovoltaic) |
+| `select` | Heating circuit | Mode, heating mode, cooling |
+| `select` | Boiler | Holding mode |
+| `select` | Heat pump | Smart grid |
+| `switch` | Heat pump | EVU lock |
+| `button` | Boiler | Single charge, circulation |
+
+Some noisier or less commonly used entities are created disabled; enable them on the device
+page if you need them. Which entities exist also depends on the configured API version and on
+the system - a Therminator has no heat pump sensors, and entities added in a later software
+version only appear once that version is selected.
+
+## How Data Is Updated
+
+The integration polls; the eco<sup>manager-touch</sup> does not push anything.
+
+A single coordinator reads all configured components over one Modbus TCP connection, every
+_polling interval_ seconds (10 by default). Every entity of the entry is updated from that one
+read, so raising the number of components does not raise the number of round trips per
+interval. The connection is opened once and re-established automatically if it drops.
+
+If a read fails, the entities of the entry become unavailable until the next successful poll.
+
+Writes go the other way and take effect immediately: setting a target temperature, pressing a
+button or changing a select writes the register, re-reads the component it belongs to and
+updates the entity right away, rather than waiting for the next interval.
+
+## Use Cases
+
+- **Feed your own meter readings back.** The heating system optimizes its running times around
+  self-produced electricity if you push the values of your PV inverter and smart meter into it,
+  see [Photovoltaic](#photovoltaic).
+- **Room control without a Solarfocus room sensor.** Send the temperature of any Home Assistant
+  sensor to a heating circuit, see [External room sensors](#external-room-sensors).
+- **Cheap-tariff or surplus heating.** Use the `EVU lock` switch or the `Smart grid` select of
+  the heat pump to block or request operation, driven by a dynamic electricity price or by PV
+  surplus.
+- **Hot water on demand.** Trigger the `Single charge` button of a boiler from an automation
+  instead of keeping a schedule on the display.
+- **Monitoring and statistics.** The heat pump energy sensors are `total_increasing`, so they
+  can be added to the Energy dashboard, and the biomass boiler exposes pellet usage, ash
+  container and cleaning levels for maintenance reminders.
+- **Alerting.** `Message number` of the biomass boiler and the state sensors carry the
+  translated fault texts of the controller and can be used for notifications.
+
+## Known Limitations
+
+These are properties of the integration or the Modbus interface, not bugs:
+
+- **Polling only.** Changes made on the display of the heating system show up in Home Assistant
+  after the next poll, not immediately.
+- **No discovery.** The eco<sup>manager-touch</sup> announces itself over no protocol Home
+  Assistant can pick up, so the address has to be entered by hand. Give the controller a fixed
+  address or a DNS name.
+- **No authentication.** Modbus TCP has none. Anyone with access to the network segment of the
+  controller can read and write the same registers.
+- **The system type cannot be changed.** Switching between vampair, Therminator and EcoTop means
+  deleting the entry and setting it up again.
+- **Register coverage follows the specification of the selected version.** Features the
+  eco<sup>manager-touch</sup> only offers on its display, and registers added after `26.020`,
+  are not available.
+- **Entity names are English.** Entity states, the config flow and the fault texts are
+  translated (English and German), the entity names themselves are not.
+- **Writes can be ignored by the controller.** The photovoltaic registers only take effect once
+  the display is configured for it, see [Photovoltaic](#photovoltaic), and the heating system
+  keeps enforcing its own limits (for example the outdoor shutdown temperature) regardless of
+  what is written.
+- **Cooling turns off the dew point monitoring of the controller.** See the warning under
+  [Cooling](#cooling).
+
+## Troubleshooting
+
+**Setup fails with "Failed to connect".**
+Check that the address and port are right and reachable from the Home Assistant host
+(`nc -z <host> 502`), and that Modbus TCP is enabled on the display of the
+eco<sup>manager-touch</sup>. The controller accepts only a small number of connections at a
+time, so close other Modbus clients pointing at it.
+
+**All entities are unavailable.**
+The last poll failed. The log says why, once per outage rather than once per interval. Common
+causes are the controller being restarted, a DHCP address change (fix it in the options, see
+[Configuration Options](#configuration-options)) or another Modbus client holding the
+connection.
+
+**Entities I expect are missing.**
+Either the component is set to 0 in the options, or the entity needs a newer API version than
+the one configured, or it does not exist for your system. Check the version selected under
+[Configuration Options](#configuration-options) against the version shown on your display, and
+note that some entities are created disabled and have to be enabled on the device page.
+
+**More than one solar circuit does not show up.**
+Multiple solar circuits require API version `25.030` or newer. Below that the count is capped
+at one.
+
+**Values written from Home Assistant have no effect.**
+For the photovoltaic registers, set the source to `Modbus` on the display, see
+[Photovoltaic](#photovoltaic). For heating parameters, check that the heating system is not
+overruling the value with a limit configured on the display.
+
+**Getting a debug log.**
+Add the following to `configuration.yaml` and restart, or use **Enable debug logging** on the
+integration page:
+
+```yaml
+logger:
+  default: info
+  logs:
+    custom_components.solarfocus: debug
+    pysolarfocus: debug
+```
+
+The debug log contains the registers being read and written, which is what an issue report
+needs.
 
 ## Contribution
 


### PR DESCRIPTION
Closes eight documentation items from #125 in one pass, since they are all the same file:

`docs-removal-instructions` (Bronze) · `docs-configuration-parameters`, `docs-installation-parameters` (Silver) · `docs-data-update`, `docs-known-limitations`, `docs-supported-functions`, `docs-troubleshooting`, `docs-use-cases` (Gold).

The README explained the parts of the integration that are surprising — the climate entity, the photovoltaic registers, the external room sensors — but never the ordinary ones: what the setup asks for, what can be changed afterwards, which entities exist, how often they update, or what to do when nothing works.

New sections:

- **Installation Parameters** / **Configuration Options** — tables with the defaults and ranges the config flow actually enforces (min scan interval 5s, 0–8 heating circuits, 0–4 for the rest, solar > 1 needs `25.030`, and that the system type is the one thing that cannot be changed later).
- **Removing the Integration** — including the HACS vs. manual difference, and that values written to the controller stay where they were left.
- **Supported Functionality** — the entities every component gets, per platform.
- **How Data Is Updated** — one coordinator, one connection, one read per interval for all entities, and writes taking effect immediately instead of at the next interval.
- **Use Cases**, **Known Limitations**, **Troubleshooting** — the last one with the `logger:` snippet for a debug log.

Two fixes along the way: the prerequisites still said Home Assistant `v2024.1.2` while `hacs.json` requires `2025.1.0`, and the bare list of platform names under "Home Assistant Device Types" now points at the new entity table instead of duplicating it.

One note on ordering: "If a read fails, the entities of the entry become unavailable until the next successful poll" is true today for a connection that drops, and true for every failure once #186 lands. Merging that one first makes the sentence exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)