### PR TITLE
Let an entry say how it is configured and what it last read

### DIFF
--- a/custom_components/solarfocus/coordinator.py
+++ b/custom_components/solarfocus/coordinator.py
@@ -55,6 +55,11 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
     @property
+    def failed_components(self) -> set[str]:
+        """Return the components that could not be read on the last refresh."""
+        return set(self._failed_components)
+
+    @property
     def _address(self) -> str:
         """Return the address of the heating system, for log messages."""
         return f"{self._entry.options[CONF_HOST]}:{self._entry.options[CONF_PORT]}"

--- a/custom_components/solarfocus/coordinator.py
+++ b/custom_components/solarfocus/coordinator.py
@@ -85,6 +85,11 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator):
             # Nothing could be read: the system is gone rather than one of its
             # components being unhappy. Reporting that as a success would leave
             # every entity available and showing its last value.
+            #
+            # No component is failing on its own any more, so whatever was doing
+            # that is forgotten here rather than left behind to be reported as
+            # still true. The outage itself is what the failed refresh says.
+            self._failed_components = set()
             raise UpdateFailed(
                 f"Failed to read {', '.join(failed)} from {self._address}"
             )

--- a/custom_components/solarfocus/diagnostics.py
+++ b/custom_components/solarfocus/diagnostics.py
@@ -1,0 +1,98 @@
+"""Diagnostics for the Solarfocus integration.
+
+What a report about this integration needs is the two things a log line does not
+carry: how the entry is configured, and what the heating system last answered
+with. Almost every issue so far has been a register reading something other than
+what the specification says, on a firmware and a component layout that have to be
+asked for one message at a time.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pysolarfocus.components.base.part import Part
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    BIOMASS_BOILER_COMPONENT,
+    BOILER_COMPONENT,
+    BUFFER_COMPONENT,
+    FRESH_WATER_MODULE_COMPONENT,
+    HEAT_PUMP_COMPONENT,
+    HEATING_CIRCUIT_COMPONENT,
+    PHOTOVOLTAIC_COMPONENT,
+    SOLAR_COMPONENT,
+)
+from .coordinator import SolarfocusConfigEntry
+
+# The components pysolarfocus builds, in the order the coordinator reads them.
+COMPONENTS: tuple[str, ...] = (
+    HEATING_CIRCUIT_COMPONENT,
+    BUFFER_COMPONENT,
+    BOILER_COMPONENT,
+    HEAT_PUMP_COMPONENT,
+    PHOTOVOLTAIC_COMPONENT,
+    BIOMASS_BOILER_COMPONENT,
+    SOLAR_COMPONENT,
+    FRESH_WATER_MODULE_COMPONENT,
+)
+
+# The address of the controller is on the user's own network and says little on
+# its own, but a diagnostics download is something people paste into an issue.
+TO_REDACT = {CONF_HOST}
+
+
+def _registers(component: Any) -> dict[str, Any]:
+    """Return every register of one component, the way the entities read it.
+
+    `Part` is what pysolarfocus gives a component for each of its registers, and
+    for the two values it calculates rather than reads, so this is exactly the
+    set of values an entity of that component can show.
+    """
+    return {
+        name: part.scaled_value
+        for name, part in vars(component).items()
+        if isinstance(part, Part)
+    }
+
+
+def _component_registers(component: Any) -> Any:
+    """Return the registers of a component, or of each of them if it is a list.
+
+    A heating circuit, buffer, boiler, solar circuit and fresh water module can
+    exist several times over; the heat pump, photovoltaic and biomass boiler are
+    either there once or not at all.
+    """
+    if isinstance(component, list):
+        return [_registers(one) for one in component]
+
+    return None if component is None else _registers(component)
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: SolarfocusConfigEntry
+) -> dict[str, Any]:
+    """Return what the entry is configured as and what it last read."""
+    coordinator = entry.runtime_data
+
+    return {
+        "entry": {
+            "version": entry.version,
+            "data": async_redact_data(entry.data, TO_REDACT),
+            "options": async_redact_data(entry.options, TO_REDACT),
+        },
+        "coordinator": {
+            "last_update_success": coordinator.last_update_success,
+            # Empty unless a component fails on its own while the others read
+            # fine, which is what an unsupported register range looks like.
+            "failed_components": sorted(coordinator.failed_components),
+        },
+        "components": {
+            name: _component_registers(getattr(coordinator.api, name, None))
+            for name in COMPONENTS
+        },
+    }

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,172 @@
+"""What a diagnostics download says about an entry.
+
+The point of the file is that a user can attach one to an issue, so the two
+things worth testing are that everything needed to reproduce their setup is in
+it, and that the address of their controller is not.
+"""
+
+import json
+
+from pysolarfocus import ApiVersions
+from pysolarfocus.components.boiler import Boiler
+from pysolarfocus.components.heat_pump import HeatPump
+from pysolarfocus.components.heating_circuit import HeatingCircuit
+from pytest_homeassistant_custom_component.components.diagnostics import (
+    get_diagnostics_for_config_entry,
+)
+
+from custom_components.solarfocus.diagnostics import async_get_config_entry_diagnostics
+from homeassistant.components.diagnostics import REDACTED
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.json import ExtendedJSONEncoder
+from homeassistant.setup import async_setup_component
+
+from .conftest import build_config_entry
+
+
+async def _diagnostics(hass: HomeAssistant, api, **options) -> dict:
+    """Set an entry up and return its diagnostics."""
+    api.heating_circuits = [HeatingCircuit()]
+    api.boilers = [Boiler()]
+    api.heatpump = HeatPump(api_version=ApiVersions.V_23_020)
+
+    entry = build_config_entry(**options)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    return await async_get_config_entry_diagnostics(hass, entry)
+
+
+async def test_diagnostics_hide_the_address_of_the_controller(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """The host is the one thing in the options a user should not have to strip."""
+    diagnostics = await _diagnostics(hass, api, heating_circuit=1)
+
+    assert diagnostics["entry"]["options"][CONF_HOST] == REDACTED
+    # The port says nothing on its own and tells a non-standard setup apart
+    assert diagnostics["entry"]["options"][CONF_PORT] == 502
+    assert "solarfocus.local" not in str(diagnostics)
+
+
+async def test_home_assistant_serves_the_download(
+    hass: HomeAssistant,
+    hass_client,
+    enable_custom_integrations,
+    mock_api,
+    api,
+) -> None:
+    """Only a module named `diagnostics.py` next to the platforms is found at all.
+
+    Going through the http api is what tells a working download apart from a
+    working function: nothing declares the platform, Home Assistant looks for
+    the module by name.
+    """
+    api.heating_circuits = [HeatingCircuit()]
+
+    entry = build_config_entry(heating_circuit=1)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(hass, "diagnostics", {})
+
+    diagnostics = await get_diagnostics_for_config_entry(hass, hass_client, entry)
+
+    assert diagnostics["entry"]["options"][CONF_HOST] == REDACTED
+    assert diagnostics["components"]["heating_circuits"][0]["supply_temperature"] == 0
+
+
+async def test_diagnostics_survive_being_written_out(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """Home Assistant serves the download as JSON, so it has to encode.
+
+    Nothing in a register is exotic, but the system of an entry is an enum and
+    the values come out of a library, which is where this would break.
+    """
+    diagnostics = await _diagnostics(hass, api, heating_circuit=1, heatpump=True)
+
+    assert json.loads(json.dumps(diagnostics, cls=ExtendedJSONEncoder))
+
+
+async def test_diagnostics_describe_how_the_entry_is_configured(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """The component counts and the api version are what a report has to state."""
+    diagnostics = await _diagnostics(hass, api, heating_circuit=2, boiler=1)
+
+    entry = diagnostics["entry"]
+
+    assert entry["version"] == 7
+    assert entry["options"]["heating_circuit"] == 2
+    assert entry["options"]["api_version"] == ApiVersions.V_23_020.value
+    assert entry["data"]["system"] is not None
+
+
+async def test_diagnostics_report_the_registers_of_every_component(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """A value the heating system reports is the point of the whole download.
+
+    The components that can exist several times over are a list even when only
+    one is configured, so that the index in an entity name lines up with it.
+    """
+    diagnostics = await _diagnostics(hass, api, heating_circuit=1, heatpump=True)
+
+    components = diagnostics["components"]
+
+    assert components["heating_circuits"][0]["supply_temperature"] == 0
+    assert "mixer_valve" in components["heating_circuits"][0]
+    assert components["heatpump"]["compressor_speed"] == 0
+    # A calculated value is not a register but is read like one, and it is the
+    # first thing asked about when a COP looks wrong
+    assert "cop_heating" in components["heatpump"]
+
+
+async def test_diagnostics_leave_out_a_component_that_is_not_configured(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """A component the user does not have has no registers to report."""
+    api.biomassboiler = None
+    api.photovoltaic = None
+
+    diagnostics = await _diagnostics(hass, api, heating_circuit=1)
+
+    assert diagnostics["components"]["biomassboiler"] is None
+    assert diagnostics["components"]["photovoltaic"] is None
+
+
+async def test_diagnostics_name_the_components_that_could_not_be_read(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """Which component is failing is what a partial failure comes down to.
+
+    It is only in the log otherwise, once, so a download taken later would not
+    show it at all.
+    """
+    api.heating_circuits = [HeatingCircuit()]
+    api.boilers = [Boiler()]
+
+    entry = build_config_entry(heating_circuit=1, boiler=1)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diagnostics["coordinator"]["last_update_success"] is True
+    assert diagnostics["coordinator"]["failed_components"] == []
+
+    api.update_boiler.return_value = False
+    await entry.runtime_data.async_refresh()
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diagnostics["coordinator"]["last_update_success"] is True
+    assert diagnostics["coordinator"]["failed_components"] == ["boiler"]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -170,3 +170,37 @@ async def test_diagnostics_name_the_components_that_could_not_be_read(
 
     assert diagnostics["coordinator"]["last_update_success"] is True
     assert diagnostics["coordinator"]["failed_components"] == ["boiler"]
+
+
+async def test_diagnostics_do_not_blame_one_component_for_a_whole_outage(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """A component named here is one that fails while the others read fine.
+
+    When the heating system stops answering altogether the refresh fails, and
+    that is what the download says. Naming the component that happened to be
+    failing before would point a report at the wrong thing.
+    """
+    api.heating_circuits = [HeatingCircuit()]
+    api.boilers = [Boiler()]
+
+    entry = build_config_entry(heating_circuit=1, boiler=1)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    api.update_boiler.return_value = False
+    await entry.runtime_data.async_refresh()
+
+    assert (await async_get_config_entry_diagnostics(hass, entry))["coordinator"][
+        "failed_components"
+    ] == ["boiler"]
+
+    api.update_heating.return_value = False
+    await entry.runtime_data.async_refresh()
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diagnostics["coordinator"]["last_update_success"] is False
+    assert diagnostics["coordinator"]["failed_components"] == []


### PR DESCRIPTION
Gold `diagnostics`, from #125.

An issue about this integration turns on two things a log line does not carry: how the entry is configured, and what the heating system answered with. Both have to be asked for one message at a time, and almost every issue so far has come down to a register reporting something other than the specification says — on a firmware and a component layout nobody could see.

`diagnostics.py` puts them in a file the user can attach:

- the entry, its version and its options
- whether the last refresh worked, and which components failed on their own
- every register of every component that exists, read the way the entities read it

`Part` is what `pysolarfocus` gives a component for each of its registers and for the two values it calculates rather than reads, so the dump is exactly the set of values an entity of that component could show.

**The host is redacted.** It says little on its own — it is an address on the user's own network — but a download is something people paste into an issue. The port is left alone, since it is what tells a non-standard setup apart.

The coordinator gains a `failed_components` property. The set was private and only ever reached the log, once, so a download taken later than the failure would not have shown the thing most worth reporting.

## Tests

Seven, and two of them are about the plumbing rather than the content:

- `test_home_assistant_serves_the_download` goes through the http api, which is what tells a working download apart from a working function — nothing declares this platform, Home Assistant finds it by the name of the module
- `test_diagnostics_survive_being_written_out` encodes the result, the failure that would otherwise only show as a 500

The redaction test fails if `TO_REDACT` is emptied; I checked. 968 passed, coverage stays at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)