### PR TITLE
Give the numeric sensors an icon that moves with the value

### DIFF
--- a/custom_components/solarfocus/icons.json
+++ b/custom_components/solarfocus/icons.json
@@ -351,7 +351,13 @@
         }
       },
       "hp_compressor_speed": {
-        "default": "mdi:gauge"
+        "default": "mdi:gauge",
+        "range": {
+          "0": "mdi:gauge-empty",
+          "1": "mdi:gauge-low",
+          "1500": "mdi:gauge",
+          "3000": "mdi:gauge-full"
+        }
       },
       "hp_cop_cooling": {
         "default": "mdi:poll"

--- a/custom_components/solarfocus/icons.json
+++ b/custom_components/solarfocus/icons.json
@@ -86,7 +86,11 @@
     },
     "sensor": {
       "bb_ash_container": {
-        "default": "mdi:trash-can-outline"
+        "default": "mdi:trash-can-outline",
+        "range": {
+          "0": "mdi:trash-can-outline",
+          "50": "mdi:trash-can"
+        }
       },
       "bb_boiler_operating_mode": {
         "default": "mdi:format-list-bulleted"
@@ -276,7 +280,12 @@
         }
       },
       "hc_mixer_valve": {
-        "default": "mdi:valve"
+        "default": "mdi:valve",
+        "range": {
+          "0": "mdi:valve-closed",
+          "1": "mdi:valve",
+          "100": "mdi:valve-open"
+        }
       },
       "hc_room_temperature": {
         "default": "mdi:home-thermometer-outline"

--- a/custom_components/solarfocus/icons.json
+++ b/custom_components/solarfocus/icons.json
@@ -267,7 +267,13 @@
         "default": "mdi:thermometer-high"
       },
       "fm_flow_rate": {
-        "default": "mdi:speedometer"
+        "default": "mdi:speedometer",
+        "range": {
+          "0": "mdi:water-off",
+          "1": "mdi:speedometer-slow",
+          "5": "mdi:speedometer-medium",
+          "10": "mdi:speedometer"
+        }
       },
       "fm_state": {
         "default": "mdi:faucet",

--- a/custom_components/solarfocus/icons.json
+++ b/custom_components/solarfocus/icons.json
@@ -387,7 +387,13 @@
         "default": "mdi:lightning-bolt"
       },
       "hp_flow_rate": {
-        "default": "mdi:speedometer"
+        "default": "mdi:speedometer",
+        "range": {
+          "0": "mdi:water-off",
+          "1": "mdi:speedometer-slow",
+          "900": "mdi:speedometer-medium",
+          "1800": "mdi:speedometer"
+        }
       },
       "hp_performance_overall": {
         "default": "mdi:poll"

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -204,9 +204,10 @@ def test_range_keys_are_numbers() -> None:
 def test_a_range_starts_at_the_bottom_of_the_scale() -> None:
     """Below the lowest step there is nothing to find but the default icon.
 
-    Every entity with a range reports a percentage, so the scale starts at 0. A
-    range that starts higher leaves its own first band showing the default and
-    the step is dead, which is invisible in the file itself.
+    Every entity with a range counts up from nothing - a percentage, or a
+    compressor that is not turning - so the scale starts at 0. A range that
+    starts higher leaves its own first band showing the default and the step is
+    dead, which is invisible in the file itself.
     """
     starting_late = [
         path for path, steps in _icon_ranges() if min(float(key) for key in steps) > 0

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -13,6 +13,7 @@ None of it shows up in a test of the platforms, only in the frontend, which is
 what these tests are for.
 """
 
+import itertools
 import json
 import pathlib
 import re
@@ -73,12 +74,25 @@ def _icon_sections():
     yield from _sections(_icons())
 
 
+def _icon_ranges():
+    """Yield every ((domain, key, attribute), range) of the icon translations.
+
+    A `range` is what a numeric entity has where an enum has a `state`: the icon
+    shown is the one of the highest key the value does not fall below.
+    """
+    for path, section in _icon_sections():
+        if "range" in section:
+            yield path, section["range"]
+
+
 def _translated_icons():
     """Yield every (domain, translation key, icon) of the icon translations."""
     for (domain, key, _), section in _icon_sections():
         if "default" in section:
             yield domain, key, section["default"]
         for icon in section.get("state", {}).values():
+            yield domain, key, icon
+        for icon in section.get("range", {}).values():
             yield domain, key, icon
 
 
@@ -166,6 +180,54 @@ def test_no_state_icon_repeats_the_default() -> None:
         for path, section in _icon_sections()
         for state, icon in section.get("state", {}).items()
         if icon == section.get("default")
+    ]
+
+    assert not repeated
+
+
+def test_range_keys_are_numbers() -> None:
+    """A range is looked up by value, so a key that is not one matches nothing.
+
+    The rule for translation keys does not apply here: these are not keys of a
+    translation, they are the bottom of a band of the scale.
+    """
+    invalid = [
+        (*path, key)
+        for path, steps in _icon_ranges()
+        for key in steps
+        if not re.fullmatch(r"-?\d+(\.\d+)?", key)
+    ]
+
+    assert not invalid
+
+
+def test_a_range_starts_at_the_bottom_of_the_scale() -> None:
+    """Below the lowest step there is nothing to find but the default icon.
+
+    Every entity with a range reports a percentage, so the scale starts at 0. A
+    range that starts higher leaves its own first band showing the default and
+    the step is dead, which is invisible in the file itself.
+    """
+    starting_late = [
+        path for path, steps in _icon_ranges() if min(float(key) for key in steps) > 0
+    ]
+
+    assert not starting_late
+
+
+def test_no_range_icon_repeats_the_step_below_it() -> None:
+    """Two steps showing one icon is a step that changes nothing.
+
+    Unlike a state, the lowest step is allowed to repeat the default: naming it
+    is what keeps the step above it from swallowing the bottom of the scale.
+    """
+    repeated = [
+        (*path, key)
+        for path, steps in _icon_ranges()
+        for (_, below), (key, icon) in itertools.pairwise(
+            sorted(steps.items(), key=lambda step: float(step[0]))
+        )
+        if icon == below
     ]
 
     assert not repeated


### PR DESCRIPTION
Icon translations key an icon on the `state` of an entity, which is a name, and on a `range`, which is a number: the icon shown is the one of the highest key the value does not fall below. These sensors had a single icon each and so said the same thing at the bottom of their scale as at the top.

```json
"hc_mixer_valve": {
  "default": "mdi:valve",
  "range": { "0": "mdi:valve-closed", "1": "mdi:valve", "100": "mdi:valve-open" }
},
"hp_compressor_speed": {
  "default": "mdi:gauge",
  "range": { "0": "mdi:gauge-empty", "1": "mdi:gauge-low", "1500": "mdi:gauge", "3000": "mdi:gauge-full" }
},
"hp_flow_rate": {
  "default": "mdi:speedometer",
  "range": { "0": "mdi:water-off", "1": "mdi:speedometer-slow", "900": "mdi:speedometer-medium", "1800": "mdi:speedometer" }
},
"fm_flow_rate": {
  "default": "mdi:speedometer",
  "range": { "0": "mdi:water-off", "1": "mdi:speedometer-slow", "5": "mdi:speedometer-medium", "10": "mdi:speedometer" }
},
"bb_ash_container": {
  "default": "mdi:trash-can-outline",
  "range": { "0": "mdi:trash-can-outline", "50": "mdi:trash-can" }
}
```

They apply to every instance of their component — heating circuits 1-4, fresh water modules 1-4 — since icon translations key on the translation key rather than on the entity.

**`hc_mixer_valve`** gets the three icons the frontend already ships for a valve — closed at 0, `mdi:valve` while it is somewhere in between, open at 100. The middle step is not redundant with the default: without it a half open valve falls back to the 0 step and reads as closed.

**`hp_compressor_speed`** reads 0 to 4000 rpm and had one gauge for all of it, so an idle heat pump looked like one running flat out. The step at 1 separates off from slow, which is the distinction worth seeing on a dashboard.

**`hp_flow_rate` and `fm_flow_rate`** are the same measurement on two circuits and now read alike, with the thresholds on their own scales: thirds of 2600 l/h for the heat pump, thirds of 15 l/min for the fresh water module. Both sit at 0 whenever nothing is being drawn or pumped, which is most of the time.

Both give 0 `mdi:water-off` rather than a fourth dial: the speedometer has no empty face, and "nothing is flowing" is the state these entities are in almost all the time. It is the one place here where an icon leaves its family, on the same grounds as the smart grid state taking the lock of the evu lock in #191 — what it means beats what it matches.

**`bb_ash_container`** counts up towards a service, so it goes from `mdi:trash-can-outline` to a filled `mdi:trash-can` at 50.

**`bb_cleaning`** keeps `mdi:broom`. There is no graded broom in Material Design Icons, and a shape picked for the sake of having three of them says less than the number next to it.

### The thresholds are judgements

Only the mixer valve has a documented scale. The compressor maximum (register 2303, a bare UINT), the two flow rate ceilings and where the ash container stops looking empty are all what the hardware reports or what reads well, not what any specification states. Each is a one-line change.

Every icon used here is one Home Assistant itself ships in a component `icons.json`, which is the only check there is that a name resolves — hassfest does not verify that an icon exists, and neither can a test here. That ruled out an "ash container full" alert step: no `-alert` variant of either can family appears anywhere in core.

## Tests

`tests/test_icons.py` only ever read `state`, so a range would have gone in with no check on the prefix of its icons, on whether its keys are numbers, or on whether any of its steps do anything. It now covers ranges too:

- `test_range_keys_are_numbers` — a range is looked up by value, so a key that is not one matches nothing
- `test_a_range_starts_at_the_bottom_of_the_scale` — below the lowest step there is nothing but the default, so a range starting above 0 has a dead first band
- `test_no_range_icon_repeats_the_step_below_it` — the range equivalent of a state icon repeating the default, with the lowest step exempt
- `test_icons_use_the_material_design_prefix` and `test_every_icon_belongs_to_an_entity` now see range icons as well

Each fails on the defect it describes; I checked all four by mutating the file. 961 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)