### PR TITLE
Set the version to 5.1.0-rc1

### DIFF
--- a/custom_components/solarfocus/manifest.json
+++ b/custom_components/solarfocus/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/lavermanjj/home-assistant-solarfocus/issues",
   "requirements": ["pysolarfocus==5.2.2"],
   "ssdp": [],
-  "version": "5.0.0",
+  "version": "5.1.0-rc1",
   "zeroconf": []
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "solarfocus"
-version = "5.0.0"
+version = "5.1.0rc1"
 description = "Custom component for integrating Solarfocus heating systems into Home Assistant."
 authors = [{ name = "Jeroen Laverman", email = "jjlaverman@web.de" }]
 requires-python = ">=3.14.2,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -2292,7 +2292,7 @@ wheels = [
 
 [[package]]
 name = "solarfocus"
-version = "5.0.0"
+version = "5.1.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
The manifest still said `5.0.0`, the release it was cut for, so a user installing the `5.1.0-rc1` pre-release would see 5.0.0 in Home Assistant. That is the mismatch #182 corrected for the last release train, where the manifest had drifted to `6.1.0` while every release was a `5.0.0-rc`.

- **`manifest.json`** → `5.1.0-rc1`. This is what Home Assistant shows and what HACS compares against the tag.
- **`pyproject.toml`** → `5.1.0rc1`, the same version in the spelling PEP 440 normalises it to. The two have agreed since 5.0.0 and there is no reason for the repository to carry two answers.
- **`uv.lock`** records the version of the project itself and CI runs `uv sync --locked`, so it is relocked here — one line, no dependency moves.

The config entry migration version in `config_flow.py` is unrelated and stays at 7.

Needed before the [`5.1.0-rc1` draft release](https://github.com/LavermanJJ/home-assistant-solarfocus/releases) is published; that draft targets `main`, so it picks this up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)