### PR TITLE
Build the components the options actually ask for

### DIFF
--- a/custom_components/solarfocus/__init__.py
+++ b/custom_components/solarfocus/__init__.py
@@ -29,6 +29,7 @@ from .const import (
     CONF_SOLARFOCUS_SYSTEM,
     DATA_COORDINATOR,
     DOMAIN,
+    solar_count,
 )
 from .coordinator import SolarfocusDataUpdateCoordinator
 
@@ -57,9 +58,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         heating_circuit_count=entry.options[CONF_HEATING_CIRCUIT],
         buffer_count=entry.options[CONF_BUFFER],
         boiler_count=entry.options[CONF_BOILER],
-        solar_count=entry.options.get(CONF_SOLAR, 0)
-        if isinstance(entry.options.get(CONF_SOLAR), int)
-        else (1 if entry.options.get(CONF_SOLAR) else 0),
+        fresh_water_module_count=entry.options[CONF_FRESH_WATER_MODULE],
+        solar_count=solar_count(entry.options),
         system=Systems(entry.data[CONF_SOLARFOCUS_SYSTEM]),
         api_version=ApiVersions(entry.options[CONF_API_VERSION]),
     )

--- a/custom_components/solarfocus/const.py
+++ b/custom_components/solarfocus/const.py
@@ -1,5 +1,12 @@
 """Constants for the Solarfocus integration."""
 
+from collections.abc import Mapping
+from typing import Any
+
+from packaging import version
+
+from homeassistant.const import CONF_API_VERSION
+
 DOMAIN = "solarfocus"
 UPDATE_LISTENER = "update-listener"
 DATA_COORDINATOR = "data-coordinator"
@@ -9,6 +16,7 @@ DEFAULT_HOST = "solarfocus"
 DEFAULT_PORT = 502
 DEFAULT_NAME = "Solarfocus"
 DEFAULT_SCAN_INTERVAL = 10
+DEFAULT_API_VERSION = "21.140"
 
 """Configuration and options"""
 CONF_SOLARFOCUS_SYSTEM = "system"
@@ -53,3 +61,25 @@ SOLAR_COMPONENT_PREFIX = "so"
 FRESH_WATER_MODULE_PREFIX = "Fresh water module"
 FRESH_WATER_MODULE_COMPONENT = "fresh_water_modules"
 FRESH_WATER_MODULE_COMPONENT_PREFIX = "fm"
+
+"""Version from which several solar circuits exist"""
+MULTI_SOLAR_MIN_VERSION = "25.030"
+
+
+def solar_count(options: Mapping[str, Any]) -> int:
+    """Return how many solar circuits to build for these options.
+
+    Solar was a boolean before it became a count, and several circuits only
+    exist from api version 25.030 on - pysolarfocus rejects a higher count
+    below that and the whole entry fails to load. The options let the count be
+    raised regardless of the selected version, so it is capped here.
+    """
+    raw = options.get(CONF_SOLAR, 0)
+    count = (1 if raw else 0) if isinstance(raw, bool) else int(raw or 0)
+
+    if version.parse(
+        options.get(CONF_API_VERSION, DEFAULT_API_VERSION)
+    ) < version.parse(MULTI_SOLAR_MIN_VERSION):
+        return min(count, 1)
+
+    return count

--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -3,7 +3,6 @@
 from dataclasses import dataclass
 import logging
 
