### PR TITLE
Translate the operating mode of the biomass boiler

### DIFF
--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -89,7 +89,7 @@
           "2": "Time trigger"
         }
       },
-      "bb_mode" : {
+      "bb_boiler_operating_mode" : {
         "state" : {
           "0": "Log wood",
           "1": "Log wood automatic",

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -88,7 +88,7 @@
           "2": "Zeitschaltung"
         }
       },
-      "bb_mode" : {
+      "bb_boiler_operating_mode" : {
         "state" : {
           "0": "Stückholz",
           "1": "Stückholz Automatik",

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -89,7 +89,7 @@
           "2": "Time trigger"
         }
       },
-      "bb_mode" : {
+      "bb_boiler_operating_mode" : {
         "state" : {
           "0": "Log wood",
           "1": "Log wood automatic",

--- a/tests/test_sensor_enum_options.py
+++ b/tests/test_sensor_enum_options.py
@@ -89,6 +89,24 @@ def test_translated_states_are_valid_options(
     )
 
 
+@pytest.mark.parametrize(
+    "filename", ["strings.json", "translations/en.json", "translations/de.json"]
+)
+@pytest.mark.parametrize(("translation_key", "options"), CASES)
+def test_every_enum_sensor_has_translated_states(
+    filename: str, translation_key: str, options: list[int]
+) -> None:
+    """An enum sensor is a list of names, and without them it is a list of numbers.
+
+    The test above skips an entity that has no states at all, which is how
+    `bb_boiler_operating_mode` went untranslated: `strings.json` held its states
+    under `bb_mode`, a key of no entity.
+    """
+    entity = _translations(filename).get(translation_key)
+
+    assert entity and "state" in entity
+
+
 def test_cases_cover_the_known_enum_sensors() -> None:
     """Guard the parametrization against silently matching nothing."""
     keys = {case.values[0] for case in CASES}

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -14,11 +14,35 @@ fit a custom component: numeric state keys are allowed, sloppy values are not.
 import json
 import pathlib
 
+from pysolarfocus import ApiVersions, Systems
 import pytest
 
-from custom_components.solarfocus import sensor
+from custom_components.solarfocus import (
+    binary_sensor,
+    button,
+    climate,
+    number,
+    select,
+    sensor,
+    switch,
+    water_heater,
+)
+from homeassistant.core import HomeAssistant
+
+from .conftest import build_config_entry, build_coordinator
 
 COMPONENT_DIR = pathlib.Path(sensor.__file__).parent
+
+PLATFORMS = {
+    "binary_sensor": binary_sensor,
+    "button": button,
+    "climate": climate,
+    "number": number,
+    "select": select,
+    "sensor": sensor,
+    "switch": switch,
+    "water_heater": water_heater,
+}
 
 FILENAMES = ["strings.json", "translations/en.json", "translations/de.json"]
 
@@ -102,6 +126,54 @@ def test_english_translations_match_the_strings_file() -> None:
     english = dict(_strings(_load("translations/en.json").get("entity", {})))
 
     assert english == strings
+
+
+async def _translation_keys(hass: HomeAssistant) -> dict[str, set[str]]:
+    """Return the translation keys of every entity, per domain."""
+    keys: dict[str, set[str]] = {}
+    for domain, module in PLATFORMS.items():
+        created = []
+        for system in Systems:
+            entry = build_config_entry(
+                system,
+                api_version=ApiVersions.V_26_020.value,
+                heating_circuit=1,
+                buffer=1,
+                boiler=1,
+                fresh_water_module=1,
+                solar=1,
+                heatpump=True,
+                biomassboiler=True,
+                photovoltaic=True,
+            )
+            entry.add_to_hass(hass)
+            entry.runtime_data = build_coordinator(entry)
+
+            await module.async_setup_entry(hass, entry, created.extend)
+
+        keys[domain] = {e.entity_description.translation_key for e in created}
+
+    return keys
+
+
+async def test_every_translated_entity_exists(hass: HomeAssistant) -> None:
+    """A key no entity uses translates nothing.
+
+    Home Assistant looks the states up under the translation key of the entity,
+    so a key that belongs to no entity leaves that entity showing the raw value
+    of the register - which is what `bb_mode` did to the operating mode of the
+    biomass boiler, whose key is `bb_boiler_operating_mode`.
+    """
+    entities = await _translation_keys(hass)
+
+    unused = [
+        (domain, key)
+        for domain, keys in _load("strings.json")["entity"].items()
+        for key in keys
+        if key not in entities.get(domain, set())
+    ]
+
+    assert not unused
 
 
 def test_the_locked_state_is_still_translated() -> None:


### PR DESCRIPTION
Found while writing the state icons in #191, independent of both icon PRs and mergeable on its own.

## The bug

The states of `bb_boiler_operating_mode` have never been translated. The translations exist - all six, in all three files - but under the key `bb_mode`, which is the translation key of **no entity**. The sensor is built from `key="boiler_operating_mode"`, so `create_description` gives it `bb_boiler_operating_mode`.

Home Assistant looks the states up under the key of the entity, finds nothing, and falls back to the raw register value. A Therminator or Octoplus user reads `0` … `5` where it should say "Log wood" … "Wood chips" (`Stückholz` … `Hackgut` in German). That has been true since the states were added in #76.

## The fix

Rename the key in `strings.json`, `translations/en.json` and `translations/de.json`. Nothing else changes: the entity keeps its unique id and its entity id, only the lookup changes, so an existing entity starts resolving its states after a restart.

## Why it went unnoticed for so long

`test_translated_states_are_valid_options` skips an entity that has no states:

```python
if entity is None or "state" not in entity:
    pytest.skip(f"{translation_key} has no states in {filename}")
```

`bb_boiler_operating_mode` has no states, so all three of its cases were skipped, every run, for exactly the reason the test existed. `pytest -rs` on `main` shows them:

```
SKIPPED [1] tests/test_sensor_enum_options.py:80: bb_boiler_operating_mode has no states in strings.json
SKIPPED [1] tests/test_sensor_enum_options.py:80: bb_boiler_operating_mode has no states in translations/en.json
SKIPPED [1] tests/test_sensor_enum_options.py:80: bb_boiler_operating_mode has no states in translations/de.json
```

Those three skips are gone after this change - the suite has no skips left.

## Tests

Two, and both fail on the key as it was:

- **`test_every_translated_entity_exists`** reads the direction the file was missing. Every other test there asks "is this translation sound"; this one asks "does any entity use it", by building every entity of every platform for every system and comparing the keys.
- **`test_every_enum_sensor_has_translated_states`** closes the hole above: an enum sensor without translated states is a list of numbers, which is always a bug.

The skip in the older test is left in place as a guard, but it can no longer hide anything while the new test passes.

The helper that builds every entity is close to the one in #191's `tests/test_icons.py`. I kept them separate so this can merge independently of the icon PRs; happy to lift it into `conftest.py` once both have landed.

Part of #125 (`entity-translations`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)