### PR TITLE
Set the version to 5.1.0-rc2

### DIFF
--- a/custom_components/solarfocus/manifest.json
+++ b/custom_components/solarfocus/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/lavermanjj/home-assistant-solarfocus/issues",
   "requirements": ["pysolarfocus==5.2.2"],
   "ssdp": [],
-  "version": "5.1.0-rc1",
+  "version": "5.1.0-rc2",
   "zeroconf": []
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "solarfocus"
-version = "5.1.0rc1"
+version = "5.1.0rc2"
 description = "Custom component for integrating Solarfocus heating systems into Home Assistant."
 authors = [{ name = "Jeroen Laverman", email = "jjlaverman@web.de" }]
 requires-python = ">=3.14.2,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -2292,7 +2292,7 @@ wheels = [
 
 [[package]]
 name = "solarfocus"
-version = "5.1.0rc1"
+version = "5.1.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
`5.1.0-rc1` was cut at #197 and the icon ranges in #198 landed after it, so the next pre-release needs a version of its own.

Same three files as last time: `manifest.json` is what Home Assistant shows, `pyproject.toml` has agreed with it since 5.0.0, and `uv.lock` records the version of the project itself — CI checks that with `uv sync --locked`.

Needed before the [`5.1.0-rc2` draft release](https://github.com/LavermanJJ/home-assistant-solarfocus/releases) is published; that draft targets `main`, so it picks this up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)