### PR TITLE
Let an entry be pointed at a new address on its own, and report a bad interval where it was typed

### DIFF
--- a/custom_components/solarfocus/config_flow.py
+++ b/custom_components/solarfocus/config_flow.py
@@ -353,7 +353,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                return self.async_update_reload_and_abort(
+                # Updating the options is what reloads the entry: the update
+                # listener the integration registers does that already, for the
+                # options flow as much as for here. Asking for the reload as
+                # well would do it twice, and Home Assistant refuses to from
+                # 2026.12 for exactly that reason.
+                return self.async_update_and_abort(
                     entry,
                     # An entry the migration left without a unique id shares an
                     # address with another one by definition, so giving it one

--- a/custom_components/solarfocus/config_flow.py
+++ b/custom_components/solarfocus/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for Solarfocus integration."""
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
 from typing import Any
 
@@ -77,6 +78,24 @@ _COMPONENT_COUNT_ZERO_FOUR_SELECTOR = vol.All(
     ),
     vol.Coerce(int),
 )
+
+def _connection_schema(current: Mapping[str, Any]) -> vol.Schema:
+    """Return the form for where the heating system is and how often to ask it."""
+    return vol.Schema(
+        {
+            vol.Required(CONF_HOST, default=current[CONF_HOST]): cv.string,
+            vol.Optional(CONF_PORT, default=current[CONF_PORT]): cv.port,
+            vol.Optional(
+                CONF_SCAN_INTERVAL, default=current[CONF_SCAN_INTERVAL]
+            ): cv.positive_int,
+            vol.Required(
+                CONF_API_VERSION, default=current[CONF_API_VERSION]
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(options=SOLARFOCUS_API_VERSIONS),
+            ),
+        }
+    )
+
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -286,6 +305,65 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_BIOMASS_BOILER: self.data[CONF_BIOMASS_BOILER],
                 CONF_FRESH_WATER_MODULE: user_input[CONF_FRESH_WATER_MODULE],
             },
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Point an entry at the address its heating system is on now.
+
+        The options flow can already change these four settings, but it asks for
+        the whole component layout in the same form: a user whose controller
+        moved to another address has to answer for every component of their
+        heating system in order to say so, and a wrong answer there removes
+        entities. This is the connection on its own.
+        """
+        entry = self._get_reconfigure_entry()
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reconfigure", data_schema=_connection_schema(entry.options)
+            )
+
+        errors: dict[str, str] = {}
+        unique_id = build_unique_id(user_input[CONF_HOST], user_input[CONF_PORT])
+
+        if any(
+            other.unique_id == unique_id and other.entry_id != entry.entry_id
+            for other in self._async_current_entries()
+        ):
+            errors["base"] = "already_configured"
+        else:
+            try:
+                await validate_input(
+                    self.hass,
+                    {
+                        CONF_NAME: entry.data[CONF_NAME],
+                        CONF_SOLARFOCUS_SYSTEM: entry.data[CONF_SOLARFOCUS_SYSTEM],
+                        **user_input,
+                    },
+                )
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidScanInterval:
+                errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    entry,
+                    # An entry the migration left without a unique id shares an
+                    # address with another one by definition, so giving it one
+                    # here is the collision that migration avoided.
+                    unique_id=None if entry.unique_id is None else unique_id,
+                    options={**entry.options, **user_input},
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=_connection_schema(user_input),
+            errors=errors,
         )
 
     @staticmethod

--- a/custom_components/solarfocus/config_flow.py
+++ b/custom_components/solarfocus/config_flow.py
@@ -249,6 +249,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "cannot_connect"
         except InvalidAuth:
             errors["base"] = "invalid_auth"
+        except InvalidScanInterval:
+            errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
@@ -435,6 +437,8 @@ class SolarfocusOptionsFlowHandler(config_entries.OptionsFlow):
             errors["base"] = "cannot_connect"
         except InvalidAuth:
             errors["base"] = "invalid_auth"
+        except InvalidScanInterval:
+            errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"

--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -50,16 +50,35 @@
           "solar" : "Solar",
           "fresh_water_module" : "Fresh water module"
         }
