### PR TITLE
Label the boiler release mode the way the register is documented

### DIFF
--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -603,8 +603,8 @@
       },
       "bo_holding_mode" : {
         "state" : {
-          "0": "Always on",
-          "1": "Always off",
+          "0": "Always off",
+          "1": "Always on",
           "2": "Monday \u2013 Sunday",
           "3": "Blockwise (Monday \u2013 Friday, Saturday \u2013 Sunday)",
           "4": "Daywise"

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -76,9 +76,9 @@
         "state" : {
           "0": "Immer Aus",
           "1": "Immer Ein",
-          "2": "Montag \u2013 Sontag",
-          "3": "Blockweise (Montag \u2013 Freitag, Samstag \u2013 Sontag)",
-          "4": "Tageweise"
+          "2": "Montag \u2013 Sonntag",
+          "3": "Blockweise (Montag \u2013 Freitag, Samstag \u2013 Sonntag)",
+          "4": "Tagweise"
         }
       },
       "bu_mode" : {
@@ -607,9 +607,9 @@
         "state" : {
           "0": "Immer Aus",
           "1": "Immer Ein",
-          "2": "Montag \u2013 Sontag",
-          "3": "Blockweise (Montag \u2013 Freitag, Samstag \u2013 Sontag)",
-          "4": "Tageweise"
+          "2": "Montag \u2013 Sonntag",
+          "3": "Blockweise (Montag \u2013 Freitag, Samstag \u2013 Sonntag)",
+          "4": "Tagweise"
         }
       }
     },

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -603,8 +603,8 @@
       },
       "bo_holding_mode" : {
         "state" : {
-          "0": "Always on",
-          "1": "Always off",
+          "0": "Always off",
+          "1": "Always on",
           "2": "Monday \u2013 Sunday",
           "3": "Blockwise (Monday \u2013 Friday, Saturday \u2013 Sunday)",
           "4": "Daywise"

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -104,6 +104,30 @@ def test_english_translations_match_the_strings_file() -> None:
     assert english == strings
 
 
+def _comparable(text: str) -> str:
+    """Return a state text without the differences that are only spelling."""
+    return text.lower().replace("–", "-").replace(" ", "")
+
+
+@pytest.mark.parametrize("filename", FILENAMES)
+def test_the_two_boiler_release_modes_agree(filename: str) -> None:
+    """The boiler reports and takes the release mode as the same enumeration.
+
+    Register 502 ("Boiler Freigabeart - Ist", the `bo_mode` sensor) and register
+    32002 ("Boiler - Freigabeart", the `bo_holding_mode` select) are documented
+    with one list of values: 0 is "Immer Aus", 1 is "Immer Ein". The English
+    select had the two the wrong way round, so picking "Always on" wrote a 0 and
+    switched the boiler off.
+    """
+    entity = _load(filename)["entity"]
+    reported = entity["sensor"]["bo_mode"]["state"]
+    settable = entity["select"]["bo_holding_mode"]["state"]
+
+    assert {state: _comparable(text) for state, text in settable.items()} == {
+        state: _comparable(text) for state, text in reported.items()
+    }
+
+
 def test_the_locked_state_is_still_translated() -> None:
     """The state hassfest rejects has to keep working, that is the whole point."""
     for filename in FILENAMES:


### PR DESCRIPTION
Found by checking the open icon PRs against the [ecomanager-touch Modbus TCP register documentation](https://www.solarfocus.com/partnerbereich/ecomanager-touch_modbus-tcp_registerdaten_anleitung1.pdf). Independent of #190, #191 and #192.

## The bug

`select.bo_holding_mode` labels **0 as "Always on" and 1 as "Always off"**. The register documentation says the opposite:

> **32002 Boiler – Freigabeart** — `0…Immer Aus`, `1…Immer Ein`, `2…Montag – Sonntag`, `3…Blockweise (Montag – Freitag, Samstag – Sonntag)`, `4…Tagweise`

The select writes the raw value of the chosen option (`async_select_option` → `_set_native_value`), so this is not a display problem:

**picking "Always on" writes 0, which switches the boiler release off.**

The `bo_mode` sensor then reports "Always Off" for the mode the user just set to "on", from register 502 (`Boiler Freigabeart – Ist`), which the documentation gives as the same enumeration and which this integration already translates correctly.

Only English is affected. `translations/de.json` has had `0…Immer Aus` / `1…Immer Ein` right all along, for both entities.

## The fix

Swap the two labels in `strings.json` and `translations/en.json`. Values 2, 3 and 4 were already correct.

## Test

`test_the_two_boiler_release_modes_agree` asserts the sensor and the select translate the same value to the same meaning, in every language file, ignoring differences that are only spelling (`Always Off` vs `Always off`, `-` vs `–`). It fails on both English files as they were.

That invariant holds because the two registers are documented as one enumeration - it is not a coincidence worth preserving by hand.

## Also in here

`translations/de.json` spelled "Sonntag" as `Sontag` and "Tagweise" as `Tageweise`, in both the sensor and the select. Corrected in a second commit - text a user reads, no key and no value changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
