### PR TITLE
Let the errors a user sees be translated

### DIFF
--- a/custom_components/solarfocus/__init__.py
+++ b/custom_components/solarfocus/__init__.py
@@ -69,12 +69,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -
     if not coordinator.last_update_success:
         # Reading every configured component once tells us whether the entry can
         # be set up at all; Home Assistant retries the setup afterwards.
+        #
+        # The two ways that fails are worth telling apart, because they send the
+        # user to different places: nothing at the address to talk to at all, or
+        # a controller that answered the connection and then none of the
+        # registers. Whether the library is still connected is what says which.
+        address = f"{entry.options[CONF_HOST]}:{entry.options[CONF_PORT]}"
+        if not api.is_connected:
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+                translation_placeholders={"address": address},
+            ) from coordinator.last_exception
+
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="cannot_set_up",
-            translation_placeholders={
-                "address": f"{entry.options[CONF_HOST]}:{entry.options[CONF_PORT]}"
-            },
+            translation_placeholders={"address": address},
         ) from coordinator.last_exception
 
     entry.runtime_data = coordinator

--- a/custom_components/solarfocus/__init__.py
+++ b/custom_components/solarfocus/__init__.py
@@ -70,8 +70,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -
         # Reading every configured component once tells us whether the entry can
         # be set up at all; Home Assistant retries the setup afterwards.
         raise ConfigEntryNotReady(
-            f"Cannot read from the Solarfocus system at "
-            f"{entry.options[CONF_HOST]}:{entry.options[CONF_PORT]}"
+            translation_domain=DOMAIN,
+            translation_key="cannot_set_up",
+            translation_placeholders={
+                "address": f"{entry.options[CONF_HOST]}:{entry.options[CONF_PORT]}"
+            },
         ) from coordinator.last_exception
 
     entry.runtime_data = coordinator

--- a/custom_components/solarfocus/coordinator.py
+++ b/custom_components/solarfocus/coordinator.py
@@ -65,7 +65,11 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator):
         if not self.api.is_connected and not await self.hass.async_add_executor_job(
             self.api.connect
         ):
-            raise UpdateFailed(f"Cannot connect to {self._address}")
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+                translation_placeholders={"address": self._address},
+            )
 
         configured = 0
         failed = []
@@ -81,7 +85,12 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator):
             # components being unhappy. Reporting that as a success would leave
             # every entity available and showing its last value.
             raise UpdateFailed(
-                f"Failed to read {', '.join(failed)} from {self._address}"
+                translation_domain=DOMAIN,
+                translation_key="cannot_read",
+                translation_placeholders={
+                    "address": self._address,
+                    "components": ", ".join(failed),
+                },
             )
 
         self._report_partial_failure(failed)

--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -62,6 +62,17 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "Cannot connect to the Solarfocus system at {address}."
+    },
+    "cannot_read": {
+      "message": "Cannot read {components} from the Solarfocus system at {address}. No configured component answered, so the system is treated as unreachable."
+    },
+    "cannot_set_up": {
+      "message": "Cannot read from the Solarfocus system at {address}. It accepted the connection but did not answer the registers."
+    }
+  },
   "entity": {
     "sensor": {
       "fm_state" : {

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -61,6 +61,17 @@
       }
     }
   },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "Keine Verbindung zur Solarfocus-Anlage unter {address}."