+      },
+      "reconfigure": {
+        "title": "Solarfocus connection",
+        "description": "Change where this entry looks for your heating system. Which components it reads stays as it is.",
+        "data": {
+          "host": "Host",
+          "port": "Port",
+          "scan_interval": "Polling interval (s)",
+          "api_version": "Solarfocus API Version"
+        },
+        "data_description": {
+          "host": "The hostname or IP address of the eco manager-touch.",
+          "port": "The Modbus TCP port of the controller, 502 unless it was changed.",
+          "scan_interval": "How often every configured component is read, in seconds. Five is the lowest accepted.",
+          "api_version": "The version the controller shows under Fachmann - Modbus. A higher one than it runs creates entities it cannot answer."
+        }
       }
     },
     "error": {
       "name_exists": "Another Solarfocus entry already uses this name",
+      "already_configured": "Another Solarfocus entry already uses this address",
+      "invalid_scan_interval": "The polling interval has to be at least five seconds",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },
   "entity": {

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -27,10 +27,13 @@
   },
   "config": {
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "reconfigure_successful": "Neu konfiguriert"
     },
     "error": {
       "name_exists": "Dieser Name wird bereits von einem anderen Solarfocus-Eintrag verwendet",
+      "already_configured": "Diese Adresse wird bereits von einem anderen Solarfocus-Eintrag verwendet",
+      "invalid_scan_interval": "Das Abfrageintervall muss mindestens fünf Sekunden betragen",
       "cannot_connect": "Verbindung Fehlgeschlagen",
       "unknown": "Unexpected error"
     },
@@ -57,6 +60,22 @@
           "biomassboiler": "Kessel",
           "solar": "Solar",
           "fresh_water_module" : "Frischwassermodule"
+        }
+      },
+      "reconfigure": {
+        "title": "Solarfocus-Verbindung",
+        "description": "Ändern, wo dieser Eintrag die Heizungsanlage sucht. Welche Komponenten gelesen werden, bleibt unverändert.",
+        "data": {
+          "host": "Host",
+          "port": "Port",
+          "scan_interval": "Abfrage Intervall (s)",
+          "api_version": "Solarfocus API Version"
+        },
+        "data_description": {
+          "host": "Hostname oder IP-Adresse des eco manager-touch.",
+          "port": "Der Modbus-TCP-Port des Reglers, 502 sofern er nicht geändert wurde.",
+          "scan_interval": "Wie oft jede konfigurierte Komponente gelesen wird, in Sekunden. Fünf ist der kleinste akzeptierte Wert.",
+          "api_version": "Die Version, die der Regler unter Fachmann - Modbus anzeigt. Eine höhere als die tatsächliche erzeugt Entitäten, die er nicht beantworten kann."
         }
       }
     }

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -50,16 +50,35 @@
           "solar" : "Solar",
           "fresh_water_module" : "Fresh water module"
         }
+      },
+      "reconfigure": {
+        "title": "Solarfocus connection",
+        "description": "Change where this entry looks for your heating system. Which components it reads stays as it is.",
+        "data": {
+          "host": "Host",
+          "port": "Port",
+          "scan_interval": "Polling interval (s)",
+          "api_version": "Solarfocus API Version"
+        },
+        "data_description": {
+          "host": "The hostname or IP address of the eco manager-touch.",
+          "port": "The Modbus TCP port of the controller, 502 unless it was changed.",
+          "scan_interval": "How often every configured component is read, in seconds. Five is the lowest accepted.",
+          "api_version": "The version the controller shows under Fachmann - Modbus. A higher one than it runs creates entities it cannot answer."
+        }
       }
     },
     "error": {
       "name_exists": "Another Solarfocus entry already uses this name",
+      "already_configured": "Another Solarfocus entry already uses this address",
+      "invalid_scan_interval": "The polling interval has to be at least five seconds",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },
   "entity": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -699,6 +699,32 @@ async def test_reconfigure_moves_the_entry_and_its_unique_id(
     assert entry.unique_id == "10.0.0.5:503"
 
 
+async def test_reconfigure_reloads_the_entry_once(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """Saving the new address is what reloads the entry, and only that.
+
+    The integration registers an update listener that reloads on an options
+    change. Asking the flow to reload as well reloads twice, which Home
+    Assistant reports from 2026.6 and refuses from 2026.12.
+    """
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_reload"
+    ) as async_reload:
+        result = await _start_reconfigure(hass, entry)
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"], RECONFIGURE_INPUT
+        )
+        await hass.async_block_till_done()
+
+    assert async_reload.call_args_list == [((entry.entry_id,),)]
+
+
 async def test_reconfigure_leaves_the_components_alone(
     hass: HomeAssistant, enable_custom_integrations, mock_api
 ) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -217,11 +217,16 @@ async def test_form_unknown_error(
 async def test_form_scan_interval_below_minimum(
     hass: HomeAssistant, enable_custom_integrations, mock_api
 ) -> None:
-    """A scan interval below 5 seconds is rejected as an unknown error."""
+    """A scan interval below five seconds is reported on the field it is in.
+
+    It used to fall through to the broad handler and be shown as "unknown
+    error", with a traceback in the log, which says nothing about the one field
+    the user has to change.
+    """
     result = await _start_user_step(hass, {**USER_INPUT, CONF_SCAN_INTERVAL: 1})
 
     assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "unknown"}
