### PR TITLE
Say what the options form rejects, and set the version to 5.1.0-rc4

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
    - [Integration Setup](#integration-setup)
    - [Installation Parameters](#installation-parameters)
    - [Configuration Options](#configuration-options)
+   - [Changing the Connection](#changing-the-connection)
    - [Removing the Integration](#removing-the-integration)
 5. [Supported Functionality](#supported-functionality)
 6. [How Data Is Updated](#how-data-is-updated)
@@ -411,21 +412,21 @@ time, so close other Modbus clients pointing at it.
 **All entities are unavailable.**
 The heating system could not be read at all on the last poll. The log says why, once per outage
 rather than once per interval. Common causes are the controller being restarted, a DHCP address
-change (fix it in the options, see [Configuration Options](#configuration-options)) or another
-Modbus client holding the connection.
+change (point the entry at the new address, see [Changing the Connection](#changing-the-connection))
+or another Modbus client holding the connection.
 
 **One component is stuck on old values while the rest updates.**
 That component could not be read. The log names it, with a warning when it starts failing and
 another when it recovers. If it fails on every poll, the registers of that component are
 probably not answered by your software version - lower the API version under
-[Configuration Options](#configuration-options) or set the component to 0 if your installation
-does not have it.
+[Changing the Connection](#changing-the-connection) or set the component to 0 under
+[Configuration Options](#configuration-options) if your installation does not have it.
 
 **Entities I expect are missing.**
 Either the component is set to 0 in the options, or the entity needs a newer API version than
 the one configured, or it does not exist for your system. Check the version selected under
-[Configuration Options](#configuration-options) against the version shown on your display, and
-note that some entities are created disabled and have to be enabled on the device page.
+[Changing the Connection](#changing-the-connection) against the version shown on your display,
+and note that some entities are created disabled and have to be enabled on the device page.
 
 **More than one solar circuit does not show up.**
 Multiple solar circuits require API version `25.030` or newer. Below that the count is capped

--- a/custom_components/solarfocus/manifest.json
+++ b/custom_components/solarfocus/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/lavermanjj/home-assistant-solarfocus/issues",
   "requirements": ["pysolarfocus==5.2.2"],
   "ssdp": [],
-  "version": "5.1.0-rc3",
+  "version": "5.1.0-rc4",
   "zeroconf": []
 }

--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -2,8 +2,8 @@
   "options": {
     "step": {
       "init": {
-        "title": "Update Component Selection",
-        "description": "Select which components are available in your setup and should be read.",
+        "title": "Components and Polling",
+        "description": "How often the heating system is read, and which of its components to read. The address of the controller and its API version are changed under Reconfigure.",
         "data": {
           "scan_interval": "Polling interval (s)",
           "heating_circuit": "Heating Circuit",
@@ -29,7 +29,7 @@
       }
     },
     "error": {
-      "already_configured": "This address is already used by another Solarfocus entry"
+      "invalid_scan_interval": "[%key:component::solarfocus::config::error::invalid_scan_interval%]"
     }
   },
   "config": {

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -2,8 +2,8 @@
   "options": {
     "step": {
       "init": {
-        "title": "Aktualisiere Komponenten Auswahl",
-        "description": "Welche Komponenten sollen integriert werden?",
+        "title": "Komponenten und Abfrage",
+        "description": "Wie oft die Anlage gelesen wird und welche ihrer Komponenten. Die Adresse des Reglers und die API-Version werden unter „Neu konfigurieren“ geändert.",
         "data": {
           "scan_interval": "Abfrage Intervall (s)",
           "boiler": "Boiler",
@@ -29,7 +29,7 @@
       }
     },
     "error": {
-      "already_configured": "Diese Adresse wird bereits von einem anderen Solarfocus-Eintrag verwendet"
+      "invalid_scan_interval": "Das Abfrageintervall muss mindestens fünf Sekunden betragen"
     }
   },
   "config": {

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -2,8 +2,8 @@
   "options": {
     "step": {
       "init": {
-        "title": "Update Component Selection",
-        "description": "Select which components are available in your setup and should be read.",
+        "title": "Components and Polling",
+        "description": "How often the heating system is read, and which of its components to read. The address of the controller and its API version are changed under Reconfigure.",
         "data": {
           "scan_interval": "Polling interval (s)",
           "heating_circuit": "Heating Circuit",
@@ -29,7 +29,7 @@
       }
     },
     "error": {
-      "already_configured": "This address is already used by another Solarfocus entry"
+      "invalid_scan_interval": "The polling interval has to be at least five seconds"
     }
   },
   "config": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "solarfocus"
-version = "5.1.0rc3"
+version = "5.1.0rc4"
 description = "Custom component for integrating Solarfocus heating systems into Home Assistant."
 authors = [{ name = "Jeroen Laverman", email = "jjlaverman@web.de" }]
 requires-python = ">=3.14.2,<3.15"

--- a/tests/test_quality_scale.py
+++ b/tests/test_quality_scale.py
@@ -10,6 +10,7 @@ fail this file and be answered for, which is exactly what a list that has to be
 updated by hand does.
 """
 
+import json
 import pathlib
 
 import pytest
@@ -18,6 +19,16 @@ import yaml
 from custom_components.solarfocus import sensor
 
 COMPONENT_DIR = pathlib.Path(sensor.__file__).parent
+
+# `strings.json` is the source of the translations; the files under
+# `translations` are what Home Assistant actually loads for a custom
+# integration, so a description that only reaches the first of them reaches no
+# user.
+STRING_FILES = (
+    "strings.json",
+    "translations/en.json",
+    "translations/de.json",
+)
 
 PLATFORMS = (
     "binary_sensor",
@@ -190,7 +201,8 @@ def test_the_gold_rules_that_are_a_file_or_a_function_exist() -> None:
     assert (COMPONENT_DIR / "icons.json").stat().st_size > 0
 
 
-def test_every_field_of_every_step_is_described() -> None:
+@pytest.mark.parametrize("strings_file", STRING_FILES)
+def test_every_field_of_every_step_is_described(strings_file: str) -> None:
     """Half of the config flow rule, and the half that rots.
 
     A field added to a form without a `data_description` is one the user is
@@ -200,7 +212,7 @@ def test_every_field_of_every_step_is_described() -> None:
     """
     assert _status("config-flow") == "done"
 
-    strings = yaml.safe_load((COMPONENT_DIR / "strings.json").read_text("utf-8"))
+    strings = json.loads((COMPONENT_DIR / strings_file).read_text("utf-8"))
     steps = {**strings["config"]["step"], **strings["options"]["step"]}
 
     undescribed = {
@@ -210,6 +222,26 @@ def test_every_field_of_every_step_is_described() -> None:
     }
 
     assert not undescribed
+
+
+@pytest.mark.parametrize("strings_file", STRING_FILES)
+def test_every_error_a_form_shows_is_a_string(strings_file: str) -> None:
+    """An error with no string reaches the user as its own key.
+
+    The two flows do not share an error block: what the options form returns is
+    looked up under `options`, what the config and reconfigure steps return
+    under `config`. The options form rejects one thing, a polling interval
+    below the minimum; a key left behind on either side is one that no longer
+    matches what the flow can say.
+    """
+    strings = json.loads((COMPONENT_DIR / strings_file).read_text("utf-8"))
+    source = _source("config_flow")
+
+    assert set(strings["options"]["error"]) == {"invalid_scan_interval"}
+
+    unused = [key for key in strings["config"]["error"] if f'"{key}"' not in source]
+
+    assert not unused
 
 
 def test_the_platinum_rules_are_still_open() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2292,7 +2292,7 @@ wheels = [
 
 [[package]]
 name = "solarfocus"
-version = "5.1.0rc3"
+version = "5.1.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
Two commits: the review fixes for #207 that did not make it into the merge, and the version bump for the `5.1.0-rc4` pre-release.

## 1. What the options form rejects, said in the file that is actually read

#207 narrowed the options flow to one error - a polling interval below five - but `options.error` still held only `already_configured`, the string for the address check that moved to the reconfigure flow along with the address. Home Assistant renders the raw key when the lookup misses, so a user who typed `3` got **`invalid_scan_interval`** printed under the field.

The guard that was supposed to catch this read `strings.json`, which nothing loads for a custom integration: `translations/en.json` and `translations/de.json` are the files a user's Home Assistant reads, and the two have already drifted apart on six labels. Both checks now run against all three files, and a new one holds the error blocks to what the flows can actually say - verified to fail against the files as they are on `main` today.

Also in this commit:

- The options form was still titled "Update Component Selection" while asking for the polling interval first. It is "Components and Polling" now, with a description that points at Reconfigure for the address and the API version.
- Three troubleshooting answers in the README still sent a user with a moved controller or a wrong API version to the options form those settings had just left.

## 2. `5.1.0-rc4`

`manifest.json` and `pyproject.toml`. Nothing else changed for the release - rc4 is rc3 plus #207 plus the fix above, and it exists so #207 gets a run in a real installation before 5.1.0 is final.

## Tests

1028 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
