### PR TITLE
Reach Bronze: the connection in entry data, and a description on every field

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,10 +229,7 @@ immediately.
 
 | Option | Range | Description |
 |---|---|---|
-| Host | | Address of the controller, e.g. after a DHCP change. |
-| Port | | Modbus TCP port. |
 | Polling interval (s) | ≥ 5 | Seconds between two reads. |
-| Solarfocus API Version | `21.140` - `26.020` | Raise this after a software update of the heating system to get the entities that version added. |
 | Heating Circuit | 0 - 8 | Number of heating circuits (_Heizkreise_) to read. |
 | Buffer | 0 - 4 | Number of buffer cylinders (_Puffer_). |
 | Boiler | 0 - 4 | Number of boilers (_Boiler_). |
@@ -244,6 +241,20 @@ immediately.
 
 Setting a count to 0 (or a switch to off) stops that component from being polled and removes
 its entities.
+
+### Changing the Connection
+
+The address of the controller, its Modbus TCP port and the API version are what it takes to
+read the system at all, so they are not in the form above. Change them via **Settings →
+Devices & Services → Solarfocus → the three-dot menu of the entry → Reconfigure**, which
+asks for the connection on its own and leaves your component layout untouched.
+
+| Setting | Description |
+|---|---|
+| Host | Address of the controller, e.g. after a DHCP change. |
+| Port | Modbus TCP port. |
+| Polling interval (s) | Seconds between two reads, the same setting as above. |
+| Solarfocus API Version | Raise this after a software update of the heating system to get the entities that version added. Setting it higher than the controller runs makes it answer the wrong registers, see [Troubleshooting](#troubleshooting). |
 
 ### Removing the Integration
 

--- a/custom_components/solarfocus/__init__.py
+++ b/custom_components/solarfocus/__init__.py
@@ -58,15 +58,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -
     _async_report_duplicate_entry(hass, entry)
 
     api = SolarfocusAPI(
-        ip=entry.options[CONF_HOST],
-        port=entry.options[CONF_PORT],
+        ip=entry.data[CONF_HOST],
+        port=entry.data[CONF_PORT],
         heating_circuit_count=entry.options[CONF_HEATING_CIRCUIT],
         buffer_count=entry.options[CONF_BUFFER],
         boiler_count=entry.options[CONF_BOILER],
         fresh_water_module_count=entry.options[CONF_FRESH_WATER_MODULE],
-        solar_count=solar_count(entry.options),
+        solar_count=solar_count(entry),
         system=Systems(entry.data[CONF_SOLARFOCUS_SYSTEM]),
-        api_version=ApiVersions(entry.options[CONF_API_VERSION]),
+        api_version=ApiVersions(entry.data[CONF_API_VERSION]),
     )
     coordinator = SolarfocusDataUpdateCoordinator(hass, entry, api)
 
@@ -80,7 +80,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -
         # user to different places: nothing at the address to talk to at all, or
         # a controller that answered the connection and then none of the
         # registers. Whether the library is still connected is what says which.
-        address = f"{entry.options[CONF_HOST]}:{entry.options[CONF_PORT]}"
+        address = f"{entry.data[CONF_HOST]}:{entry.data[CONF_PORT]}"
         if not api.is_connected:
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
@@ -108,17 +108,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -
 def _async_sync_unique_id(hass: HomeAssistant, entry: SolarfocusConfigEntry) -> None:
     """Keep the unique id on the address the entry is actually talking to.
 
-    The address can be changed in the options. Doing this here rather than in
-    the options flow keeps the update out of the flow, where it would fire the
-    update listener and reload the entry against the options it is about to
-    replace. Saving options reloads the entry, so this runs right after.
+    The reconfigure flow can move an entry to another address, and a
+    hand-edited entry can arrive at one, so the id is settled here rather than
+    in the flow - where updating it would fire the update listener and reload
+    the entry against the address it is about to leave.
 
     An entry the migration left without a unique id is given one here as soon
     as the address is free, which is how the duplicate reported below stops
     being reported: the user removes the other entry, and the one they kept
     takes the address over on its next load.
     """
-    unique_id = build_unique_id(entry.options[CONF_HOST], entry.options[CONF_PORT])
+    unique_id = build_unique_id(entry.data[CONF_HOST], entry.data[CONF_PORT])
     if entry.unique_id == unique_id:
         return
 
@@ -171,7 +171,7 @@ def _async_report_duplicate_entry(
         translation_placeholders={
             "title": entry.title,
             "address": build_unique_id(
-                entry.options[CONF_HOST], entry.options[CONF_PORT]
+                entry.data[CONF_HOST], entry.data[CONF_PORT]
             ),
         },
     )
@@ -335,6 +335,21 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
             config_entry,
             unique_id=None if already_taken else unique_id,
             version=7,
+        )
+
+    if config_entry.version == 7:
+        # Where the controller is and which register layout it speaks are what
+        # it takes to read anything at all, so they belong in `data`. `options`
+        # keeps what a user changes about an entry that already works: how often
+        # to poll, and which components to poll.
+        new_data = {**config_entry.data}
+        new_options = {**config_entry.options}
+
+        for setting in (CONF_HOST, CONF_PORT, CONF_API_VERSION):
+            new_data[setting] = new_options.pop(setting)
+
+        hass.config_entries.async_update_entry(
+            config_entry, data=new_data, options=new_options, version=8
         )
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)

