### PR TITLE
Report the state of an enum sensor as a whole number

### DIFF
--- a/custom_components/solarfocus/button.py
+++ b/custom_components/solarfocus/button.py
@@ -25,6 +25,11 @@ _LOGGER = logging.getLogger(__name__)
 # reads the coordinator does, which is why writes re-read their component.
 PARALLEL_UPDATES = 1
 
+# The value that triggers the action. The register is a number, and it is read
+# back as one by the sensor of the same name, so write it as one: a bool would
+# survive in the component until the next successful read.
+PRESSED = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -74,7 +79,7 @@ class SolarfocusButtonEntity(SolarfocusEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Update the current value."""
         button = self.entity_description.item
-        return self._set_native_value(button, True)
+        return self._set_native_value(button, PRESSED)
 
 
 BOILER_BUTTON_TYPES = [

--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -244,8 +244,12 @@ class SolarfocusSensor(SolarfocusEntity, SensorEntity):
 
         if self.device_class is SensorDeviceClass.ENUM and value is not None:
             # The state of an enum sensor has to be one of its options, and those
-            # are the strings of the values the heating system reports.
-            return str(value)
+            # are the strings of the values the heating system reports. Going
+            # through int() first keeps a register that holds a bool or a float
+            # off the failing path: str(True) is "True" and str(3.0) is "3.0",
+            # neither of which is an option, and core rejects the whole entity
+            # for it.
+            return str(int(value))
 
         return value
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -374,7 +374,12 @@ def test_switch_reports_its_state() -> None:
 
 @pytest.mark.parametrize("description", BOILER_BUTTON_TYPES, ids=lambda d: d.key)
 async def test_button_triggers_its_item(description) -> None:
-    """Pressing a button writes True to the register it names."""
+    """Pressing a button writes 1 to the register it names.
+
+    A number, not a bool: the sensor of the same name reads the register back and
+    turns it into a state, and "True" is not one of the states it accepts. Since
+    `True == 1`, the type is what the assertion is about.
+    """
     entity = _make(
         SolarfocusButtonEntity,
         description,
@@ -386,7 +391,8 @@ async def test_button_triggers_its_item(description) -> None:
     with patch.object(entity, "_set_native_value") as set_value:
         await entity.async_press()
 
-    assert set_value.call_args_list == [((description.key, True),)]
+    assert set_value.call_args_list == [((description.key, 1),)]
+    assert not isinstance(set_value.call_args.args[1], bool)
 
 
 # --- water heater -----------------------------------------------------------

--- a/tests/test_sensor_enum_options.py
+++ b/tests/test_sensor_enum_options.py
@@ -147,6 +147,29 @@ async def test_the_state_of_an_enum_sensor_is_one_of_its_options(
     assert state.state in state.attributes["options"]
 
 
+async def test_an_enum_sensor_survives_a_register_holding_a_bool(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """A bool left in a register must not cost the entity its state.
+
+    `single_charge` is a button as well as a sensor, and a press writes to the
+    register the sensor reads. If the re-read right after the write fails, which
+    the coordinator tolerates on purpose, whatever was written stays in the
+    component until the next poll: str(True) is "True", not an option.
+    """
+    api.boilers[0].single_charge.scaled_value = True
+    entry = build_config_entry(boiler=1)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.solarfocus_boiler_1_single_charge")
+
+    assert state.state == "1"
+    assert state.state in state.attributes["options"]
+
+
 def test_cases_cover_the_known_enum_sensors() -> None:
     """Guard the parametrization against silently matching nothing."""
     keys = {case.values[0] for case in CASES}


### PR DESCRIPTION
`native_value` turned the value of an enum sensor into its state with `str(value)`, which is right for the int every enum register holds and wrong for anything else.

`bo_single_charge` is a button as well as a sensor, and `async_press` wrote `True` into the register the sensor reads. The re-read right after a write is allowed to fail — the coordinator reports it as a partial failure and keeps the entry available — and the bool then stays in the component until the next successful poll. `str(True)` is `"True"`, which is not one of `["-1", "0", "1"]`, so core raises

```
ValueError: Sensor sensor.solarfocus_boiler_1_single_charge provides state
            value 'True', which is not in the list of options provided
```

and the entity is dropped rather than shown with an odd state. That is what it did before #195, `True in [-1, 0, 1]` being true.

Both ends are fixed:

- The button writes `PRESSED = 1`, the way the switch writes `ON = 1`, because the register is a number and is read back as one.
- `native_value` goes through `int()` first, which covers the other value that cannot be a state: a float, should an enum register ever gain a multiplier, `str(3.0)` being `"3.0"`.

## Tests

`test_an_enum_sensor_survives_a_register_holding_a_bool` puts a `True` in the register, sets the integration up and asserts the state is one of the options. Without the `int()` it fails with the error above and no entity at all.

`test_button_triggers_its_item` gains an `isinstance` check, because `True == 1` and the equality assertion it had passes either way.

958 passed.

Found reviewing #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)