+    },
+    "cannot_read": {
+      "message": "{components} kann nicht von der Solarfocus-Anlage unter {address} gelesen werden. Keine der konfigurierten Komponenten hat geantwortet, die Anlage gilt daher als nicht erreichbar."
+    },
+    "cannot_set_up": {
+      "message": "Von der Solarfocus-Anlage unter {address} kann nicht gelesen werden. Sie nimmt die Verbindung an, antwortet aber nicht auf die Register."
+    }
+  },
   "entity": {
     "sensor": {
       "fm_state" : {

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -62,6 +62,17 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "Cannot connect to the Solarfocus system at {address}."
+    },
+    "cannot_read": {
+      "message": "Cannot read {components} from the Solarfocus system at {address}. No configured component answered, so the system is treated as unreachable."
+    },
+    "cannot_set_up": {
+      "message": "Cannot read from the Solarfocus system at {address}. It accepted the connection but did not answer the registers."
+    }
+  },
   "entity": {
     "sensor": {
       "fm_state" : {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -149,9 +149,11 @@ async def test_unreachable_device_fails_the_update(hass: HomeAssistant) -> None:
     api.is_connected = False
     coordinator = _coordinator(hass, api, heating_circuit=1)
 
-    with pytest.raises(UpdateFailed, match="solarfocus.local:502"):
+    with pytest.raises(UpdateFailed) as failure:
         await coordinator._async_update_data()
 
+    assert failure.value.translation_key == "cannot_connect"
+    assert failure.value.translation_placeholders == {"address": "solarfocus.local:502"}
     assert not api.update_heating.called
 
 
@@ -167,8 +169,14 @@ async def test_all_reads_failing_fails_the_refresh(hass: HomeAssistant) -> None:
     api.update_buffer.return_value = False
     coordinator = _coordinator(hass, api, heating_circuit=1, buffer=1)
 
-    with pytest.raises(UpdateFailed, match=CONF_HEATING_CIRCUIT):
+    with pytest.raises(UpdateFailed) as failure:
         await coordinator._async_update_data()
+
+    assert failure.value.translation_key == "cannot_read"
+    assert failure.value.translation_placeholders == {
+        "address": "solarfocus.local:502",
+        "components": f"{CONF_HEATING_CIRCUIT}, {CONF_BUFFER}",
+    }
 
 
 async def test_one_failing_component_keeps_the_others_working(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -146,6 +146,41 @@ async def test_setup_retries_when_the_device_is_unreachable(
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
+async def test_a_refused_connection_says_so(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api, config_entry
+) -> None:
+    """Nothing to talk to at the address is the common half of a failed setup.
+
+    Telling that user their controller answered and then went quiet sends them
+    looking at the heating system for a problem that is in the network.
+    """
+    api.connect.return_value = False
+    api.is_connected = False
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert config_entry.error_reason_translation_key == "cannot_connect"
+
+
+async def test_a_controller_that_answers_nothing_says_that_instead(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api, config_entry
+) -> None:
+    """A connection that is accepted and read from anyway is the other half."""
+    api.is_connected = True
+    for component in ("heating", "buffer", "boiler", "heatpump"):
+        getattr(api, f"update_{component}").return_value = False
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert config_entry.error_reason_translation_key == "cannot_set_up"
+
+
 async def test_updating_options_reloads_the_entry(
     hass: HomeAssistant, enable_custom_integrations, mock_api, config_entry
 ) -> None:

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -11,8 +11,10 @@ These tests take over the part of that plugin that does matter, under rules that
 fit a custom component: numeric state keys are allowed, sloppy values are not.
 """
 
+import ast
 import json
 import pathlib
+import re
 
 from pysolarfocus import ApiVersions, Systems
 import pytest
@@ -27,7 +29,9 @@ from custom_components.solarfocus import (
     switch,
     water_heater,
 )
+from custom_components.solarfocus.const import DOMAIN
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.translation import async_get_translations
 
 from .conftest import build_config_entry, build_coordinator
 
@@ -206,3 +210,133 @@ def test_the_locked_state_is_still_translated() -> None:
         sensors = _load(filename)["entity"]["sensor"]
         for key in ("bo_circulation", "bo_single_charge"):
             assert sensors[key]["state"]["-1"]
+
+
+def _domain(node: ast.expr) -> str:
+    """Return the domain a raise names, spelled out or as the constant."""
+    if isinstance(node, ast.Constant):
+        return node.value
+
+    return DOMAIN if ast.unparse(node) == "DOMAIN" else ast.unparse(node)
+
+
+def _raised_translations():
+    """Yield every (module, key, domain, placeholders) the integration raises.
+
+    Read out of the source rather than listed here: a raise added with a key
+    nobody translated is the failure these tests are for, and a list would have
+    to be remembered at exactly the moment it was not.
+    """
+    for path in sorted(COMPONENT_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Raise) or not isinstance(node.exc, ast.Call):
+                continue
+
+            keywords = {kw.arg: kw.value for kw in node.exc.keywords}
+            if "translation_key" not in keywords:
+                continue
+
+            given = keywords.get("translation_placeholders")
+            yield (
+                path.name,
+                ast.literal_eval(keywords["translation_key"]),
+                _domain(keywords["translation_domain"]),
+                {ast.literal_eval(key) for key in given.keys} if given else set(),
+            )
+
+
+RAISED = list(_raised_translations())
+
+
+def _placeholders(message: str) -> set[str]:
+    """Return the names Home Assistant substitutes into a message."""
+    return set(re.findall(r"\{(\w+)\}", message))
+
+
+def test_something_raises_a_translated_exception() -> None:
+    """Guard the source scan against silently finding nothing."""
+    assert {key for _, key, _, _ in RAISED} == {
+        "cannot_connect",
+        "cannot_read",
+        "cannot_set_up",
+    }
+
+
+def test_every_raised_exception_names_this_integration() -> None:
+    """The message is looked up in the domain given, so a wrong one finds none."""
+    wrong = [(module, key) for module, key, domain, _ in RAISED if domain != DOMAIN]
+
+    assert not wrong
+
+
+@pytest.mark.parametrize("filename", FILENAMES)
+def test_every_raised_exception_is_translated(filename: str) -> None:
+    """An exception with no message shows the user its key instead.
+
+    `HomeAssistantError` builds the message from the translation when it is
+    raised without one, so a key that is missing here reaches the user as
+    `cannot_read` rather than as a sentence.
+    """
+    messages = _load(filename).get("exceptions", {})
+
+    missing = [
+        (module, key) for module, key, _, _ in RAISED if not messages.get(key, {}).get("message")
+    ]
+
+    assert not missing, f"{filename}: {missing}"
+
+
+@pytest.mark.parametrize("filename", FILENAMES)
+def test_exception_messages_use_exactly_the_placeholders_they_are_given(
+    filename: str,
+) -> None:
+    """A placeholder is only substituted if both sides name it.
+
+    One the message does not use drops the detail; one the raise does not pass
+    is rendered as `{address}`, in curly braces, to the user.
+    """
+    messages = _load(filename).get("exceptions", {})
+
+    mismatched = [
+        (module, key, given, _placeholders(messages[key]["message"]))
+        for module, key, _, given in RAISED
+        if key in messages and _placeholders(messages[key]["message"]) != given
+    ]
+
+    assert not mismatched, f"{filename}: {mismatched}"
+
+
+@pytest.mark.parametrize("filename", FILENAMES)
+def test_no_exception_translation_is_left_over(filename: str) -> None:
+    """A message nothing raises is a rename that left its old key behind."""
+    raised = {key for _, key, _, _ in RAISED}
+
+    unused = [key for key in _load(filename).get("exceptions", {}) if key not in raised]
+
+    assert not unused, f"{filename}: {unused}"
+
+
+def test_english_exception_messages_match_the_strings_file() -> None:
+    """`translations/en.json` is the English copy of `strings.json`."""
+    assert _load("translations/en.json")["exceptions"] == (
+        _load("strings.json")["exceptions"]
+    )
+
+
+async def test_home_assistant_renders_a_raised_exception(
+    hass: HomeAssistant, enable_custom_integrations
+) -> None:
+    """The messages have to be where Home Assistant looks for them.
+
+    Everything above reads the files off disk. This reads them back the way the
+    exception does, which is the part that fails if the section is named or
+    nested wrongly - the user gets the bare key and no error anywhere says why.
+    """
+    translations = await async_get_translations(hass, "en", "exceptions", [DOMAIN])
+
+    message = translations[f"component.{DOMAIN}.exceptions.cannot_connect.message"]
+
+    assert message.format(address="solarfocus.local:502") == (
+        "Cannot connect to the Solarfocus system at solarfocus.local:502."
+    )


### PR DESCRIPTION
Gold `exception-translations`, from #125.

The two failures that reach a user as text — the entry that cannot be set up, and the refresh that cannot read — built their message with an f-string, so they were English no matter what language Home Assistant is in.

`HomeAssistantError` builds the message from a translation when it is raised without one, so the three of them move into an `exceptions` section of `strings.json` and both translation files, with the address and the failing components as placeholders. German is translated rather than copied.

`cannot_set_up` and `cannot_read` say different things on purpose. One is the system accepting a connection and then answering no register — a wrong port, or a controller still booting. The other is every configured component failing on a system that had been read before.

## Tests

They read the raises out of the source with `ast` rather than listing the keys, because a raise added with a key nobody translated is the failure being guarded against, and a list would have to be remembered at exactly the wrong moment.

- every key raised has a message in all three files
- the placeholders on both sides are the same set — one the message does not use drops the detail, one the raise does not pass reaches the user in curly braces
- the domain named is this one, so the lookup finds anything at all
- no message is left over from a rename
- **and one asks Home Assistant for the message** instead of reading the file, which is the part that fails if the section is nested wrongly: the user then sees `cannot_connect` and nothing anywhere says why

I checked each by mutation — a missing message, a renamed placeholder and a wrong domain each fail the test that names them.

The two coordinator tests that matched on the message now assert the key and the placeholders, which is what is shown whatever the language. 974 passed, coverage stays at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)