--- a/custom_components/solarfocus/config_flow.py
+++ b/custom_components/solarfocus/config_flow.py
@@ -42,6 +42,9 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Below this the controller is asked faster than it answers.
+MINIMUM_SCAN_INTERVAL = 5
+
 SOLARFOCUS_SYSTEMS = [
     selector.SelectOptionDict(value="Vampair", label="Heat pump vampair"),
     selector.SelectOptionDict(
@@ -198,7 +201,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     if not await hass.async_add_executor_job(client.api.connect):
         raise CannotConnect
 
-    if data[CONF_SCAN_INTERVAL] < 5:
+    if data[CONF_SCAN_INTERVAL] < MINIMUM_SCAN_INTERVAL:
         raise InvalidScanInterval
 
     # Return info that you want to store in the config entry.
@@ -208,7 +211,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Solarfocus."""
 
-    VERSION = 7
+    VERSION = 8
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     data: dict[str, Any]
@@ -292,12 +295,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data={
                 CONF_NAME: self.data[CONF_NAME],
                 CONF_SOLARFOCUS_SYSTEM: self.data[CONF_SOLARFOCUS_SYSTEM],
-            },
-            options={
                 CONF_HOST: self.data[CONF_HOST],
                 CONF_PORT: self.data[CONF_PORT],
-                CONF_SCAN_INTERVAL: self.data[CONF_SCAN_INTERVAL],
                 CONF_API_VERSION: self.data[CONF_API_VERSION],
+            },
+            options={
+                CONF_SCAN_INTERVAL: self.data[CONF_SCAN_INTERVAL],
                 CONF_BOILER: user_input[CONF_BOILER],
                 CONF_BUFFER: user_input[CONF_BUFFER],
                 CONF_HEATING_CIRCUIT: user_input[CONF_HEATING_CIRCUIT],
@@ -324,7 +327,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is None:
             return self.async_show_form(
-                step_id="reconfigure", data_schema=_connection_schema(entry.options)
+                step_id="reconfigure",
+                data_schema=_connection_schema({**entry.data, **entry.options}),
             )
 
         errors: dict[str, str] = {}
@@ -358,13 +362,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # options flow as much as for here. Asking for the reload as
                 # well would do it twice, and Home Assistant refuses to from
                 # 2026.12 for exactly that reason.
+                connection = dict(user_input)
+                scan_interval = connection.pop(CONF_SCAN_INTERVAL)
                 return self.async_update_and_abort(
                     entry,
                     # An entry the migration left without a unique id shares an
                     # address with another one by definition, so giving it one
                     # here is the collision that migration avoided.
                     unique_id=None if entry.unique_id is None else unique_id,
-                    options={**entry.options, **user_input},
+                    data={**entry.data, **connection},
+                    options={**entry.options, CONF_SCAN_INTERVAL: scan_interval},
                 )
 
         return self.async_show_form(
@@ -383,217 +390,79 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class SolarfocusOptionsFlowHandler(config_entries.OptionsFlow):
-    """Solarfocus config flow options handler."""
+    """Solarfocus config flow options handler.
 
-    def __init__(self) -> None:
-        """Initialize Solarfocus options flow."""
-
-        self._errors = {}
-        self.options: dict[str, Any] = {}
+    What an entry that already works lets a user change: how often to ask the
+    heating system, and which of its components to ask about. Where the system
+    is and which register layout it speaks are what it takes to read anything
+    at all, so they live in `ConfigEntry.data` and are changed by the
+    reconfigure flow.
+    """
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage the options."""
-
-        errors = {}
-        self.options = dict(self.config_entry.options)
-
         if user_input is None:
-            return await self._show_init_form(user_input, errors)
+            return self._show_init_form(self.config_entry.options, {})
 
-        # The address is the unique id, so moving this entry onto the address of
-        # another one would give two entries for the same controller. An entry
-        # that has no unique id is a duplicate the migration found and left
-        # alone; it already shares an address, and refusing to save its options
-        # would only lock it out of its own form.
-        if self.config_entry.unique_id is not None and self._address_is_taken(
-            build_unique_id(user_input[CONF_HOST], user_input[CONF_PORT])
-        ):
-            return await self._show_init_form(
-                user_input, {"base": "already_configured"}
+        if user_input[CONF_SCAN_INTERVAL] < MINIMUM_SCAN_INTERVAL:
+            return self._show_init_form(
+                user_input, {CONF_SCAN_INTERVAL: "invalid_scan_interval"}
             )
 
-        if self.config_entry.data[CONF_SOLARFOCUS_SYSTEM] == Systems.VAMPAIR:
-            self.options[CONF_HEATPUMP] = user_input[CONF_HEATPUMP]
-            self.options[CONF_BIOMASS_BOILER] = False
-        elif self.config_entry.data[CONF_SOLARFOCUS_SYSTEM] in [
-            Systems.THERMINATOR,
-            Systems.ECOTOP,
-        ]:
-            self.options[CONF_BIOMASS_BOILER] = user_input[CONF_BIOMASS_BOILER]
-            self.options[CONF_HEATPUMP] = False
+        # Which of the two the system can have is not asked, so it is not in the
+        # form and has to be carried over rather than read back from it.
+        vampair = self.config_entry.data[CONF_SOLARFOCUS_SYSTEM] == Systems.VAMPAIR
 
-        try:
-            await validate_input(
-                self.hass,
-                {
-                    CONF_NAME: self.config_entry.data[CONF_NAME],
-                    CONF_HOST: user_input[CONF_HOST],
-                    CONF_PORT: user_input[CONF_PORT],
-                    CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL],
-                    CONF_API_VERSION: user_input[CONF_API_VERSION],
-                    CONF_SOLARFOCUS_SYSTEM: self.config_entry.data[
-                        CONF_SOLARFOCUS_SYSTEM
-                    ],
-                },
-            )
-        except CannotConnect:
-            errors["base"] = "cannot_connect"
-        except InvalidAuth:
-            errors["base"] = "invalid_auth"
-        except InvalidScanInterval:
-            errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception("Unexpected exception")
-            errors["base"] = "unknown"
-        else:
-            # The unique id is not updated here: that fires the update listener
-            # and reloads the entry against the options it still has, which
-            # means a connect to the address the user just left. Saving the
-            # options reloads anyway, and `async_setup_entry` syncs it then.
-            return self.async_create_entry(
-                title="",
-                data={
-                    CONF_HOST: user_input[CONF_HOST],
-                    CONF_PORT: user_input[CONF_PORT],
-                    CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL],
-                    CONF_API_VERSION: user_input[CONF_API_VERSION],
-                    CONF_BOILER: user_input[CONF_BOILER],
-                    CONF_BUFFER: user_input[CONF_BUFFER],
-                    CONF_HEATING_CIRCUIT: user_input[CONF_HEATING_CIRCUIT],
-                    CONF_PHOTOVOLTAIC: user_input[CONF_PHOTOVOLTAIC],
-                    CONF_SOLAR: user_input[CONF_SOLAR],
-                    CONF_HEATPUMP: self.options[CONF_HEATPUMP],
-                    CONF_BIOMASS_BOILER: self.options[CONF_BIOMASS_BOILER],
-                    CONF_FRESH_WATER_MODULE: user_input[CONF_FRESH_WATER_MODULE],
-                },
-            )
-
-        return await self._show_init_form(user_input, errors)
-
-    def _address_is_taken(self, unique_id: str) -> bool:
-        """Return whether another entry already covers this address."""
-        return any(
-            entry.unique_id == unique_id
-            and entry.entry_id != self.config_entry.entry_id
-            for entry in self.hass.config_entries.async_entries(DOMAIN)
+        return self.async_create_entry(
+            title="",
+            data={
+                **user_input,
+                CONF_HEATPUMP: user_input[CONF_HEATPUMP] if vampair else False,
+                CONF_BIOMASS_BOILER: (
+                    False if vampair else user_input[CONF_BIOMASS_BOILER]
+                ),
+            },
         )
 
-    async def _show_init_form(self, user_input, errors):
-        """Show the options form to edit info."""
-
-        data_schema = {}
+    @callback
+    def _show_init_form(self, current: Mapping[str, Any], errors: dict[str, str]):
+        """Show the options form, filled in with what the entry has now."""
+        schema = {
+            vol.Optional(
+                CONF_SCAN_INTERVAL, default=current[CONF_SCAN_INTERVAL]
+            ): cv.positive_int,
+            vol.Optional(
+                CONF_HEATING_CIRCUIT, default=current[CONF_HEATING_CIRCUIT]
+            ): _COMPONENT_COUNT_ZERO_EIGHT_SELECTOR,
+            vol.Optional(
+                CONF_BUFFER, default=current[CONF_BUFFER]
+            ): _COMPONENT_COUNT_ZERO_FOUR_SELECTOR,
+            vol.Optional(
+                CONF_BOILER, default=current[CONF_BOILER]
+            ): _COMPONENT_COUNT_ZERO_FOUR_SELECTOR,
+            vol.Optional(
+                CONF_FRESH_WATER_MODULE, default=current[CONF_FRESH_WATER_MODULE]
+            ): _COMPONENT_COUNT_ZERO_FOUR_SELECTOR,
+        }
 
         if self.config_entry.data[CONF_SOLARFOCUS_SYSTEM] == Systems.VAMPAIR:
-            data_schema = vol.Schema(
-                {
-                    vol.Required(
-                        CONF_HOST, default=self.config_entry.options[CONF_HOST]
-                    ): cv.string,
-                    vol.Optional(
-                        CONF_PORT, default=self.config_entry.options[CONF_PORT]
-                    ): cv.port,
-                    vol.Optional(
-                        CONF_SCAN_INTERVAL,
-                        default=self.config_entry.options[CONF_SCAN_INTERVAL],
-                    ): cv.positive_int,
-                    vol.Required(
-                        CONF_API_VERSION,
-                        default=self.config_entry.options[CONF_API_VERSION],
-                    ): selector.SelectSelector(
-                        selector.SelectSelectorConfig(
-                            options=SOLARFOCUS_API_VERSIONS,
-                            mode=selector.SelectSelectorMode.DROPDOWN,
-                        ),
-                    ),
-                    vol.Optional(
-                        CONF_HEATING_CIRCUIT,
-                        default=self.config_entry.options[CONF_HEATING_CIRCUIT],
-                    ): _COMPONENT_COUNT_ZERO_EIGHT_SELECTOR,
-                    vol.Optional(
-                        CONF_BUFFER, default=self.config_entry.options[CONF_BUFFER]
-                    ): _COMPONENT_COUNT_ZERO_FOUR_SELECTOR,
-                    vol.Optional(
-                        CONF_BOILER, default=self.config_entry.options[CONF_BOILER]
-                    ): _COMPONENT_COUNT_ZERO_FOUR_SELECTOR,
-                    vol.Optional(
-                        CONF_FRESH_WATER_MODULE,
-                        default=self.config_entry.options[CONF_FRESH_WATER_MODULE],
-                    ): _COMPONENT_COUNT_ZERO_FOUR_SELECTOR,
-                    vol.Optional(
-                        CONF_HEATPUMP,
-                        default=self.config_entry.options[CONF_HEATPUMP],
-                    ): bool,
-                    vol.Optional(
-                        CONF_PHOTOVOLTAIC,
-                        default=self.config_entry.options[CONF_PHOTOVOLTAIC],
-                    ): bool,
-                    vol.Optional(
-                        CONF_SOLAR, default=self.config_entry.options[CONF_SOLAR]
-                    ): _COMPONENT_COUNT_ZERO_FOUR_SELECTOR,
-                }
-            )
+            schema[vol.Optional(CONF_HEATPUMP, default=current[CONF_HEATPUMP])] = bool
+        else:
+            schema[
+                vol.Optional(CONF_BIOMASS_BOILER, default=current[CONF_BIOMASS_BOILER])
+            ] = bool
 
-        elif self.config_entry.data[CONF_SOLARFOCUS_SYSTEM] in [
-            Systems.THERMINATOR,
-            Systems.ECOTOP,
-        ]:
-            data_schema = vol.Schema(
-                {
-                    vol.Required(
-                        CONF_HOST, default=self.config_entry.options[CONF_HOST]
-                    ): cv.string,
-                    vol.Optional(
-                        CONF_PORT, default=self.config_entry.options[CONF_PORT]
-                    ): cv.port,
-                    vol.Optional(
-                        CONF_SCAN_INTERVAL,
-                        default=self.config_entry.options[CONF_SCAN_INTERVAL],
-                    ): cv.positive_int,
-                    vol.Required(
-                        CONF_API_VERSION,
-                        default=self.config_entry.options[CONF_API_VERSION],
-                    ): selector.SelectSelector(
-                        selector.SelectSelectorConfig(
-                            options=SOLARFOCUS_API_VERSIONS,
-                            mode=selector.SelectSelectorMode.DROPDOWN,
-                        ),
-                    ),
-                    vol.Optional(
-                        CONF_HEATING_CIRCUIT,
-                        default=self.config_entry.options[CONF_HEATING_CIRCUIT],
-                    ): bool,
-                    vol.Optional(
-                        CONF_HEATING_CIRCUIT,
-                        default=self.config_entry.options[CONF_HEATING_CIRCUIT],
-                    ): _COMPONENT_COUNT_ZERO_EIGHT_SELECTOR,
-                    vol.Optional(
-                        CONF_BUFFER, default=self.config_entry.options[CONF_BUFFER]
-                    ): _COMPONENT_COUNT_ZERO_FOUR_SELECTOR,
-                    vol.Optional(
-                        CONF_BOILER, default=self.config_entry.options[CONF_BOILER]
-                    ): _COMPONENT_COUNT_ZERO_FOUR_SELECTOR,
-                    vol.Optional(
-                        CONF_FRESH_WATER_MODULE,
-                        default=self.config_entry.options[CONF_FRESH_WATER_MODULE],
-                    ): _COMPONENT_COUNT_ZERO_FOUR_SELECTOR,
-                    vol.Optional(
-                        CONF_BIOMASS_BOILER,
-                        default=self.config_entry.options[CONF_BIOMASS_BOILER],
-                    ): bool,
-                    vol.Optional(
-                        CONF_PHOTOVOLTAIC,
-                        default=self.config_entry.options[CONF_PHOTOVOLTAIC],
-                    ): bool,
-                    vol.Optional(
-                        CONF_SOLAR, default=self.config_entry.options[CONF_SOLAR]
-                    ): _COMPONENT_COUNT_ZERO_FOUR_SELECTOR,
-                }
-            )
+        schema[
+            vol.Optional(CONF_PHOTOVOLTAIC, default=current[CONF_PHOTOVOLTAIC])
+        ] = bool
+        schema[
+            vol.Optional(CONF_SOLAR, default=current[CONF_SOLAR])
+        ] = _COMPONENT_COUNT_ZERO_FOUR_SELECTOR
 
         return self.async_show_form(
-            step_id="init", data_schema=data_schema, errors=errors
+            step_id="init", data_schema=vol.Schema(schema), errors=errors
         )
 
 

--- a/custom_components/solarfocus/const.py
+++ b/custom_components/solarfocus/const.py
@@ -1,10 +1,8 @@
 """Constants for the Solarfocus integration."""
 
-from collections.abc import Mapping
-from typing import Any
-
 from packaging import version
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_VERSION
 
 DOMAIN = "solarfocus"
@@ -64,19 +62,22 @@ FRESH_WATER_MODULE_COMPONENT_PREFIX = "fm"
 MULTI_SOLAR_MIN_VERSION = "25.030"
 
 
-def solar_count(options: Mapping[str, Any]) -> int:
-    """Return how many solar circuits to build for these options.
+def solar_count(entry: ConfigEntry) -> int:
+    """Return how many solar circuits to build for this entry.
 
     Solar was a boolean before it became a count, and several circuits only
     exist from api version 25.030 on - pysolarfocus rejects a higher count
     below that and the whole entry fails to load. The options let the count be
     raised regardless of the selected version, so it is capped here.
+
+    The count is an option and the version is data, so this takes the entry
+    rather than either half of it.
     """
-    raw = options.get(CONF_SOLAR, 0)
+    raw = entry.options.get(CONF_SOLAR, 0)
     count = (1 if raw else 0) if isinstance(raw, bool) else int(raw or 0)
 
     if version.parse(
-        options.get(CONF_API_VERSION, DEFAULT_API_VERSION)
+        entry.data.get(CONF_API_VERSION, DEFAULT_API_VERSION)
     ) < version.parse(MULTI_SOLAR_MIN_VERSION):
         return min(count, 1)
 

--- a/custom_components/solarfocus/coordinator.py
+++ b/custom_components/solarfocus/coordinator.py
@@ -64,7 +64,7 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator):
     @property
     def _address(self) -> str:
         """Return the address of the heating system, for log messages."""
-        return f"{self._entry.options[CONF_HOST]}:{self._entry.options[CONF_PORT]}"
+        return f"{self._entry.data[CONF_HOST]}:{self._entry.data[CONF_PORT]}"
 
     async def _async_update_data(self):
         """Update data via library."""

--- a/custom_components/solarfocus/entity.py
+++ b/custom_components/solarfocus/entity.py
@@ -94,7 +94,7 @@ def create_description(
 
 def filterVersionAndSystem(config_entry: ConfigEntry, entities):
     """Filter entities not compatible to version or system."""
-    api_version = version.parse(config_entry.options[CONF_API_VERSION])
+    api_version = version.parse(config_entry.data[CONF_API_VERSION])
 
     filtered_entities = filter(
         lambda entity: version.parse(entity.entity_description.min_required_version)

--- a/custom_components/solarfocus/quality_scale.yaml
+++ b/custom_components/solarfocus/quality_scale.yaml
@@ -1,0 +1,121 @@
+# The status of this integration against Home Assistant's integration quality
+# scale, tracked in issue #125.
+#
+# The scale is a gate for integrations in Home Assistant core and does not bind
+# a custom integration, so nothing validates this file here. It is kept because
+# its rule list is the clearest description of what is left to do, and a status
+# written down is one that can be argued with.
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: |
+      This integration registers no service actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow:
+    status: todo
+    comment: |
+      The flow works and is tested, but two parts of the rule are not met.
+      `data_description` is only on the reconfigure step, not on the user, the
+      component or the options step. And the connection settings live in
+      `ConfigEntry.options` rather than in `ConfigEntry.data`, where the rule
+      wants everything that is not a user preference; moving them needs another
+      entry migration.
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: |
+      This integration registers no service actions.
+  docs-conditions:
+    status: exempt
+    comment: |
+      This integration provides no conditions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: |
+      This integration provides no triggers.
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: |
+      This integration registers no service actions.
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: |
+      Modbus TCP has no authentication, so there are no credentials to renew.
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: done
+  discovery-update-info:
+    status: exempt
+    comment: |
+      Nothing is discovered, so there is no discovery information to follow.
+  discovery:
+    status: exempt
+    comment: |
+      The eco manager-touch announces itself over nothing Home Assistant can
+      pick up; the controller is reached at an address the user knows.
+  docs-data-update: done
+  docs-examples: done
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
+  dynamic-devices:
+    status: exempt
+    comment: |
+      One device per config entry, and its components are chosen by the user
+      rather than found, so nothing appears after setup.
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
+  reconfiguration-flow: done
+  repair-issues: done
+  stale-devices:
+    status: exempt
+    comment: |
+      The one device of an entry is removed with the entry.
+
+  # Platinum
+  async-dependency:
+    status: todo
+    comment: |
+      pysolarfocus is synchronous, so every read and write goes through
+      `async_add_executor_job`. This is a change in the library rather than
+      here.
+  inject-websession:
+    status: exempt
+    comment: |
+      Modbus TCP, there is no HTTP session to inject.
+  strict-typing:
+    status: todo
+    comment: |
+      There is no `py.typed` and no mypy configuration; the platform modules
+      are only partly annotated.

--- a/custom_components/solarfocus/quality_scale.yaml
+++ b/custom_components/solarfocus/quality_scale.yaml
@@ -15,15 +15,7 @@ rules:
   brands: done
   common-modules: done
   config-flow-test-coverage: done
-  config-flow:
-    status: todo
-    comment: |
-      The flow works and is tested, but two parts of the rule are not met.
-      `data_description` is only on the reconfigure step, not on the user, the
-      component or the options step. And the connection settings live in
-      `ConfigEntry.options` rather than in `ConfigEntry.data`, where the rule
-      wants everything that is not a user preference; moving them needs another
-      entry migration.
+  config-flow: done
   dependency-transparency: done
   docs-actions:
     status: exempt

--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -175,7 +175,7 @@ async def async_setup_entry(
 
     if config_entry.options[CONF_SOLAR]:
         # The same count the library was built with, see `solar_count`
-        count = solar_count(config_entry.options)
+        count = solar_count(config_entry)
 
         for i in range(count):
             for description in SOLAR_SENSOR_TYPES:

--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -5,11 +5,7 @@
         "title": "Update Component Selection",
         "description": "Select which components are available in your setup and should be read.",
         "data": {
-          "name": "Name",
-          "host": "Host",
-          "port": "Port",
           "scan_interval": "Polling interval (s)",
-          "api_version": "Solarfocus API Version",
           "heating_circuit": "Heating Circuit",
           "buffer": "Buffer",
           "boiler": "Boiler",
@@ -18,6 +14,17 @@
           "biomassboiler": "Biomass boiler",
           "solar": "Solar",
           "fresh_water_module": "Fresh water module"
+        },
+        "data_description": {
+          "scan_interval": "How often every configured component is read, in seconds. Five is the lowest accepted.",
+          "heating_circuit": "How many heating circuits the controller has. Each one becomes its own set of entities.",
+          "buffer": "How many buffer tanks are installed.",
+          "boiler": "How many hot water boilers are installed.",
+          "heatpump": "Whether the heat pump of the system should be read.",
+          "photovoltaic": "Whether the photovoltaic registers should be read. Only answered if a meter is connected.",
+          "biomassboiler": "Whether the biomass boiler of the system should be read.",
+          "solar": "How many solar circuits are installed. More than one needs API version 25.030 or newer.",
+          "fresh_water_module": "How many fresh water modules are installed."
         }
       }
     },
@@ -35,6 +42,14 @@
           "scan_interval": "Polling interval (s)",
           "system": "Solarfocus System",
           "api_version": "Solarfocus API Version"
+        },
+        "data_description": {
+          "name": "The name of this entry. The entities of the heating system are named after it.",
+          "host": "The hostname or IP address of the eco manager-touch.",
+          "port": "The Modbus TCP port of the controller, 502 unless it was changed.",
+          "scan_interval": "How often every configured component is read, in seconds. Five is the lowest accepted.",
+          "system": "Which Solarfocus system this is. It decides which components can be selected in the next step.",
+          "api_version": "The version the controller shows under Fachmann - Modbus. A higher one than it runs creates entities it cannot answer."
         }
       },
       "component": {
@@ -49,6 +64,16 @@
           "biomassboiler": "Biomass boiler",
           "solar": "Solar",
           "fresh_water_module": "Fresh water module"
+        },
+        "data_description": {
+          "heating_circuit": "How many heating circuits the controller has. Each one becomes its own set of entities.",
+          "buffer": "How many buffer tanks are installed.",
+          "boiler": "How many hot water boilers are installed.",
+          "heatpump": "Whether the heat pump of the system should be read.",
+          "photovoltaic": "Whether the photovoltaic registers should be read. Only answered if a meter is connected.",
+          "biomassboiler": "Whether the biomass boiler of the system should be read.",
+          "solar": "How many solar circuits are installed. More than one needs API version 25.030 or newer.",
+          "fresh_water_module": "How many fresh water modules are installed."
         }
       },
       "reconfigure": {

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -5,11 +5,7 @@
         "title": "Aktualisiere Komponenten Auswahl",
         "description": "Welche Komponenten sollen integriert werden?",
         "data": {
-          "name": "Name",
-          "host": "Host",
-          "port": "Port",
           "scan_interval": "Abfrage Intervall (s)",
-          "api_version": "Solarfocus API Version",
           "boiler": "Boiler",
           "buffer": "Pufferspeicher",
           "heating_circuit": "Heizkreise",
@@ -18,6 +14,17 @@
           "biomassboiler": "Kessel",
           "solar": "Solar",
           "fresh_water_module": "Frischwassermodule"
+        },
+        "data_description": {
+          "scan_interval": "Wie oft jede konfigurierte Komponente gelesen wird, in Sekunden. Fünf ist der kleinste akzeptierte Wert.",
+          "boiler": "Wie viele Boiler vorhanden sind.",
+          "buffer": "Wie viele Pufferspeicher vorhanden sind.",
+          "heating_circuit": "Wie viele Heizkreise der Regler hat. Jeder wird zu einem eigenen Satz Entitäten.",
+          "heatpump": "Ob die Wärmepumpe der Anlage gelesen werden soll.",
+          "photovoltaic": "Ob die Photovoltaik-Register gelesen werden sollen. Sie werden nur beantwortet, wenn ein Zähler angeschlossen ist.",
+          "biomassboiler": "Ob der Biomassekessel der Anlage gelesen werden soll.",
+          "solar": "Wie viele Solarkreise vorhanden sind. Mehr als einer benötigt API-Version 25.030 oder neuer.",
+          "fresh_water_module": "Wie viele Frischwassermodule vorhanden sind."
         }
       }
     },
@@ -46,6 +53,14 @@
           "scan_interval": "Abfrage Intervall (s)",
           "system": "Solarfocus System",
           "api_version": "Solarfocus API Version"
+        },
+        "data_description": {
+          "name": "Der Name dieses Eintrags. Die Entitäten der Anlage werden danach benannt.",
+          "host": "Hostname oder IP-Adresse des eco manager-touch.",
+          "port": "Der Modbus-TCP-Port des Reglers, 502 sofern er nicht geändert wurde.",
+          "scan_interval": "Wie oft jede konfigurierte Komponente gelesen wird, in Sekunden. Fünf ist der kleinste akzeptierte Wert.",
+          "system": "Um welche Solarfocus-Anlage es sich handelt. Davon hängt ab, welche Komponenten im nächsten Schritt zur Auswahl stehen.",
+          "api_version": "Die Version, die der Regler unter Fachmann - Modbus anzeigt. Eine höhere als die tatsächliche erzeugt Entitäten, die er nicht beantworten kann."
         }
       },
       "component": {
@@ -60,6 +75,16 @@
           "biomassboiler": "Kessel",
           "solar": "Solar",
           "fresh_water_module": "Frischwassermodule"
+        },
+        "data_description": {
+          "boiler": "Wie viele Boiler vorhanden sind.",
+          "buffer": "Wie viele Pufferspeicher vorhanden sind.",
+          "heating_circuit": "Wie viele Heizkreise der Regler hat. Jeder wird zu einem eigenen Satz Entitäten.",
+          "heatpump": "Ob die Wärmepumpe der Anlage gelesen werden soll.",
+          "photovoltaic": "Ob die Photovoltaik-Register gelesen werden sollen. Sie werden nur beantwortet, wenn ein Zähler angeschlossen ist.",
+          "biomassboiler": "Ob der Biomassekessel der Anlage gelesen werden soll.",
+          "solar": "Wie viele Solarkreise vorhanden sind. Mehr als einer benötigt API-Version 25.030 oder neuer.",
+          "fresh_water_module": "Wie viele Frischwassermodule vorhanden sind."
         }
       },
       "reconfigure": {

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -5,11 +5,7 @@
         "title": "Update Component Selection",
         "description": "Select which components are available in your setup and should be read.",
         "data": {
-          "name": "Name",
-          "host": "Host",
-          "port": "Port",
           "scan_interval": "Polling interval (s)",
-          "api_version": "Solarfocus API Version",
           "heating_circuit": "Heating Circuit",
           "buffer": "Buffer",
           "boiler": "Boiler",
@@ -18,6 +14,17 @@
           "biomassboiler": "Biomass boiler",
           "solar": "Solar",
           "fresh_water_module": "Fresh water module"
+        },
+        "data_description": {
+          "scan_interval": "How often every configured component is read, in seconds. Five is the lowest accepted.",
+          "heating_circuit": "How many heating circuits the controller has. Each one becomes its own set of entities.",
+          "buffer": "How many buffer tanks are installed.",
+          "boiler": "How many hot water boilers are installed.",
+          "heatpump": "Whether the heat pump of the system should be read.",
+          "photovoltaic": "Whether the photovoltaic registers should be read. Only answered if a meter is connected.",
+          "biomassboiler": "Whether the biomass boiler of the system should be read.",
+          "solar": "How many solar circuits are installed. More than one needs API version 25.030 or newer.",
+          "fresh_water_module": "How many fresh water modules are installed."
         }
       }
     },
@@ -35,6 +42,14 @@
           "scan_interval": "Polling interval (s)",
           "system": "Solarfocus system",
           "api_version": "Solarfocus API Version"
+        },
+        "data_description": {
+          "name": "The name of this entry. The entities of the heating system are named after it.",
+          "host": "The hostname or IP address of the eco manager-touch.",
+          "port": "The Modbus TCP port of the controller, 502 unless it was changed.",
+          "scan_interval": "How often every configured component is read, in seconds. Five is the lowest accepted.",
+          "system": "Which Solarfocus system this is. It decides which components can be selected in the next step.",
+          "api_version": "The version the controller shows under Fachmann - Modbus. A higher one than it runs creates entities it cannot answer."
         }
       },
       "component": {
@@ -49,6 +64,16 @@
           "biomassboiler": "Biomass boiler",
           "solar": "Solar",
           "fresh_water_module": "Fresh water module"
+        },
+        "data_description": {
+          "heating_circuit": "How many heating circuits the controller has. Each one becomes its own set of entities.",
+          "buffer": "How many buffer tanks are installed.",
+          "boiler": "How many hot water boilers are installed.",
+          "heatpump": "Whether the heat pump of the system should be read.",
+          "photovoltaic": "Whether the photovoltaic registers should be read. Only answered if a meter is connected.",
+          "biomassboiler": "Whether the biomass boiler of the system should be read.",
+          "solar": "How many solar circuits are installed. More than one needs API version 25.030 or newer.",
+          "fresh_water_module": "How many fresh water modules are installed."
         }
       },
       "reconfigure": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,16 +29,24 @@ from homeassistant.const import (
 )
 
 # The config entry version the integration currently migrates to.
-CURRENT_VERSION = 7
+CURRENT_VERSION = 8
+
+
+def build_data(system: Systems = Systems.VAMPAIR) -> dict:
+    """Return the entry data: what it takes to read the heating system at all."""
+    return {
+        CONF_NAME: DEFAULT_NAME,
+        CONF_SOLARFOCUS_SYSTEM: system,
+        CONF_HOST: "solarfocus.local",
+        CONF_PORT: 502,
+        CONF_API_VERSION: ApiVersions.V_23_020.value,
+    }
 
 
 def build_options(**overrides) -> dict:
     """Return config entry options with all components off unless overridden."""
     options = {
-        CONF_HOST: "solarfocus.local",
-        CONF_PORT: 502,
         CONF_SCAN_INTERVAL: 10,
-        CONF_API_VERSION: ApiVersions.V_23_020.value,
         CONF_HEATING_CIRCUIT: 0,
         CONF_BUFFER: 0,
         CONF_BOILER: 0,
@@ -53,16 +61,30 @@ def build_options(**overrides) -> dict:
 
 
 def build_config_entry(
-    system: Systems = Systems.VAMPAIR, **option_overrides
+    system: Systems = Systems.VAMPAIR, **overrides
 ) -> MockConfigEntry:
-    """Return a config entry in the layout the current version stores."""
-    options = build_options(**option_overrides)
+    """Return a config entry in the layout the current version stores.
+
+    An override goes to whichever half of the entry holds that setting, so a
+    test says what its entry is rather than where the integration keeps it.
+    """
+    data = build_data(system)
+    options = build_options()
+
+    for setting, value in overrides.items():
+        if setting in data:
+            data[setting] = value
+        elif setting in options:
+            options[setting] = value
+        else:
+            raise KeyError(f"{setting} is in neither the data nor the options")
+
     return MockConfigEntry(
         domain=DOMAIN,
         title=DEFAULT_NAME,
         version=CURRENT_VERSION,
-        unique_id=build_unique_id(options[CONF_HOST], options[CONF_PORT]),
-        data={CONF_NAME: DEFAULT_NAME, CONF_SOLARFOCUS_SYSTEM: system},
+        unique_id=build_unique_id(data[CONF_HOST], data[CONF_PORT]),
+        data=data,
         options=options,
     )
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -113,15 +113,17 @@ async def test_full_flow_vampair(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
+    # What it takes to read the system is data, what the user chose about it
+    # is options
     assert result["data"] == {
         CONF_NAME: DEFAULT_NAME,
         CONF_SOLARFOCUS_SYSTEM: Systems.VAMPAIR,
-    }
-    assert result["options"] == {
         CONF_HOST: "solarfocus.local",
         CONF_PORT: 502,
-        CONF_SCAN_INTERVAL: 10,
         CONF_API_VERSION: ApiVersions.V_23_020.value,
+    }
+    assert result["options"] == {
+        CONF_SCAN_INTERVAL: 10,
         CONF_HEATING_CIRCUIT: 2,
         CONF_BUFFER: 1,
         CONF_BOILER: 1,
@@ -342,6 +344,18 @@ async def test_options_flow_form(
     assert result["data_schema"] is not None
 
 
+OPTIONS_INPUT = {
+    CONF_SCAN_INTERVAL: 30,
+    CONF_HEATING_CIRCUIT: 3,
+    CONF_BUFFER: 2,
+    CONF_BOILER: 1,
+    CONF_FRESH_WATER_MODULE: 1,
+    CONF_HEATPUMP: True,
+    CONF_PHOTOVOLTAIC: True,
+    CONF_SOLAR: 1,
+}
+
+
 async def test_options_flow_updates_options(
     hass: HomeAssistant, enable_custom_integrations, mock_api
 ) -> None:
@@ -353,140 +367,56 @@ async def test_options_flow_updates_options(
 
     with patch("custom_components.solarfocus.async_setup_entry", return_value=True):
         result = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: "10.0.0.5",
-                CONF_PORT: 503,
-                CONF_SCAN_INTERVAL: 30,
-                CONF_API_VERSION: ApiVersions.V_25_030.value,
-                CONF_HEATING_CIRCUIT: 3,
-                CONF_BUFFER: 2,
-                CONF_BOILER: 1,
-                CONF_FRESH_WATER_MODULE: 1,
-                CONF_HEATPUMP: True,
-                CONF_PHOTOVOLTAIC: True,
-                CONF_SOLAR: 1,
-            },
+            result["flow_id"], OPTIONS_INPUT
         )
         await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_HOST] == "10.0.0.5"
-    assert result["data"][CONF_PORT] == 503
     assert result["data"][CONF_SCAN_INTERVAL] == 30
-    assert result["data"][CONF_API_VERSION] == ApiVersions.V_25_030.value
     assert result["data"][CONF_HEATING_CIRCUIT] == 3
     assert result["data"][CONF_HEATPUMP] is True
     assert result["data"][CONF_BIOMASS_BOILER] is False
 
 
-async def test_options_flow_follows_the_address(
+async def test_the_options_form_does_not_ask_for_the_connection(
     hass: HomeAssistant, enable_custom_integrations, mock_api
 ) -> None:
-    """Moving an entry to another address moves its unique id along.
+    """Where the system is belongs to the entry data and the reconfigure flow.
 
-    A stale unique id would let the same system be added a second time under
-    its new address. The move happens on the reload that saving the options
-    triggers, not in the flow itself, so this runs the real setup.
+    Asking for it here as well was how the same setting ended up in both
+    halves of the entry, and how a user came to the form to add a heating
+    circuit and left having changed the address.
     """
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    fields = {key.schema for key in result["data_schema"].schema}
+
+    assert fields.isdisjoint({CONF_HOST, CONF_PORT, CONF_API_VERSION, CONF_NAME})
+    assert CONF_SCAN_INTERVAL in fields
+    assert CONF_HEATING_CIRCUIT in fields
+
+
+async def test_saving_options_leaves_the_connection_alone(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """The data of the entry is not the options flow's to write."""
     entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-    await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        {
-            CONF_HOST: "10.0.0.5",
-            CONF_PORT: 503,
-            CONF_SCAN_INTERVAL: 30,
-            CONF_API_VERSION: ApiVersions.V_25_030.value,
-            CONF_HEATING_CIRCUIT: 1,
-            CONF_BUFFER: 0,
-            CONF_BOILER: 0,
-            CONF_FRESH_WATER_MODULE: 0,
-            CONF_HEATPUMP: True,
-            CONF_PHOTOVOLTAIC: False,
-            CONF_SOLAR: 0,
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert entry.options[CONF_HOST] == "10.0.0.5"
-    assert entry.unique_id == "10.0.0.5:503"
-
-
-async def test_saving_options_does_not_reload_against_the_old_address(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
-) -> None:
-    """The entry is reloaded once, with the options the user just saved.
-
-    Updating the unique id inside the flow fired the update listener before the
-    new options were stored, so the entry was reloaded twice and the first of
-    those reloads connected to the address the user had just left.
-    """
-    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    mock_api.reset_mock()
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-    await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        {
-            CONF_HOST: "10.0.0.5",
-            CONF_PORT: 503,
-            CONF_SCAN_INTERVAL: 30,
-            CONF_API_VERSION: ApiVersions.V_25_030.value,
-            CONF_HEATING_CIRCUIT: 1,
-            CONF_BUFFER: 0,
-            CONF_BOILER: 0,
-            CONF_FRESH_WATER_MODULE: 0,
-            CONF_HEATPUMP: True,
-            CONF_PHOTOVOLTAIC: False,
-            CONF_SOLAR: 0,
-        },
-    )
-    await hass.async_block_till_done()
-
-    setups = [call for call in mock_api.call_args_list if "heating_circuit_count" in call.kwargs]
-    assert len(setups) == 1
-    assert setups[0].kwargs["ip"] == "10.0.0.5"
-
-
-async def test_options_flow_rejects_the_address_of_another_entry(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
-) -> None:
-    """Two entries must not end up pointing at the same system."""
-    other = build_config_entry()
-    other.add_to_hass(hass)
-    entry = build_config_entry(Systems.VAMPAIR, host="10.0.0.5", heatpump=True)
-    entry.add_to_hass(hass)
+    before = dict(entry.data)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        {
-            CONF_HOST: other.options[CONF_HOST],
-            CONF_PORT: other.options[CONF_PORT],
-            CONF_SCAN_INTERVAL: 10,
-            CONF_API_VERSION: ApiVersions.V_23_020.value,
-            CONF_HEATING_CIRCUIT: 0,
-            CONF_BUFFER: 0,
-            CONF_BOILER: 0,
-            CONF_FRESH_WATER_MODULE: 0,
-            CONF_HEATPUMP: True,
-            CONF_PHOTOVOLTAIC: False,
-            CONF_SOLAR: 0,
-        },
-    )
+    await hass.config_entries.options.async_configure(result["flow_id"], OPTIONS_INPUT)
+    await hass.async_block_till_done()
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "init"
-    assert result["errors"] == {"base": "already_configured"}
-    assert entry.unique_id == "10.0.0.5:502"
+    assert entry.data == before
+    assert entry.options[CONF_SCAN_INTERVAL] == 30
+    assert entry.unique_id == "solarfocus.local:502"
 
 
 async def test_a_legacy_duplicate_can_still_edit_its_options(
@@ -494,9 +424,9 @@ async def test_a_legacy_duplicate_can_still_edit_its_options(
 ) -> None:
     """The migration leaves one of two entries for a system without a unique id.
 
-    That entry shares its address with the other one by definition, so the
-    duplicate check must not fire for it - it would refuse every save and lock
-    the entry out of its own options form.
+    That entry shares its address with the other one by definition, so nothing
+    about saving its options may refuse it - that would lock the entry out of
+    its own form.
     """
     first = build_config_entry()
     first.add_to_hass(hass)
@@ -506,20 +436,7 @@ async def test_a_legacy_duplicate_can_still_edit_its_options(
 
     result = await hass.config_entries.options.async_init(duplicate.entry_id)
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        {
-            CONF_HOST: first.options[CONF_HOST],
-            CONF_PORT: first.options[CONF_PORT],
-            CONF_SCAN_INTERVAL: 30,
-            CONF_API_VERSION: ApiVersions.V_23_020.value,
-            CONF_HEATING_CIRCUIT: 0,
-            CONF_BUFFER: 0,
-            CONF_BOILER: 0,
-            CONF_FRESH_WATER_MODULE: 0,
-            CONF_HEATPUMP: True,
-            CONF_PHOTOVOLTAIC: False,
-            CONF_SOLAR: 0,
-        },
+        result["flow_id"], OPTIONS_INPUT
     )
     await hass.async_block_till_done()
 
@@ -533,7 +450,9 @@ async def test_options_flow_biomass_system_disables_heatpump(
     hass: HomeAssistant, enable_custom_integrations, mock_api
 ) -> None:
     """A therminator keeps the biomass boiler flag and never enables the heat pump."""
-    entry = build_config_entry(Systems.THERMINATOR, heating_circuit=1, biomassboiler=True)
+    entry = build_config_entry(
+        Systems.THERMINATOR, heating_circuit=1, biomassboiler=True
+    )
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
@@ -542,10 +461,7 @@ async def test_options_flow_biomass_system_disables_heatpump(
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             {
-                CONF_HOST: "solarfocus.local",
-                CONF_PORT: 502,
                 CONF_SCAN_INTERVAL: 10,
-                CONF_API_VERSION: ApiVersions.V_23_020.value,
                 CONF_HEATING_CIRCUIT: 1,
                 CONF_BUFFER: 1,
                 CONF_BOILER: 1,
@@ -560,80 +476,6 @@ async def test_options_flow_biomass_system_disables_heatpump(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_BIOMASS_BOILER] is True
     assert result["data"][CONF_HEATPUMP] is False
-
-
-async def test_options_flow_cannot_connect(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
-) -> None:
-    """A device that stops answering keeps the user on the options form."""
-    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-
-    api.connect.return_value = False
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        {
-            CONF_HOST: "unreachable",
-            CONF_PORT: 502,
-            CONF_SCAN_INTERVAL: 10,
-            CONF_API_VERSION: ApiVersions.V_23_020.value,
-            CONF_HEATING_CIRCUIT: 1,
-            CONF_BUFFER: 0,
-            CONF_BOILER: 0,
-            CONF_FRESH_WATER_MODULE: 0,
-            CONF_HEATPUMP: True,
-            CONF_PHOTOVOLTAIC: False,
-            CONF_SOLAR: 0,
-        },
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "init"
-    assert result["errors"] == {"base": "cannot_connect"}
-
-
-@pytest.mark.parametrize(
-    ("side_effect", "expected"),
-    [(InvalidAuth, "invalid_auth"), (RuntimeError("boom"), "unknown")],
-)
-async def test_options_flow_errors(
-    hass: HomeAssistant,
-    enable_custom_integrations,
-    mock_api,
-    side_effect: Exception,
-    expected: str,
-) -> None:
-    """Auth and unexpected failures are reported on the options form."""
-    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-
-    with patch(
-        "custom_components.solarfocus.config_flow.validate_input",
-        side_effect=side_effect,
-    ):
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: "solarfocus.local",
-                CONF_PORT: 502,
-                CONF_SCAN_INTERVAL: 10,
-                CONF_API_VERSION: ApiVersions.V_23_020.value,
-                CONF_HEATING_CIRCUIT: 1,
-                CONF_BUFFER: 0,
-                CONF_BOILER: 0,
-                CONF_FRESH_WATER_MODULE: 0,
-                CONF_HEATPUMP: True,
-                CONF_PHOTOVOLTAIC: False,
-                CONF_SOLAR: 0,
-            },
-        )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": expected}
 
 
 # --- reconfigure -------------------------------------------------------------
@@ -692,10 +534,10 @@ async def test_reconfigure_moves_the_entry_and_its_unique_id(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
 
-    assert entry.options[CONF_HOST] == "10.0.0.5"
-    assert entry.options[CONF_PORT] == 503
+    assert entry.data[CONF_HOST] == "10.0.0.5"
+    assert entry.data[CONF_PORT] == 503
     assert entry.options[CONF_SCAN_INTERVAL] == 30
-    assert entry.options[CONF_API_VERSION] == ApiVersions.V_25_030.value
+    assert entry.data[CONF_API_VERSION] == ApiVersions.V_25_030.value
     assert entry.unique_id == "10.0.0.5:503"
 
 
@@ -765,7 +607,7 @@ async def test_reconfigure_refuses_the_address_of_another_entry(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "already_configured"}
-    assert entry.options[CONF_HOST] == "solarfocus.local"
+    assert entry.data[CONF_HOST] == "solarfocus.local"
 
 
 async def test_reconfigure_reports_a_system_it_cannot_reach(
@@ -784,7 +626,7 @@ async def test_reconfigure_reports_a_system_it_cannot_reach(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
-    assert entry.options[CONF_HOST] == "solarfocus.local"
+    assert entry.data[CONF_HOST] == "solarfocus.local"
 
 
 async def test_reconfigure_rejects_a_polling_interval_below_five(
@@ -823,7 +665,7 @@ async def test_reconfigure_keeps_a_duplicate_entry_without_a_unique_id(
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
-    assert entry.options[CONF_HOST] == "10.0.0.5"
+    assert entry.data[CONF_HOST] == "10.0.0.5"
     assert entry.unique_id is None
 
 
@@ -846,7 +688,7 @@ async def test_reconfigure_reports_an_unexpected_failure(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "unknown"}
-    assert entry.options[CONF_HOST] == "solarfocus.local"
+    assert entry.data[CONF_HOST] == "solarfocus.local"
 
 
 async def test_options_flow_scan_interval_below_minimum(
@@ -858,20 +700,7 @@ async def test_options_flow_scan_interval_below_minimum(
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        {
-            CONF_HOST: "solarfocus.local",
-            CONF_PORT: 502,
-            CONF_SCAN_INTERVAL: 1,
-            CONF_API_VERSION: ApiVersions.V_23_020.value,
-            CONF_HEATING_CIRCUIT: 1,
-            CONF_BUFFER: 0,
-            CONF_BOILER: 0,
-            CONF_FRESH_WATER_MODULE: 0,
-            CONF_HEATPUMP: True,
-            CONF_PHOTOVOLTAIC: False,
-            CONF_SOLAR: 0,
-        },
+        result["flow_id"], {**OPTIONS_INPUT, CONF_SCAN_INTERVAL: 1}
     )
 
     assert result["type"] is FlowResultType.FORM

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -46,9 +46,9 @@ async def test_diagnostics_hide_the_address_of_the_controller(
     """The host is the one thing in the options a user should not have to strip."""
     diagnostics = await _diagnostics(hass, api, heating_circuit=1)
 
-    assert diagnostics["entry"]["options"][CONF_HOST] == REDACTED
+    assert diagnostics["entry"]["data"][CONF_HOST] == REDACTED
     # The port says nothing on its own and tells a non-standard setup apart
-    assert diagnostics["entry"]["options"][CONF_PORT] == 502
+    assert diagnostics["entry"]["data"][CONF_PORT] == 502
     assert "solarfocus.local" not in str(diagnostics)
 
 
@@ -77,7 +77,7 @@ async def test_home_assistant_serves_the_download(
 
     diagnostics = await get_diagnostics_for_config_entry(hass, hass_client, entry)
 
-    assert diagnostics["entry"]["options"][CONF_HOST] == REDACTED
+    assert diagnostics["entry"]["data"][CONF_HOST] == REDACTED
     assert diagnostics["components"]["heating_circuits"][0]["supply_temperature"] == 0
 
 
@@ -102,9 +102,9 @@ async def test_diagnostics_describe_how_the_entry_is_configured(
 
     entry = diagnostics["entry"]
 
-    assert entry["version"] == 7
+    assert entry["version"] == 8
     assert entry["options"]["heating_circuit"] == 2
-    assert entry["options"]["api_version"] == ApiVersions.V_23_020.value
+    assert entry["data"]["api_version"] == ApiVersions.V_23_020.value
     assert entry["data"]["system"] is not None
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -257,12 +257,12 @@ async def test_migration_from_version_1(hass: HomeAssistant) -> None:
     # Systems default to the heat pump the integration started out with
     assert entry.data[CONF_SOLARFOCUS_SYSTEM] == Systems.VAMPAIR
     # Connection details moved from data to options
-    assert entry.options[CONF_HOST] == "solarfocus.local"
-    assert entry.options[CONF_PORT] == 502
+    assert entry.data[CONF_HOST] == "solarfocus.local"
+    assert entry.data[CONF_PORT] == 502
     assert entry.options[CONF_SCAN_INTERVAL] == 10
-    assert CONF_HOST not in entry.data
+    assert CONF_HOST not in entry.options
     # New options got a default
-    assert entry.options[CONF_API_VERSION] == "21.140"
+    assert entry.data[CONF_API_VERSION] == "21.140"
     assert entry.options[CONF_FRESH_WATER_MODULE] == 0
     assert entry.options[CONF_SOLAR] == 0
     # pelletsboiler was renamed
@@ -300,8 +300,10 @@ async def test_migration_from_version_3_moves_options(hass: HomeAssistant) -> No
     assert entry.data == {
         CONF_NAME: DEFAULT_NAME,
         CONF_SOLARFOCUS_SYSTEM: Systems.THERMINATOR,
+        CONF_HOST: "10.0.0.2",
+        CONF_PORT: 502,
+        CONF_API_VERSION: "21.140",
     }
-    assert entry.options[CONF_HOST] == "10.0.0.2"
     assert entry.options[CONF_SCAN_INTERVAL] == 15
     assert entry.options[CONF_HEATING_CIRCUIT] == 2
     assert entry.options[CONF_BIOMASS_BOILER] is True
@@ -451,21 +453,28 @@ async def test_migrated_entries_can_be_set_up(
 
 
 def _version_6_entry(**option_overrides) -> MockConfigEntry:
-    """Return an entry in the layout of version 6, which had no unique id."""
+    """Return an entry as version 6 stored one: no unique id, and the
+    connection still among the options."""
+    options = {
+        CONF_HOST: "solarfocus.local",
+        CONF_PORT: 502,
+        CONF_API_VERSION: ApiVersions.V_23_020.value,
+        **build_options(**option_overrides),
+    }
     return MockConfigEntry(
         domain=DOMAIN,
         title=DEFAULT_NAME,
         version=6,
         unique_id=None,
         data={CONF_NAME: DEFAULT_NAME, CONF_SOLARFOCUS_SYSTEM: Systems.VAMPAIR},
-        options=build_options(**option_overrides),
+        options=options,
     )
 
 
 async def test_setup_moves_the_unique_id_to_the_configured_address(
     hass: HomeAssistant, enable_custom_integrations, mock_api
 ) -> None:
-    """The address can change in the options, the unique id follows on reload."""
+    """The address can change, and the unique id follows it on the next load."""
     entry = build_config_entry(heating_circuit=1)
     entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(entry, unique_id="stale.local:502")
@@ -513,6 +522,50 @@ async def test_setup_does_not_move_a_unique_id_onto_another_entry(
 
     assert other.unique_id == "10.0.0.7:502"
     assert "another entry already has it" in caplog.text
+
+
+async def test_migration_moves_the_connection_into_the_entry_data(
+    hass: HomeAssistant,
+) -> None:
+    """Version 8 keeps what it takes to read the system in `data`.
+
+    Everything used to be an option, including the address. What a user
+    changes about a system that already answers - how often to ask it, and
+    which of its components to ask about - stays in `options`.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_NAME,
+        version=7,
+        unique_id="10.0.0.2:503",
+        data={CONF_NAME: DEFAULT_NAME, CONF_SOLARFOCUS_SYSTEM: Systems.THERMINATOR},
+        options={
+            CONF_HOST: "10.0.0.2",
+            CONF_PORT: 503,
+            CONF_API_VERSION: "25.030",
+            **build_options(heating_circuit=2, biomassboiler=True),
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == CURRENT_VERSION
+    assert entry.data == {
+        CONF_NAME: DEFAULT_NAME,
+        CONF_SOLARFOCUS_SYSTEM: Systems.THERMINATOR,
+        CONF_HOST: "10.0.0.2",
+        CONF_PORT: 503,
+        CONF_API_VERSION: "25.030",
+    }
+    for moved in (CONF_HOST, CONF_PORT, CONF_API_VERSION):
+        assert moved not in entry.options
+
+    # What the user chose about the system is left where it was
+    assert entry.options[CONF_SCAN_INTERVAL] == 10
+    assert entry.options[CONF_HEATING_CIRCUIT] == 2
+    assert entry.options[CONF_BIOMASS_BOILER] is True
+    assert entry.unique_id == "10.0.0.2:503"
 
 
 async def test_migration_backfills_the_unique_id(hass: HomeAssistant) -> None:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -21,8 +21,8 @@ from homeassistant.const import CONF_API_VERSION
 def _config_entry(api_version: str):
     """Create a minimal config entry stub for entity filtering."""
     return SimpleNamespace(
-        options={CONF_API_VERSION: api_version},
-        data={"system": Systems.VAMPAIR},
+        data={CONF_API_VERSION: api_version, "system": Systems.VAMPAIR},
+        options={},
     )
 
 

--- a/tests/test_quality_scale.py
+++ b/tests/test_quality_scale.py
@@ -1,0 +1,223 @@
+"""The status this integration claims against the quality scale.
+
+Nothing validates `quality_scale.yaml` for a custom integration, so the file is
+only worth having if it cannot quietly go out of date. These tests hold it to
+the rule list of the scale, and hold the handful of claims that can be read out
+of the source to what the source actually does.
+
+The rules are listed here rather than fetched: the scale gaining a rule should
+fail this file and be answered for, which is exactly what a list that has to be
+updated by hand does.
+"""
+
+import pathlib
+
+import pytest
+import yaml
+
+from custom_components.solarfocus import sensor
+
+COMPONENT_DIR = pathlib.Path(sensor.__file__).parent
+
+PLATFORMS = (
+    "binary_sensor",
+    "button",
+    "climate",
+    "number",
+    "select",
+    "sensor",
+    "switch",
+    "water_heater",
+)
+
+# https://developers.home-assistant.io/docs/core/integration-quality-scale/checklist
+BRONZE = {
+    "action-setup",
+    "appropriate-polling",
+    "brands",
+    "common-modules",
+    "config-flow-test-coverage",
+    "config-flow",
+    "dependency-transparency",
+    "docs-actions",
+    "docs-conditions",
+    "docs-high-level-description",
+    "docs-installation-instructions",
+    "docs-removal-instructions",
+    "docs-triggers",
+    "entity-event-setup",
+    "entity-unique-id",
+    "has-entity-name",
+    "runtime-data",
+    "test-before-configure",
+    "test-before-setup",
+    "unique-config-entry",
+}
+
+SILVER = {
+    "action-exceptions",
+    "config-entry-unloading",
+    "docs-configuration-parameters",
+    "docs-installation-parameters",
+    "entity-unavailable",
+    "integration-owner",
+    "log-when-unavailable",
+    "parallel-updates",
+    "reauthentication-flow",
+    "test-coverage",
+}
+
+GOLD = {
+    "devices",
+    "diagnostics",
+    "discovery-update-info",
+    "discovery",
+    "docs-data-update",
+    "docs-examples",
+    "docs-known-limitations",
+    "docs-supported-devices",
+    "docs-supported-functions",
+    "docs-troubleshooting",
+    "docs-use-cases",
+    "dynamic-devices",
+    "entity-category",
+    "entity-device-class",
+    "entity-disabled-by-default",
+    "entity-translations",
+    "exception-translations",
+    "icon-translations",
+    "reconfiguration-flow",
+    "repair-issues",
+    "stale-devices",
+}
+
+PLATINUM = {"async-dependency", "inject-websession", "strict-typing"}
+
+RULES = BRONZE | SILVER | GOLD | PLATINUM
+
+
+def _quality_scale() -> dict:
+    """Return the rules of `quality_scale.yaml`, status and comment separated."""
+    with (COMPONENT_DIR / "quality_scale.yaml").open(encoding="utf-8") as fh:
+        loaded = yaml.safe_load(fh)
+
+    return {
+        rule: entry if isinstance(entry, dict) else {"status": entry}
+        for rule, entry in loaded["rules"].items()
+    }
+
+
+SCALE = _quality_scale()
+
+
+def _status(rule: str) -> str:
+    return SCALE[rule]["status"]
+
+
+def _source(module: str) -> str:
+    return (COMPONENT_DIR / f"{module}.py").read_text(encoding="utf-8")
+
+
+def test_every_rule_of_the_scale_is_answered() -> None:
+    """A rule left out is a rule nobody decided about."""
+    assert set(SCALE) == RULES
+
+
+def test_every_status_is_one_the_scale_knows() -> None:
+    """`done`, `todo` or `exempt`; anything else means nothing to a reader."""
+    wrong = {rule: _status(rule) for rule in SCALE if _status(rule) not in
+             ("done", "todo", "exempt")}
+
+    assert not wrong
+
+
+@pytest.mark.parametrize("status", ["todo", "exempt"])
+def test_anything_not_done_says_why(status: str) -> None:
+    """`done` speaks for itself. The other two are claims about this integration.
+
+    An exemption without a reason cannot be checked by anyone, and a `todo`
+    without one is a note to nobody.
+    """
+    silent = [
+        rule
+        for rule in SCALE
+        if _status(rule) == status and not SCALE[rule].get("comment", "").strip()
+    ]
+
+    assert not silent
+
+
+def test_the_service_action_exemptions_hold() -> None:
+    """Three rules are exempt because the integration registers no actions."""
+    for rule in ("action-setup", "docs-actions", "action-exceptions"):
+        assert _status(rule) == "exempt"
+
+    registering = [
+        path.name
+        for path in sorted(COMPONENT_DIR.glob("*.py"))
+        if "async_register" in path.read_text(encoding="utf-8")
+    ]
+
+    assert not registering
+    assert not (COMPONENT_DIR / "services.yaml").exists()
+
+
+def test_parallel_updates_is_set_where_it_is_claimed() -> None:
+    """The rule is about every platform, so one that forgets it fails it."""
+    assert _status("parallel-updates") == "done"
+
+    missing = [
+        platform
+        for platform in PLATFORMS
+        if "PARALLEL_UPDATES" not in _source(platform)
+    ]
+
+    assert not missing
+
+
+def test_the_gold_rules_that_are_a_file_or_a_function_exist() -> None:
+    """Claims that are true or false by looking, so they are looked at."""
+    assert _status("diagnostics") == "done"
+    assert "async_get_config_entry_diagnostics" in _source("diagnostics")
+
+    assert _status("reconfiguration-flow") == "done"
+    assert "async_step_reconfigure" in _source("config_flow")
+
+    assert _status("repair-issues") == "done"
+    assert "async_create_issue" in _source("coordinator")
+
+    assert _status("icon-translations") == "done"
+    assert (COMPONENT_DIR / "icons.json").stat().st_size > 0
+
+
+def test_the_config_flow_rule_is_still_open() -> None:
+    """The two things holding Bronze up, so that fixing one is noticed.
+
+    `data_description` on every step and the connection settings living in
+    `ConfigEntry.data`. When either is done this test fails, which is the
+    reminder to move the rule on rather than leave it saying `todo` forever.
+    """
+    assert _status("config-flow") == "todo"
+
+    strings = yaml.safe_load((COMPONENT_DIR / "strings.json").read_text("utf-8"))
+    steps = {
+        **strings["config"]["step"],
+        **strings["options"]["step"],
+    }
+    undescribed = [
+        step
+        for step, block in steps.items()
+        if set(block.get("data", {})) - set(block.get("data_description", {}))
+    ]
+
+    assert undescribed, "every step is described now, move config-flow on"
+
+
+def test_the_platinum_rules_are_still_open() -> None:
+    """Typing and the library, the two that need work outside the checklist."""
+    assert _status("strict-typing") == "todo"
+    assert not (COMPONENT_DIR / "py.typed").exists()
+
+    assert _status("async-dependency") == "todo"
+    # The library is synchronous, which is what the executor calls are for
+    assert "async_add_executor_job" in _source("coordinator")

--- a/tests/test_quality_scale.py
+++ b/tests/test_quality_scale.py
@@ -190,27 +190,26 @@ def test_the_gold_rules_that_are_a_file_or_a_function_exist() -> None:
     assert (COMPONENT_DIR / "icons.json").stat().st_size > 0
 
 
-def test_the_config_flow_rule_is_still_open() -> None:
-    """The two things holding Bronze up, so that fixing one is noticed.
+def test_every_field_of_every_step_is_described() -> None:
+    """Half of the config flow rule, and the half that rots.
 
-    `data_description` on every step and the connection settings living in
-    `ConfigEntry.data`. When either is done this test fails, which is the
-    reminder to move the rule on rather than leave it saying `todo` forever.
+    A field added to a form without a `data_description` is one the user is
+    asked about with nothing but its label to go on. The other half of the
+    rule - the connection in `ConfigEntry.data` and the rest in `.options` -
+    is what the config flow and migration tests are about.
     """
-    assert _status("config-flow") == "todo"
+    assert _status("config-flow") == "done"
 
     strings = yaml.safe_load((COMPONENT_DIR / "strings.json").read_text("utf-8"))
-    steps = {
-        **strings["config"]["step"],
-        **strings["options"]["step"],
-    }
-    undescribed = [
-        step
+    steps = {**strings["config"]["step"], **strings["options"]["step"]}
+
+    undescribed = {
+        step: sorted(set(block.get("data", {})) - set(block.get("data_description", {})))
         for step, block in steps.items()
         if set(block.get("data", {})) - set(block.get("data_description", {}))
-    ]
+    }
 
-    assert undescribed, "every step is described now, move config-flow on"
+    assert not undescribed
 
 
 def test_the_platinum_rules_are_still_open() -> None:


### PR DESCRIPTION
Refs #125. Two commits: the `quality_scale.yaml` that records where the integration stands, and the work that closes the last rule it showed as open.

## 1. `quality_scale.yaml`

The checklist in #125 is the only record of where this integration stands on the [quality scale](https://developers.home-assistant.io/docs/core/integration-quality-scale/), and an issue body is where a status drifts. This adds the file the scale asks for, in the format core integrations use, answering all **54 rules** with a reason on everything that is not `done`.

Two rules the scale added since #125 was written are answered for the first time: `docs-triggers` and `docs-conditions`, both exempt.

## 2. Closing `config-flow`, the last rule holding Bronze

**Every field of every step has a `data_description`.** Only the reconfigure step had them, so the user step, the component step and the options form asked for an API version, a polling interval and eight component counts with nothing but a label to go on.

**The connection moves to `ConfigEntry.data`.** The rule wants everything needed to reach the device in `data` and only preferences in `options`; the host, port and API version were options. Entry **version 8** moves them.

| | Before | After |
|---|---|---|
| `data` | name, system | name, system, **host, port, api_version** |
| `options` | host, port, api_version, scan interval, 8 component counts | scan interval, 8 component counts |

The polling interval deliberately stays an option — the rule's line is "not needed for the connection to be made", and it isn't. #125 reads it the other way; the rule's own wording won.

### What this changes for a user

The two forms now split along the same line:

- **Configure** — the component layout and the polling interval.
- **Reconfigure** (added in #202) — host, port, polling interval, API version.

The connection fields are gone from the options form. That is the better home for them anyway: the old form asked for the entire layout of a heating system in order to correct a DHCP address, and a wrong answer there removed entities. A side effect worth having is that saving options no longer opens a Modbus connection to validate, so a controller that happens to be offline no longer blocks a component change.

`README.md` is updated to match, with a new **Changing the Connection** section.

## Where the scale stands now

**Bronze, Silver and Gold are complete.** Platinum is `strict-typing` and `async-dependency`, the latter being a change in `pysolarfocus` rather than here.

The manifest is deliberately untouched — `quality_scale` there is a core-integration declaration, and I would rather you decide whether to claim `gold` in it than have CI find out for us.

## Tests

1023 passing, 100% coverage. `tests/test_quality_scale.py` holds the file to the scale: the rule list must match, every `exempt`/`todo` must say why, and the mechanical claims are checked against the source. The `config-flow` guard is now the other way round — it asserts every step describes every field, so a new field without a description fails the suite.

New coverage for the move: the version 8 migration, that the options form does not offer the connection, and that saving options leaves `entry.data` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)