+    assert result["errors"] == {CONF_SCAN_INTERVAL: "invalid_scan_interval"}
 
 
 async def test_entry_is_identified_by_its_address(
@@ -816,3 +821,32 @@ async def test_reconfigure_reports_an_unexpected_failure(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "unknown"}
     assert entry.options[CONF_HOST] == "solarfocus.local"
+
+
+async def test_options_flow_scan_interval_below_minimum(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """The options form has the same floor, and reports it the same way."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: "solarfocus.local",
+            CONF_PORT: 502,
+            CONF_SCAN_INTERVAL: 1,
+            CONF_API_VERSION: ApiVersions.V_23_020.value,
+            CONF_HEATING_CIRCUIT: 1,
+            CONF_BUFFER: 0,
+            CONF_BOILER: 0,
+            CONF_FRESH_WATER_MODULE: 0,
+            CONF_HEATPUMP: True,
+            CONF_PHOTOVOLTAIC: False,
+            CONF_SOLAR: 0,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_SCAN_INTERVAL: "invalid_scan_interval"}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -28,6 +28,7 @@ from custom_components.solarfocus.const import (
     DEFAULT_NAME,
     DOMAIN,
 )
+from homeassistant.config_entries import SOURCE_RECONFIGURE
 from homeassistant.const import (
     CONF_API_VERSION,
     CONF_HOST,
@@ -628,3 +629,190 @@ async def test_options_flow_errors(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": expected}
+
+
+# --- reconfigure -------------------------------------------------------------
+
+RECONFIGURE_INPUT = {
+    CONF_HOST: "10.0.0.5",
+    CONF_PORT: 503,
+    CONF_SCAN_INTERVAL: 30,
+    CONF_API_VERSION: ApiVersions.V_25_030.value,
+}
+
+
+async def _start_reconfigure(hass: HomeAssistant, entry) -> dict:
+    """Open the reconfigure form of an entry."""
+    return await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+    )
+
+
+async def test_reconfigure_form_starts_from_the_current_connection(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """The form is for correcting an address, so it starts at the current one."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    defaults = {
+        key.schema: key.default() for key in result["data_schema"].schema if key.default
+    }
+
+    assert defaults[CONF_HOST] == "solarfocus.local"
+    assert defaults[CONF_PORT] == 502
+
+
+async def test_reconfigure_moves_the_entry_and_its_unique_id(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """The address is the unique id, so changing one changes the other."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await _start_reconfigure(hass, entry)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], RECONFIGURE_INPUT
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+    assert entry.options[CONF_HOST] == "10.0.0.5"
+    assert entry.options[CONF_PORT] == 503
+    assert entry.options[CONF_SCAN_INTERVAL] == 30
+    assert entry.options[CONF_API_VERSION] == ApiVersions.V_25_030.value
+    assert entry.unique_id == "10.0.0.5:503"
+
+
+async def test_reconfigure_leaves_the_components_alone(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """The component layout belongs to the other form.
+
+    Asking for it again here is how a user correcting an address ends up
+    removing entities they still have.
+    """
+    entry = build_config_entry(
+        Systems.VAMPAIR, heating_circuit=3, buffer=2, boiler=1, heatpump=True
+    )
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+    await hass.config_entries.flow.async_configure(
+        result["flow_id"], RECONFIGURE_INPUT
+    )
+    await hass.async_block_till_done()
+
+    assert entry.options[CONF_HEATING_CIRCUIT] == 3
+    assert entry.options[CONF_BUFFER] == 2
+    assert entry.options[CONF_HEATPUMP] is True
+
+
+async def test_reconfigure_refuses_the_address_of_another_entry(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """Two entries on one controller is what the unique id is there to stop."""
+    other = build_config_entry(Systems.VAMPAIR, host="10.0.0.5", port=503)
+    other.add_to_hass(hass)
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], RECONFIGURE_INPUT
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "already_configured"}
+    assert entry.options[CONF_HOST] == "solarfocus.local"
+
+
+async def test_reconfigure_reports_a_system_it_cannot_reach(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """An address that answers nothing is the mistake this form is for."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+
+    api.connect.return_value = False
+
+    result = await _start_reconfigure(hass, entry)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], RECONFIGURE_INPUT
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+    assert entry.options[CONF_HOST] == "solarfocus.local"
+
+
+async def test_reconfigure_rejects_a_polling_interval_below_five(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """The same floor the user step enforces, reported on the field itself."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {**RECONFIGURE_INPUT, CONF_SCAN_INTERVAL: 1}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_SCAN_INTERVAL: "invalid_scan_interval"}
+
+
+async def test_reconfigure_keeps_a_duplicate_entry_without_a_unique_id(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """The migration left it without one on purpose, see #185.
+
+    Two entries for one controller predate the unique id. Giving this one an id
+    here is exactly the collision the migration avoided, and it would take the
+    entities of the entry that owns the address with it.
+    """
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(entry, unique_id=None)
+
+    result = await _start_reconfigure(hass, entry)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], RECONFIGURE_INPUT
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert entry.options[CONF_HOST] == "10.0.0.5"
+    assert entry.unique_id is None
+
+
+async def test_reconfigure_reports_an_unexpected_failure(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """Anything the library raises is the user's problem to see, not a traceback."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+
+    with patch(
+        "custom_components.solarfocus.config_flow.validate_input",
+        side_effect=ValueError("something the library did not expect"),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], RECONFIGURE_INPUT
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unknown"}
+    assert entry.options[CONF_HOST] == "solarfocus.local"


### PR DESCRIPTION
Gold `reconfiguration-flow`, from #125, plus the generic-exception bug it turned up.

## Reconfigure

A controller that moved — a new DHCP lease, a changed Modbus port, a firmware whose api version is now higher — could only be followed through the options flow, which asks for the whole component layout in the same form. A user correcting an address had to answer for every component of their heating system to do it, **and a wrong answer there removes entities**.

`async_step_reconfigure` asks for the connection and nothing else: host, port, polling interval, api version. The component counts are left exactly as they are, which is the point.

It keeps the rules the address already has:

- another entry on the same address is refused, because that is what the unique id has been for since #185
- the unique id moves with the entry when the address changes
- an entry the migration left **without** a unique id keeps it that way — it shares an address with another one by definition, so giving it one here is the collision the migration avoided

The reconfigure step is written with `data_description`, so every field says what it is for. The other two steps have none, which is the open half of the `config-flow` Bronze item and not this change.

## The generic exception, now fixed here too

`validate_input` raises `InvalidScanInterval` for an interval under five seconds, and only the new reconfigure step caught it. The user step and the options flow let it fall through to `except Exception`, which logs a traceback under "Unexpected exception" and shows the form **"unknown error" against the form as a whole** — saying nothing about the one field that has to change, which is also the only thing the user got wrong.

Both now catch it by name and report `invalid_scan_interval` on the polling interval field. `test_form_scan_interval_below_minimum` asserted the old behaviour down to the word "unknown"; it now asserts the field, and the options flow gains the same test, which it did not have.

## Tests

Nine for the reconfigure step — form defaults, the move and its unique id, the components staying put, the address of another entry, an unreachable system, the interval floor, the duplicate entry without a unique id, and the unexpected failure — plus the two interval tests above. 970 passed, coverage stays at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)