-from packaging import version
 from pysolarfocus import Systems
 
 from homeassistant.components.sensor import (
@@ -14,7 +13,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONF_API_VERSION,
     PERCENTAGE,
     REVOLUTIONS_PER_MINUTE,
     UnitOfEnergy,
@@ -61,6 +59,7 @@ from .const import (
     SOLAR_COMPONENT,
     SOLAR_COMPONENT_PREFIX,
     SOLAR_PREFIX,
+    solar_count,
 )
 from .coordinator import SolarfocusDataUpdateCoordinator
 from .entity import (
@@ -162,22 +161,10 @@ async def async_setup_entry(
             entities.append(entity)
 
     if config_entry.options[CONF_SOLAR]:
-        # Handle multiple solar instances for API versions >= 25.030
-        solar_count = config_entry.options[CONF_SOLAR]
-        if isinstance(solar_count, bool):
-            # Backwards compatibility: if it's a boolean, treat True as 1 instance
-            solar_count = 1 if solar_count else 0
+        # The same count the library was built with, see `solar_count`
+        count = solar_count(config_entry.options)
 
-        # For API versions < 25.030, limit to maximum 1 solar instance
-        api_version = version.parse(
-            config_entry.options.get(CONF_API_VERSION, "21.140")
-        )
-        supports_multiple = api_version >= version.parse("25.030")
-
-        if not supports_multiple and solar_count > 1:
-            solar_count = 1
-
-        for i in range(solar_count):
+        for i in range(count):
             for description in SOLAR_SENSOR_TYPES:
                 # Always use index since solar is now always a list in pysolarfocus
                 # But for single instance, don't show the number in the entity name
@@ -191,7 +178,7 @@ async def async_setup_entry(
                 )
 
                 # For single solar instance, remove the number from the name for backward compatibility
-                if solar_count == 1:
+                if count == 1:
                     # Remove the number from the entity name but keep the index for API access
                     _description.name = _description.name.replace(" 1 ", " ")
                     # Also update the key to not include the "1" for single instance

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -59,9 +59,11 @@ async def test_setup_passes_component_counts_to_the_library(
     """The configured component counts are handed to pysolarfocus."""
     entry = build_config_entry(
         Systems.THERMINATOR,
+        api_version=ApiVersions.V_25_030.value,
         heating_circuit=3,
         buffer=2,
         boiler=1,
+        fresh_water_module=2,
         solar=2,
         biomassboiler=True,
     )
@@ -74,9 +76,12 @@ async def test_setup_passes_component_counts_to_the_library(
     assert kwargs["heating_circuit_count"] == 3
     assert kwargs["buffer_count"] == 2
     assert kwargs["boiler_count"] == 1
+    # Was never passed, so the library built its default of one module and
+    # every entity of a second one raised IndexError on read.
+    assert kwargs["fresh_water_module_count"] == 2
     assert kwargs["solar_count"] == 2
     assert kwargs["system"] is Systems.THERMINATOR
-    assert kwargs["api_version"] is ApiVersions.V_23_020
+    assert kwargs["api_version"] is ApiVersions.V_25_030
 
 
 @pytest.mark.parametrize(
@@ -90,13 +95,42 @@ async def test_setup_accepts_legacy_boolean_solar_option(
     expected_count: int,
 ) -> None:
     """Entries written before solar became a count still set up."""
-    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, solar=stored_solar)
+    entry = build_config_entry(
+        Systems.VAMPAIR,
+        api_version=ApiVersions.V_25_030.value,
+        heating_circuit=1,
+        solar=stored_solar,
+    )
     entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
     assert mock_api.call_args.kwargs["solar_count"] == expected_count
+
+
+@pytest.mark.parametrize("stored_solar", [2, 4])
+async def test_setup_caps_solar_below_the_version_that_supports_several(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, stored_solar: int
+) -> None:
+    """The options allow a count the selected api version cannot have.
+
+    pysolarfocus rejects more than one solar circuit below 25.030 by raising
+    InvalidConfigurationError, which failed the whole entry rather than just
+    the extra circuits.
+    """
+    entry = build_config_entry(
+        Systems.VAMPAIR,
+        api_version=ApiVersions.V_23_020.value,
+        heating_circuit=1,
+        solar=stored_solar,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_api.call_args.kwargs["solar_count"] == 1
 
 
 async def test_setup_retries_when_the_device_is_unreachable(


### PR DESCRIPTION
Two bugs found while reviewing the documentation in #188 — both are cases where a config option did not reach `pysolarfocus` intact. Neither is caused by the quality-scale branches; both exist on `main`.

### `fresh_water_module_count` was never passed

`async_setup_entry` passes `heating_circuit_count`, `buffer_count`, `boiler_count` and `solar_count`, but not the fresh water module count, so the library always built its default of exactly one module. Configuring two or more created the entities, and each one raised `IndexError` the first time it read its value, because `api.fresh_water_modules` has a single element.

### `solar_count` could fail the whole entry

The count was passed straight through, but the library rejects more than one solar circuit below api version `25.030`:

```
InvalidConfigurationError: Solar Legacy count must be between 0 and 1
```

The options offer 0–4 regardless of the selected version, so picking two on an older version did not merely fail to create the extra circuits — `SolarfocusAPI(...)` raises inside `async_setup_entry` and the entry does not load at all.

`sensor.py` already capped the count for the entities it creates. That cap moved into `solar_count()` in `const.py` and is now applied to the library call too, so the entities and the components they read from are built from the same number.

Verified against pysolarfocus 5.2.2:

```
helper caps to: 1
raw count 3 @23.020 -> InvalidConfigurationError Solar Legacy count must be between 0 and 1
capped: ok, solar circuits = 1 fwm = 2
```

Two existing tests asserted the old behaviour (`solar_count == 2` on api `23.020`, and `4 → 4`); they were only passing because `SolarfocusAPI` is mocked and never validated. They now use `25.030` where a real multi-circuit setup is valid, and a new parametrized test covers the cap. Coverage stays at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)