### PR TITLE
One device per component, with names and stale devices to match (#208 phases 2-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ asks for the connection on its own and leaves your component layout untouched.
 ### Removing the Integration
 
 Go to **Settings → Devices & Services → Solarfocus**, open the three-dot menu of the entry
-and choose **Delete**. This removes the config entry, the device and all of its entities, and
+and choose **Delete**. This removes the config entry, its devices and all of their entities, and
 stops the polling. Nothing is left behind on the heating system - the integration only reads
 registers and writes the ones you changed from Home Assistant.
 
@@ -274,8 +274,24 @@ eco<sup>manager-touch</sup> if you do not want to keep them.
 
 ## Supported Functionality
 
-The integration creates a single device per config entry, with the entities of every
-configured component. Multi-instance components are numbered (`Heating circuit 2 ...`).
+The integration creates **one device per component**: every heating circuit, buffer, boiler,
+fresh water module and solar circuit, plus the heat pump, photovoltaic and biomass boiler, all
+of them attached to the eco<sup>manager-touch</sup> as their hub. Multi-instance components are
+numbered in the name of the device (`Heating circuit 2`), which is why the entities on them are
+called `Supply temperature` rather than `Heating circuit 2 supply temperature`.
+
+A device is what Home Assistant assigns an area to, so a heating circuit can sit in the room it
+heats. Lowering a count or switching a component off removes its device and every entity on it,
+so nothing is left behind holding the value it had when it was last polled.
+
+**Your existing entity ids do not change.** Entities already in the registry keep the ids they
+were given, so an installation upgrading from 5.1.0 keeps its `sensor.solarfocus_...` ids.
+
+Entities added **after** the upgrade - a component whose count you raise, or a fresh installation -
+are named the way Home Assistant composes an id from the device and the entity:
+`sensor.heating_circuit_1_supply_temperature`. The device half follows the language of your
+installation (`sensor.heizkreis_1_supply_temperature` on a German one); the half that names the
+reading is always English.
 
 | Platform | Component | Entities |
 |---|---|---|
@@ -392,8 +408,13 @@ These are properties of the integration or the Modbus interface, not bugs:
 - **Register coverage follows the specification of the selected version.** Features the
   eco<sup>manager-touch</sup> only offers on its display, and registers added after `26.020`,
   are not available.
-- **Entity names are English.** Entity states, the config flow and the fault texts are
-  translated (English and German), the entity names themselves are not.
+- **Entity ids added before and after 6.0.0 look different.** Entities in the registry keep the
+  id they were given, so an upgraded installation has `sensor.solarfocus_...` ids while anything
+  added afterwards is `sensor.heating_circuit_1_...`, composed by Home Assistant from the device
+  and the entity. Nothing existing moves; the two styles simply coexist.
+- **The device half of an entity id follows the language of the installation.** A German
+  installation names new entities `sensor.heizkreis_1_supply_temperature`. The half that names
+  the reading is always English.
 - **Writes can be ignored by the controller.** The photovoltaic registers only take effect once
   the display is configured for it, see [Photovoltaic](#photovoltaic), and the heating system
   keeps enforcing its own limits (for example the outdoor shutdown temperature) regardless of

--- a/README.md
+++ b/README.md
@@ -403,7 +403,8 @@ These are properties of the integration or the Modbus interface, not bugs:
   deleting the entry and setting it up again.
 - **The name of an entry is part of the identity of its entities.** Renaming the config entry
   after setup gives the entities new unique ids: the old ones are orphaned and a duplicate set
-  appears with a `_2` suffix. Rename the entities or the device instead, both of which are safe.
+  appears with a `_2` suffix. Rename the entities or one of the devices instead, both of which
+  are safe.
   For the same reason two entries cannot share a name, and the setup rejects one that is taken.
 - **Register coverage follows the specification of the selected version.** Features the
   eco<sup>manager-touch</sup> only offers on its display, and registers added after `26.020`,
@@ -448,6 +449,12 @@ Either the component is set to 0 in the options, or the entity needs a newer API
 the one configured, or it does not exist for your system. Check the version selected under
 [Changing the Connection](#changing-the-connection) against the version shown on your display,
 and note that some entities are created disabled and have to be enabled on the device page.
+
+**A device trigger or a device action in an automation stopped working.**
+The entities moved from the one device an entry used to have onto the device of their component,
+so an automation built in the UI against the old device no longer finds them. Open the automation
+and pick the entity again - it will now be under `Heating circuit 1`, `Buffer 2` and so on. This
+only affects automations that reference a **device**; anything naming an `entity_id` is unaffected.
 
 **More than one solar circuit does not show up.**
 Multiple solar circuits require API version `25.030` or newer. Below that the count is capped

--- a/README.md
+++ b/README.md
@@ -281,8 +281,12 @@ numbered in the name of the device (`Heating circuit 2`), which is why the entit
 called `Supply temperature` rather than `Heating circuit 2 supply temperature`.
 
 A device is what Home Assistant assigns an area to, so a heating circuit can sit in the room it
-heats. Lowering a count or switching a component off removes its device and every entity on it,
-so nothing is left behind holding the value it had when it was last polled.
+heats. **If your Solarfocus device was in an area, every component device starts out in that same
+area**, so nothing drops out of a room-scoped automation or voice command on the upgrade; move
+the ones that belong elsewhere and they stay where you put them.
+
+Lowering a count or switching a component off removes its device and every entity on it, so
+nothing is left behind holding the value it had when it was last polled.
 
 **Your existing entity ids do not change.** Entities already in the registry keep the ids they
 were given, so an installation upgrading from 5.1.0 keeps its `sensor.solarfocus_...` ids.

--- a/custom_components/solarfocus/__init__.py
+++ b/custom_components/solarfocus/__init__.py
@@ -34,7 +34,9 @@ from .const import (
     CONF_SOLAR,
     CONF_SOLARFOCUS_SYSTEM,
     DOMAIN,
+    MANUFACTURER,
     build_unique_id,
+    expected_device_identifiers,
     solar_count,
 )
 from .coordinator import (
@@ -99,9 +101,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -
             translation_placeholders={"address": address},
         ) from coordinator.last_exception
 
+    coordinator.hub_device_id = _async_hub_device(hass, entry, api).id
     entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    _async_remove_gone_components(hass, entry)
 
     # Registers update listener to update config entry when options are updated.
     entry.async_on_unload(entry.add_update_listener(async_update_options))
@@ -185,6 +190,70 @@ def _async_report_duplicate_entry(
 def _duplicate_issue_id(entry: SolarfocusConfigEntry) -> str:
     """Return the issue id naming this entry as one of a duplicate pair."""
     return f"duplicate_entry_{entry.entry_id}"
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, entry: SolarfocusConfigEntry, device: dr.DeviceEntry
+) -> bool:
+    """Let the user delete a device of a component their system does not have.
+
+    A component that is still configured is refused: deleting it would only
+    have it built again on the next load, with a new device the user has to
+    put back in its area.
+    """
+    return device.identifiers.isdisjoint(expected_device_identifiers(entry))
+
+
+@callback
+def _async_remove_gone_components(
+    hass: HomeAssistant, entry: SolarfocusConfigEntry
+) -> None:
+    """Remove the devices of components this entry no longer has.
+
+    Lowering a count from four to two leaves two devices behind. Nothing takes
+    them away on their own: they still name a config entry that exists, so the
+    registry keeps them, and with them every entity that was on them - reading
+    the value it held when the component was last polled.
+
+    Removing the device is what removes those entities; the entity registry
+    takes them with it.
+    """
+    registry = dr.async_get(hass)
+    expected = expected_device_identifiers(entry)
+
+    for device in dr.async_entries_for_config_entry(registry, entry.entry_id):
+        if not device.identifiers.isdisjoint(expected):
+            continue
+
+        _LOGGER.debug(
+            "Removing device %s, its component is not configured any more",
+            device.name,
+        )
+        registry.async_remove_device(device.id)
+
+
+@callback
+def _async_hub_device(
+    hass: HomeAssistant, entry: SolarfocusConfigEntry, api: SolarfocusAPI
+) -> dr.DeviceEntry:
+    """Register the controller every component of this entry hangs off.
+
+    This is the device the entry has had all along - same identifier, so an
+    existing installation keeps the one it has, with the area it is in and the
+    name the user gave it, and the components appear underneath it rather than
+    beside it.
+
+    It is registered here rather than left to an entity, because a component
+    device points at it by device id, which is only known once it exists.
+    """
+    return dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.entry_id)},
+        name="Solarfocus",
+        model=api.system.value,
+        sw_version=api.api_version.value,
+        manufacturer=MANUFACTURER,
+    )
 
 
 @callback

--- a/custom_components/solarfocus/__init__.py
+++ b/custom_components/solarfocus/__init__.py
@@ -101,11 +101,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -
             translation_placeholders={"address": address},
         ) from coordinator.last_exception
 
-    coordinator.hub_device_id = _async_hub_device(hass, entry, api).id
+    hub = _async_hub_device(hass, entry, api)
+    coordinator.hub_device_id = hub.id
     entry.runtime_data = coordinator
+
+    await _async_align_solar_unique_ids(hass, entry)
+
+    known = {
+        device.id
+        for device in dr.async_entries_for_config_entry(
+            dr.async_get(hass), entry.entry_id
+        )
+    }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    _async_inherit_the_hub_area(hass, entry, hub, known)
     _async_remove_gone_components(hass, entry)
 
     # Registers update listener to update config entry when options are updated.
@@ -202,6 +213,80 @@ async def async_remove_config_entry_device(
     put back in its area.
     """
     return device.identifiers.isdisjoint(expected_device_identifiers(entry))
+
+
+async def _async_align_solar_unique_ids(
+    hass: HomeAssistant, entry: SolarfocusConfigEntry
+) -> None:
+    """Follow the one solar circuit that is keyed without its index.
+
+    A single solar circuit keeps the unnumbered key it had before there could
+    be four of them - `so_collector_temperature_1`, not `so1_...` - so raising
+    the count to two renames every one of its entities, and lowering it back
+    renames them again. Left alone, the set under the other key stays in the
+    registry as entities that will never be written to again, on a device that
+    is still configured and so is never removed with them.
+
+    Renaming rather than removing: it is the same reading of the same circuit,
+    and the entity keeps its id, its history and anything the user set on it.
+    """
+    count = solar_count(entry)
+    if not count:
+        # No solar at all: the device is not expected, and it takes its
+        # entities with it when it goes.
+        return
+
+    old, new = ("so_", "so1_") if count > 1 else ("so1_", "so_")
+    prefix = f"{entry.title}_"
+    registry = er.async_get(hass)
+    taken = {registered.unique_id for registered in registry.entities.values()}
+
+    @callback
+    def _renamed(registered: er.RegistryEntry) -> dict[str, str] | None:
+        if not registered.unique_id.startswith(prefix + old):
+            return None
+
+        renamed = prefix + new + registered.unique_id[len(prefix + old) :]
+        if renamed in taken:
+            # Both sets exist, which takes a migration that stopped halfway.
+            # The one under the key in use is the one being written to.
+            return None
+
+        return {"new_unique_id": renamed}
+
+    await er.async_migrate_entries(hass, entry.entry_id, _renamed)
+
+
+@callback
+def _async_inherit_the_hub_area(
+    hass: HomeAssistant,
+    entry: SolarfocusConfigEntry,
+    hub: dr.DeviceEntry,
+    known: set[str],
+) -> None:
+    """Put a component device in the area its controller is in.
+
+    Everything of an entry used to be on one device, so a user who put that
+    device in a room put every entity of their heating system in it. Splitting
+    the components off would have taken all of them out again: a new device is
+    in no area, and an automation or a voice command scoped to a room stops
+    matching entities that are in none.
+
+    Only devices that were not there before this load, which on the first load
+    after the split is all of them. A device the user has since moved somewhere
+    else, or deliberately taken out of an area, is not one of those and is left
+    alone.
+    """
+    if hub.area_id is None:
+        return
+
+    registry = dr.async_get(hass)
+
+    for device in dr.async_entries_for_config_entry(registry, entry.entry_id):
+        if device.id in known or device.area_id is not None:
+            continue
+
+        registry.async_update_device(device.id, area_id=hub.area_id)
 
 
 @callback

--- a/custom_components/solarfocus/binary_sensor.py
+++ b/custom_components/solarfocus/binary_sensor.py
@@ -17,10 +17,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import (
     BIOMASS_BOILER_COMPONENT,
     BIOMASS_BOILER_COMPONENT_PREFIX,
-    BIOMASS_BOILER_PREFIX,
     BUFFER_COMPONENT,
     BUFFER_COMPONENT_PREFIX,
-    BUFFER_PREFIX,
     CONF_BIOMASS_BOILER,
     CONF_BUFFER,
     CONF_FRESH_WATER_MODULE,
@@ -29,16 +27,12 @@ from .const import (
     CONF_PHOTOVOLTAIC,
     FRESH_WATER_MODULE_COMPONENT,
     FRESH_WATER_MODULE_COMPONENT_PREFIX,
-    FRESH_WATER_MODULE_PREFIX,
     HEAT_PUMP_COMPONENT,
     HEAT_PUMP_COMPONENT_PREFIX,
-    HEAT_PUMP_PREFIX,
     HEATING_CIRCUIT_COMPONENT,
     HEATING_CIRCUIT_COMPONENT_PREFIX,
-    HEATING_CIRCUIT_PREFIX,
     PHOTOVOLTAIC_COMPONENT,
     PHOTOVOLTAIC_COMPONENT_PREFIX,
-    PHOTOVOLTAIC_PREFIX,
 )
 from .coordinator import SolarfocusConfigEntry
 from .entity import (
@@ -67,8 +61,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_HEATING_CIRCUIT]):
         for description in HEATING_CIRCUIT_BINARY_SENSOR_TYPES:
             _description = create_description(
-                HEATING_CIRCUIT_PREFIX,
-                HEATING_CIRCUIT_COMPONENT,
+                                HEATING_CIRCUIT_COMPONENT,
                 HEATING_CIRCUIT_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -80,8 +73,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_BUFFER]):
         for description in BUFFER_BINARY_SENSOR_TYPES:
             _description = create_description(
-                BUFFER_PREFIX,
-                BUFFER_COMPONENT,
+                                BUFFER_COMPONENT,
                 BUFFER_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -93,8 +85,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_HEATPUMP]:
         for description in HEATPUMP_BINARY_SENSOR_TYPES:
             _description = create_description(
-                HEAT_PUMP_PREFIX,
-                HEAT_PUMP_COMPONENT,
+                                HEAT_PUMP_COMPONENT,
                 HEAT_PUMP_COMPONENT_PREFIX,
                 "",
                 description,
@@ -106,8 +97,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_BIOMASS_BOILER]:
         for description in BIOMASS_BOILER_BINARY_SENSOR_TYPES:
             _description = create_description(
-                BIOMASS_BOILER_PREFIX,
-                BIOMASS_BOILER_COMPONENT,
+                                BIOMASS_BOILER_COMPONENT,
                 BIOMASS_BOILER_COMPONENT_PREFIX,
                 "",
                 description,
@@ -119,8 +109,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_PHOTOVOLTAIC]:
         for description in PHOTOVOLTAIC_BINARY_SENSOR_TYPES:
             _description = create_description(
-                PHOTOVOLTAIC_PREFIX,
-                PHOTOVOLTAIC_COMPONENT,
+                                PHOTOVOLTAIC_COMPONENT,
                 PHOTOVOLTAIC_COMPONENT_PREFIX,
                 "",
                 description,
@@ -132,8 +121,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_FRESH_WATER_MODULE]):
         for description in FRESH_WATER_MODULE_BINARY_SENSOR_TYPES:
             _description = create_description(
-                FRESH_WATER_MODULE_PREFIX,
-                FRESH_WATER_MODULE_COMPONENT,
+                                FRESH_WATER_MODULE_COMPONENT,
                 FRESH_WATER_MODULE_COMPONENT_PREFIX,
                 str(i + 1),
                 description,

--- a/custom_components/solarfocus/button.py
+++ b/custom_components/solarfocus/button.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import BOILER_COMPONENT, BOILER_COMPONENT_PREFIX, BOILER_PREFIX, CONF_BOILER
+from .const import BOILER_COMPONENT, BOILER_COMPONENT_PREFIX, CONF_BOILER
 from .coordinator import SolarfocusConfigEntry
 from .entity import (
     SolarfocusEntity,
@@ -43,8 +43,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_BOILER]):
         for description in BOILER_BUTTON_TYPES:
             _description = create_description(
-                BOILER_PREFIX,
-                BOILER_COMPONENT,
+                                BOILER_COMPONENT,
                 BOILER_COMPONENT_PREFIX,
                 str(i + 1),
                 description,

--- a/custom_components/solarfocus/climate.py
+++ b/custom_components/solarfocus/climate.py
@@ -24,7 +24,6 @@ from .const import (
     CONF_HEATING_CIRCUIT,
     HEATING_CIRCUIT_COMPONENT,
     HEATING_CIRCUIT_COMPONENT_PREFIX,
-    HEATING_CIRCUIT_PREFIX,
 )
 from .coordinator import SolarfocusConfigEntry
 from .entity import SolarfocusEntity, SolarfocusEntityDescription, create_description
@@ -102,8 +101,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_HEATING_CIRCUIT]):
         for description in CLIMATE_TYPES:
             _description = create_description(
-                HEATING_CIRCUIT_PREFIX,
-                HEATING_CIRCUIT_COMPONENT,
+                                HEATING_CIRCUIT_COMPONENT,
                 HEATING_CIRCUIT_COMPONENT_PREFIX,
                 str(i + 1),
                 description,

--- a/custom_components/solarfocus/const.py
+++ b/custom_components/solarfocus/const.py
@@ -58,6 +58,26 @@ FRESH_WATER_MODULE_PREFIX = "Fresh water module"
 FRESH_WATER_MODULE_COMPONENT = "fresh_water_modules"
 FRESH_WATER_MODULE_COMPONENT_PREFIX = "fm"
 
+MANUFACTURER = "Solarfocus"
+
+# The device the entities of a component belong to, keyed by the prefix every
+# entity description already carries: the key its name is translated under, and
+# the model shown on its device page - a heating circuit has no model of its own
+# to report, and a device page with nothing on it says less than the word.
+COMPONENT_DEVICES: dict[str, tuple[str, str]] = {
+    HEATING_CIRCUIT_COMPONENT_PREFIX: (CONF_HEATING_CIRCUIT, HEATING_CIRCUIT_PREFIX),
+    BUFFER_COMPONENT_PREFIX: (CONF_BUFFER, BUFFER_PREFIX),
+    BOILER_COMPONENT_PREFIX: (CONF_BOILER, BOILER_PREFIX),
+    FRESH_WATER_MODULE_COMPONENT_PREFIX: (
+        CONF_FRESH_WATER_MODULE,
+        FRESH_WATER_MODULE_PREFIX,
+    ),
+    SOLAR_COMPONENT_PREFIX: (CONF_SOLAR, SOLAR_PREFIX),
+    HEAT_PUMP_COMPONENT_PREFIX: (CONF_HEATPUMP, HEAT_PUMP_PREFIX),
+    PHOTOVOLTAIC_COMPONENT_PREFIX: (CONF_PHOTOVOLTAIC, PHOTOVOLTAIC_PREFIX),
+    BIOMASS_BOILER_COMPONENT_PREFIX: (CONF_BIOMASS_BOILER, BIOMASS_BOILER_PREFIX),
+}
+
 """Version from which several solar circuits exist"""
 MULTI_SOLAR_MIN_VERSION = "25.030"
 
@@ -91,3 +111,39 @@ def build_unique_id(host: str, port: int) -> str:
     it is reached at is the only thing telling two installations apart.
     """
     return f"{host}:{port}"
+
+
+def expected_device_identifiers(entry: ConfigEntry) -> set[tuple[str, str]]:
+    """Return the devices this entry should have, the controller included.
+
+    What a user configures is how many of each component their heating system
+    has, so lowering a count is what makes a device stale. There is nothing in
+    the registry that says which those are - a device of a component that is
+    gone looks exactly like one of a component that is there - so the set is
+    built from the configuration and everything outside it is stale.
+    """
+    counted = {
+        HEATING_CIRCUIT_COMPONENT_PREFIX: entry.options[CONF_HEATING_CIRCUIT],
+        BUFFER_COMPONENT_PREFIX: entry.options[CONF_BUFFER],
+        BOILER_COMPONENT_PREFIX: entry.options[CONF_BOILER],
+        FRESH_WATER_MODULE_COMPONENT_PREFIX: entry.options[CONF_FRESH_WATER_MODULE],
+        # The count the library was built with, not the one the options hold
+        SOLAR_COMPONENT_PREFIX: solar_count(entry),
+    }
+    once = {
+        HEAT_PUMP_COMPONENT_PREFIX: entry.options[CONF_HEATPUMP],
+        PHOTOVOLTAIC_COMPONENT_PREFIX: entry.options[CONF_PHOTOVOLTAIC],
+        BIOMASS_BOILER_COMPONENT_PREFIX: entry.options[CONF_BIOMASS_BOILER],
+    }
+
+    identifiers = {(DOMAIN, entry.entry_id)}
+    for prefix, count in counted.items():
+        identifiers |= {
+            (DOMAIN, f"{entry.entry_id}_{prefix}{index + 1}")
+            for index in range(int(count))
+        }
+    identifiers |= {
+        (DOMAIN, f"{entry.entry_id}_{prefix}") for prefix, on in once.items() if on
+    }
+
+    return identifiers

--- a/custom_components/solarfocus/coordinator.py
+++ b/custom_components/solarfocus/coordinator.py
@@ -48,6 +48,11 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator):
         self._entry = entry
         self.hass = hass
         self._failed_components: set[str] = set()
+        # The controller every component device of this entry hangs off, set by
+        # `async_setup_entry` once the device is registered. A component device
+        # points at it by id rather than by identifier, which Home Assistant
+        # deprecates.
+        self.hub_device_id: str | None = None
 
         super().__init__(
             hass,

--- a/custom_components/solarfocus/entity.py
+++ b/custom_components/solarfocus/entity.py
@@ -35,13 +35,16 @@ class SolarfocusEntityDescription(EntityDescription):
 
 
 def create_description(
-    name_prefix: str,
     component: str,
     prefix: str,
     idx: str,
     description: SolarfocusEntityDescription,
 ) -> SolarfocusEntityDescription:
-    """Create Description."""
+    """Return a copy of a description, bound to one instance of a component.
+
+    The display name of the component is not needed here any more: the device
+    an entity sits on carries it, and the name of the device is translated.
+    """
     _description = copy.copy(description)
 
     _description.item = description.key

--- a/custom_components/solarfocus/entity.py
+++ b/custom_components/solarfocus/entity.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_API_VERSION
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
 
-from .const import CONF_SOLARFOCUS_SYSTEM, DOMAIN
+from .const import COMPONENT_DEVICES, CONF_SOLARFOCUS_SYSTEM, DOMAIN, MANUFACTURER
 from .coordinator import SolarfocusDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,6 +28,8 @@ class SolarfocusEntityDescription(EntityDescription):
     component_prefix: str | None = None
     component_idx: str | None = None
     object_id_name: str | None = None
+    # The index as a device name shows it, " 1" or blank - see `create_description`
+    device_idx: str = ""
     min_required_version: str = "21.140"
     unsupported_systems: list[Systems] | None = None
 
@@ -50,21 +52,20 @@ def create_description(
     # The name the user reads is not built here any more. `has_entity_name` makes
     # it the name of the entity, and a name built from the key is English
     # whatever language Home Assistant is in, so it comes from the translation of
-    # `translation_key` instead. The index is the one part of it that is not in
-    # the key - `hc_supply_temperature` is the same for every heating circuit -
-    # so it is passed as a placeholder for the translation to put back.
-    # The space belongs to the placeholder: a single solar circuit keeps the
-    # unnumbered name it has always had, and `format` does not tidy up after
-    # an empty one.
-    _description.translation_placeholders = {"idx": f" {idx}" if idx else ""}
+    # `translation_key` instead.
+    #
+    # The index is not in the entity name either. It belongs to the device the
+    # entity is on - `Supply temperature` on `Heating circuit 2` - so it is
+    # carried here for the device name to put back. The space belongs to it: a
+    # single solar circuit keeps the unnumbered name it has always had, and
+    # `format` does not tidy up after an empty placeholder.
+    _description.device_idx = f" {idx}" if idx else ""
 
-    # The entity id is still built from it, though. Home Assistant derives one
-    # from the name in the user's own language where that language is written in
-    # latin script, German among them, so translating the name alone would have
-    # renamed every entity of a German installation - and only the ones added
-    # from then on, since the ones in the registry keep the id they were given.
-    _name = name_prefix + " " + idx + " " + description.key.replace("_", " ")
-    _description.object_id_name = " ".join(_name.split())
+    # What the entity id is built from. Home Assistant composes it out of the
+    # name of the device and this, so the component and the index are not in it
+    # either - the device supplies both. The words of the key rather than the
+    # translated name, so this half of the id stays English in every language.
+    _description.object_id_name = description.key.replace("_", " ")
 
     _description.key = "".join(
         filter(
@@ -120,6 +121,7 @@ class SolarfocusEntity(Entity):
     _attr_should_poll = True
     has_entity_name = True
 
+
     def __init__(
         self,
         coordinator: SolarfocusDataUpdateCoordinator,
@@ -132,24 +134,43 @@ class SolarfocusEntity(Entity):
         self._state = None
         self.entity_description = description
 
+
     @property
     def device_info(self) -> DeviceInfo:
-        """Return info for device registry.
+        """Return the component this entity belongs to, as its own device.
 
-        The entry id identifies the device, not the title of the entry. A title
-        is something a user renames, and renaming one used to leave the device
-        behind and build a second one next to it, with the area, the name and
-        every automation pointing at the one that was left.
+        Every heating circuit, buffer, boiler, fresh water module and solar
+        circuit is a device, as are the heat pump, the photovoltaic and the
+        biomass boiler, and all of them hang off the controller. What that buys
+        is an area per component, a page per component instead of one page
+        holding every entity of a heating system, and a name the index has been
+        lifted out of - `Top temperature` on `Buffer 1`, rather than
+        `Buffer 1 Top temperature` on `Solarfocus`.
 
-        The entity `unique_id` below is still built from the title. That is the
-        other half of the same problem and a migration of its own, see #208.
+        The identifier of a component is always indexed, `..._so1` even where
+        the name says only `Solar`, so raising the count of a component renames
+        its first device rather than orphaning it.
+
+        The entity `unique_id` is still built from the title of the entry. That
+        is the other half of the rename problem and a migration of its own, see
+        #212.
         """
+        description = self.entity_description
+        translation_key, model = COMPONENT_DEVICES[description.component_prefix]
+
         return DeviceInfo(
-            identifiers={(DOMAIN, self._entry_id)},
-            name="Solarfocus",
-            model=self.coordinator.api.system.value,
-            sw_version=self.coordinator.api.api_version.value,
-            manufacturer="Solarfocus",
+            identifiers={
+                (DOMAIN, f"{self._entry_id}_{description.component_prefix}"
+                 f"{description.component_idx or ''}")
+            },
+            translation_key=translation_key,
+            # Blank for the components that exist once, and for the single
+            # solar circuit that keeps the unnumbered name it had before there
+            # could be four of them.
+            translation_placeholders={"idx": description.device_idx},
+            model=model,
+            manufacturer=MANUFACTURER,
+            via_device_id=self.coordinator.hub_device_id,
         )
 
     @property
@@ -171,13 +192,14 @@ class SolarfocusEntity(Entity):
 
     @property
     def suggested_object_id(self) -> str | None:
-        """Return the name the entity id is built from.
+        """Return the entity half of the entity id.
 
-        Home Assistant builds it from the translated name otherwise, in every
-        language it generates native entity ids for. The name is what the
-        translations are for; the id is what dashboards, automations and every
-        answer ever given in an issue are written against, so it stays the
-        English one it has always been.
+        Home Assistant composes an id out of the name of the device and this,
+        honouring whatever the installation has configured an id to be made of.
+        The device half is translated like any device name; this half is the
+        words of the key, so the part that names the reading stays English in
+        every language - `sensor.heizkreis_1_supply_temperature`, never
+        `..._vorlauftemperatur`.
         """
         return self.entity_description.object_id_name
 

--- a/custom_components/solarfocus/manifest.json
+++ b/custom_components/solarfocus/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/lavermanjj/home-assistant-solarfocus/issues",
   "requirements": ["pysolarfocus==5.2.2"],
   "ssdp": [],
-  "version": "6.0.0-rc1",
+  "version": "6.0.0-rc2",
   "zeroconf": []
 }

--- a/custom_components/solarfocus/number.py
+++ b/custom_components/solarfocus/number.py
@@ -18,16 +18,13 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import (
     BOILER_COMPONENT,
     BOILER_COMPONENT_PREFIX,
-    BOILER_PREFIX,
     CONF_BOILER,
     CONF_HEATING_CIRCUIT,
     CONF_PHOTOVOLTAIC,
     HEATING_CIRCUIT_COMPONENT,
     HEATING_CIRCUIT_COMPONENT_PREFIX,
-    HEATING_CIRCUIT_PREFIX,
     PHOTOVOLTAIC_COMPONENT,
     PHOTOVOLTAIC_COMPONENT_PREFIX,
-    PHOTOVOLTAIC_PREFIX,
 )
 from .coordinator import SolarfocusConfigEntry
 from .entity import (
@@ -58,8 +55,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_HEATING_CIRCUIT]):
         for description in HEATING_CIRCUIT_NUMBER_TYPES:
             _description = create_description(
-                HEATING_CIRCUIT_PREFIX,
-                HEATING_CIRCUIT_COMPONENT,
+                                HEATING_CIRCUIT_COMPONENT,
                 HEATING_CIRCUIT_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -71,8 +67,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_BOILER]):
         for description in BOILER_NUMBER_TYPES:
             _description = create_description(
-                BOILER_PREFIX,
-                BOILER_COMPONENT,
+                                BOILER_COMPONENT,
                 BOILER_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -84,8 +79,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_PHOTOVOLTAIC]:
         for description in PHOTOVOLTAIC_NUMBER_TYPES:
             _description = create_description(
-                PHOTOVOLTAIC_PREFIX,
-                PHOTOVOLTAIC_COMPONENT,
+                                PHOTOVOLTAIC_COMPONENT,
                 PHOTOVOLTAIC_COMPONENT_PREFIX,
                 "",
                 description,

--- a/custom_components/solarfocus/quality_scale.yaml
+++ b/custom_components/solarfocus/quality_scale.yaml
@@ -77,11 +77,7 @@ rules:
   docs-supported-functions: done
   docs-troubleshooting: done
   docs-use-cases: done
-  dynamic-devices:
-    status: exempt
-    comment: |
-      One device per config entry, and its components are chosen by the user
-      rather than found, so nothing appears after setup.
+  dynamic-devices: done
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done
@@ -90,10 +86,7 @@ rules:
   icon-translations: done
   reconfiguration-flow: done
   repair-issues: done
-  stale-devices:
-    status: exempt
-    comment: |
-      The one device of an entry is removed with the entry.
+  stale-devices: done
 
   # Platinum
   async-dependency:

--- a/custom_components/solarfocus/select.py
+++ b/custom_components/solarfocus/select.py
@@ -14,16 +14,13 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import (
     BOILER_COMPONENT,
     BOILER_COMPONENT_PREFIX,
-    BOILER_PREFIX,
     CONF_BOILER,
     CONF_HEATING_CIRCUIT,
     CONF_HEATPUMP,
     HEAT_PUMP_COMPONENT,
     HEAT_PUMP_COMPONENT_PREFIX,
-    HEAT_PUMP_PREFIX,
     HEATING_CIRCUIT_COMPONENT,
     HEATING_CIRCUIT_COMPONENT_PREFIX,
-    HEATING_CIRCUIT_PREFIX,
 )
 from .coordinator import SolarfocusConfigEntry
 from .entity import (
@@ -54,8 +51,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_HEATING_CIRCUIT]):
         for description in HEATING_CIRCUIT_SELECT_TYPES:
             _description = create_description(
-                HEATING_CIRCUIT_PREFIX,
-                HEATING_CIRCUIT_COMPONENT,
+                                HEATING_CIRCUIT_COMPONENT,
                 HEATING_CIRCUIT_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -67,8 +63,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_BOILER]):
         for description in BOILER_SELECT_TYPES:
             _description = create_description(
-                BOILER_PREFIX,
-                BOILER_COMPONENT,
+                                BOILER_COMPONENT,
                 BOILER_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -80,8 +75,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_HEATPUMP]:
         for description in HEATPUMP_SELECT_TYPES:
             _description = create_description(
-                HEAT_PUMP_PREFIX,
-                HEAT_PUMP_COMPONENT,
+                                HEAT_PUMP_COMPONENT,
                 HEAT_PUMP_COMPONENT_PREFIX,
                 "",
                 description,

--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -191,14 +191,10 @@ async def async_setup_entry(
                 )
 
                 if count == 1:
-                    # One solar circuit keeps the unnumbered name, entity id and
-                    # key it had before there could be four of them. The index
-                    # stays on the description, the library addresses the
-                    # component with it.
-                    _description.translation_placeholders = {"idx": ""}
-                    _description.object_id_name = _description.object_id_name.replace(
-                        " 1 ", " "
-                    )
+                    # One solar circuit keeps the unnumbered name and key it had
+                    # before there could be four of them. The index stays on the
+                    # description, the library addresses the component with it.
+                    _description.device_idx = ""
                     _description.key = _description.key.replace("so1_", "so_")
 
                 entity = SolarfocusSensor(coordinator, _description)

--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -27,13 +27,10 @@ from homeassistant.core import HomeAssistant
 from .const import (
     BIOMASS_BOILER_COMPONENT,
     BIOMASS_BOILER_COMPONENT_PREFIX,
-    BIOMASS_BOILER_PREFIX,
     BOILER_COMPONENT,
     BOILER_COMPONENT_PREFIX,
-    BOILER_PREFIX,
     BUFFER_COMPONENT,
     BUFFER_COMPONENT_PREFIX,
-    BUFFER_PREFIX,
     CONF_BIOMASS_BOILER,
     CONF_BOILER,
     CONF_BUFFER,
@@ -44,19 +41,14 @@ from .const import (
     CONF_SOLAR,
     FRESH_WATER_MODULE_COMPONENT,
     FRESH_WATER_MODULE_COMPONENT_PREFIX,
-    FRESH_WATER_MODULE_PREFIX,
     HEAT_PUMP_COMPONENT,
     HEAT_PUMP_COMPONENT_PREFIX,
-    HEAT_PUMP_PREFIX,
     HEATING_CIRCUIT_COMPONENT,
     HEATING_CIRCUIT_COMPONENT_PREFIX,
-    HEATING_CIRCUIT_PREFIX,
     PHOTOVOLTAIC_COMPONENT,
     PHOTOVOLTAIC_COMPONENT_PREFIX,
-    PHOTOVOLTAIC_PREFIX,
     SOLAR_COMPONENT,
     SOLAR_COMPONENT_PREFIX,
-    SOLAR_PREFIX,
     solar_count,
 )
 from .coordinator import SolarfocusConfigEntry, SolarfocusDataUpdateCoordinator
@@ -98,8 +90,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_HEATING_CIRCUIT]):
         for description in HEATING_CIRCUIT_SENSOR_TYPES:
             _description = create_description(
-                HEATING_CIRCUIT_PREFIX,
-                HEATING_CIRCUIT_COMPONENT,
+                                HEATING_CIRCUIT_COMPONENT,
                 HEATING_CIRCUIT_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -111,8 +102,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_BOILER]):
         for description in BOILER_SENSOR_TYPES:
             _description = create_description(
-                BOILER_PREFIX,
-                BOILER_COMPONENT,
+                                BOILER_COMPONENT,
                 BOILER_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -124,8 +114,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_BUFFER]):
         for description in BUFFER_SENSOR_TYPES:
             _description = create_description(
-                BUFFER_PREFIX,
-                BUFFER_COMPONENT,
+                                BUFFER_COMPONENT,
                 BUFFER_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -137,8 +126,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_HEATPUMP]:
         for description in HEATPUMP_SENSOR_TYPES:
             _description = create_description(
-                HEAT_PUMP_PREFIX,
-                HEAT_PUMP_COMPONENT,
+                                HEAT_PUMP_COMPONENT,
                 HEAT_PUMP_COMPONENT_PREFIX,
                 "",
                 description,
@@ -150,8 +138,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_BIOMASS_BOILER]:
         for description in BIOMASS_BOILER_SENSOR_TYPES:
             _description = create_description(
-                BIOMASS_BOILER_PREFIX,
-                BIOMASS_BOILER_COMPONENT,
+                                BIOMASS_BOILER_COMPONENT,
                 BIOMASS_BOILER_COMPONENT_PREFIX,
                 "",
                 description,
@@ -163,8 +150,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_PHOTOVOLTAIC]:
         for description in PHOTOVOLTAIC_SENSOR_TYPES:
             _description = create_description(
-                PHOTOVOLTAIC_PREFIX,
-                PHOTOVOLTAIC_COMPONENT,
+                                PHOTOVOLTAIC_COMPONENT,
                 PHOTOVOLTAIC_COMPONENT_PREFIX,
                 "",
                 description,
@@ -183,8 +169,7 @@ async def async_setup_entry(
                 # But for single instance, don't show the number in the entity name
                 idx = str(i + 1)
                 _description = create_description(
-                    SOLAR_PREFIX,
-                    SOLAR_COMPONENT,
+                                        SOLAR_COMPONENT,
                     SOLAR_COMPONENT_PREFIX,
                     idx,
                     description,
@@ -203,8 +188,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_FRESH_WATER_MODULE]):
         for description in FRESH_WATER_MODULE_SENSOR_TYPES:
             _description = create_description(
-                FRESH_WATER_MODULE_PREFIX,
-                FRESH_WATER_MODULE_COMPONENT,
+                                FRESH_WATER_MODULE_COMPONENT,
                 FRESH_WATER_MODULE_COMPONENT_PREFIX,
                 str(i + 1),
                 description,

--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -130,47 +130,47 @@
   "entity": {
     "binary_sensor": {
       "bb_door_contact": {
-        "name": "Biomass boiler door contact"
+        "name": "Door contact"
       },
       "bu_pump": {
-        "name": "Buffer{idx} pump"
+        "name": "Pump"
       },
       "fm_valve": {
-        "name": "Fresh water module{idx} valve"
+        "name": "Valve"
       },
       "hc_circulator_pump": {
-        "name": "Heating circuit{idx} circulator pump"
+        "name": "Circulator pump"
       },
       "hc_limit_thermostat": {
-        "name": "Heating circuit{idx} limit thermostat"
+        "name": "Limit thermostat"
       },
       "hp_boiler_charge": {
-        "name": "Heat pump boiler charge"
+        "name": "Boiler charge"
       },
       "hp_defrost_active": {
-        "name": "Heat pump defrost active"
+        "name": "Defrost active"
       },
       "hp_evu_lock_active": {
-        "name": "Heat pump evu lock active"
+        "name": "Evu lock active"
       },
       "pv_overcharge_active": {
-        "name": "Photovoltaic overcharge active"
+        "name": "Overcharge active"
       },
       "pv_overcharge_possible": {
-        "name": "Photovoltaic overcharge possible"
+        "name": "Overcharge possible"
       }
     },
     "button": {
       "bo_circulation": {
-        "name": "Boiler{idx} circulation"
+        "name": "Circulation"
       },
       "bo_single_charge": {
-        "name": "Boiler{idx} single charge"
+        "name": "Single charge"
       }
     },
     "climate": {
       "hc_thermostat": {
-        "name": "Heating circuit{idx} thermostat",
+        "name": "Thermostat",
         "state_attributes": {
           "preset_mode": {
             "state": {
@@ -185,36 +185,36 @@
     },
     "number": {
       "bo_target_temperature": {
-        "name": "Boiler{idx} target temperature"
+        "name": "Target temperature"
       },
       "hc_indoor_humidity_external": {
-        "name": "Heating circuit{idx} indoor humidity external"
+        "name": "Indoor humidity external"
       },
       "hc_indoor_temperature_external": {
-        "name": "Heating circuit{idx} indoor temperature external"
+        "name": "Indoor temperature external"
       },
       "hc_target_room_temperature": {
-        "name": "Heating circuit{idx} target room temperature"
+        "name": "Target room temperature"
       },
       "hc_target_supply_temperature": {
-        "name": "Heating circuit{idx} target supply temperature"
+        "name": "Target supply temperature"
       },
       "pv_grid_im_export": {
-        "name": "Photovoltaic grid im export"
+        "name": "Grid im export"
       },
       "pv_hems_target_electrical_power": {
-        "name": "Photovoltaic hems target electrical power"
+        "name": "Hems target electrical power"
       },
       "pv_photovoltaic": {
-        "name": "Photovoltaic photovoltaic"
+        "name": "Photovoltaic"
       },
       "pv_smart_meter": {
-        "name": "Photovoltaic smart meter"
+        "name": "Smart meter"
       }
     },
     "select": {
       "bo_holding_mode": {
-        "name": "Boiler{idx} holding mode",
+        "name": "Holding mode",
         "state": {
           "0": "Always off",
           "1": "Always on",
@@ -224,14 +224,14 @@
         }
       },
       "hc_cooling": {
-        "name": "Heating circuit{idx} cooling",
+        "name": "Cooling",
         "state": {
           "0": "Heating",
           "1": "Cooling"
         }
       },
       "hc_heating_mode": {
-        "name": "Heating circuit{idx} heating mode",
+        "name": "Heating mode",
         "state": {
           "0": "Heating",
           "1": "Cooling",
@@ -239,7 +239,7 @@
         }
       },
       "hc_mode": {
-        "name": "Heating circuit{idx} mode",
+        "name": "Mode",
         "state": {
           "0": "Continuous operation",
           "1": "Reduced operation",
@@ -248,7 +248,7 @@
         }
       },
       "hp_smart_grid": {
-        "name": "Heat pump smart grid",
+        "name": "Smart grid",
         "state": {
           "0": "Deactivated",
           "1": "No operation",
@@ -260,10 +260,10 @@
     },
     "sensor": {
       "bb_ash_container": {
-        "name": "Biomass boiler ash container"
+        "name": "Ash container"
       },
       "bb_boiler_operating_mode": {
-        "name": "Biomass boiler boiler operating mode",
+        "name": "Boiler operating mode",
         "state": {
           "0": "Log wood",
           "1": "Log wood automatic",
@@ -274,20 +274,20 @@
         }
       },
       "bb_cleaning": {
-        "name": "Biomass boiler cleaning"
+        "name": "Cleaning"
       },
       "bb_heat_energy_total": {
-        "name": "Biomass boiler heat energy total"
+        "name": "Heat energy total"
       },
       "bb_log_wood": {
-        "name": "Biomass boiler log wood",
+        "name": "Log wood",
         "state": {
           "0": "Begin to heat log wood / putting more wood not required / possible",
           "1": "More Log wood can be put on the fire"
         }
       },
       "bb_message_number": {
-        "name": "Biomass boiler message number",
+        "name": "Message number",
         "state": {
           "0": "No Message",
           "1": "Internal memory is invalid",
@@ -413,22 +413,22 @@
         }
       },
       "bb_octoplus_buffer_temperature_bottom": {
-        "name": "Biomass boiler octoplus buffer temperature bottom"
+        "name": "Octoplus buffer temperature bottom"
       },
       "bb_octoplus_buffer_temperature_top": {
-        "name": "Biomass boiler octoplus buffer temperature top"
+        "name": "Octoplus buffer temperature top"
       },
       "bb_outdoor_temperature": {
-        "name": "Biomass boiler outdoor temperature"
+        "name": "Outdoor temperature"
       },
       "bb_pellet_usage_last_fill": {
-        "name": "Biomass boiler pellet usage last fill"
+        "name": "Pellet usage last fill"
       },
       "bb_pellet_usage_total": {
-        "name": "Biomass boiler pellet usage total"
+        "name": "Pellet usage total"
       },
       "bb_status": {
-        "name": "Biomass boiler status",
+        "name": "Status",
         "state": {
           "0": "Standby",
           "1": "Ignition phase",
@@ -577,10 +577,10 @@
         }
       },
       "bb_temperature": {
-        "name": "Biomass boiler temperature"
+        "name": "Temperature"
       },
       "bo_circulation": {
-        "name": "Boiler{idx} circulation",
+        "name": "Circulation",
         "state": {
           "-1": "Locked",
           "0": "Off",
@@ -588,7 +588,7 @@
         }
       },
       "bo_mode": {
-        "name": "Boiler{idx} mode",
+        "name": "Mode",
         "state": {
           "0": "Always Off",
           "1": "Always On",
@@ -598,7 +598,7 @@
         }
       },
       "bo_single_charge": {
-        "name": "Boiler{idx} single charge",
+        "name": "Single charge",
         "state": {
           "-1": "Locked",
           "0": "Off",
@@ -606,7 +606,7 @@
         }
       },
       "bo_state": {
-        "name": "Boiler{idx} state",
+        "name": "State",
         "state": {
           "0": "Boiler state unavailable",
           "1": "Standby",
@@ -638,22 +638,22 @@
         }
       },
       "bo_temperature": {
-        "name": "Boiler{idx} temperature"
+        "name": "Temperature"
       },
       "bu_bottom_temperature": {
-        "name": "Buffer{idx} bottom temperature"
+        "name": "Bottom temperature"
       },
       "bu_external_bottom_temperature_x35": {
-        "name": "Buffer{idx} external bottom temperature x35"
+        "name": "External bottom temperature x35"
       },
       "bu_external_middle_temperature_x36": {
-        "name": "Buffer{idx} external middle temperature x36"
+        "name": "External middle temperature x36"
       },
       "bu_external_top_temperature_x44": {
-        "name": "Buffer{idx} external top temperature x44"
+        "name": "External top temperature x44"
       },
       "bu_mode": {
-        "name": "Buffer{idx} mode",
+        "name": "Mode",
         "state": {
           "0": "Always Off",
           "1": "Always On",
@@ -661,7 +661,7 @@
         }
       },
       "bu_state": {
-        "name": "Buffer{idx} state",
+        "name": "State",
         "state": {
           "0": "State unavailable",
           "1": "Standby",
@@ -683,16 +683,16 @@
         }
       },
       "bu_top_temperature": {
-        "name": "Buffer{idx} top temperature"
+        "name": "Top temperature"
       },
       "bu_x35_temperature": {
-        "name": "Buffer{idx} x35 temperature"
+        "name": "X35 temperature"
       },
       "fm_flow_rate": {
-        "name": "Fresh water module{idx} flow rate"
+        "name": "Flow rate"
       },
       "fm_state": {
-        "name": "Fresh water module{idx} state",
+        "name": "State",
         "state": {
           "0": "Flow sensor not connected",
           "1": "Pump turned off",
@@ -702,22 +702,22 @@
         }
       },
       "fm_supply_temperature": {
-        "name": "Fresh water module{idx} supply temperature"
+        "name": "Supply temperature"
       },
       "fm_target_temperature": {
-        "name": "Fresh water module{idx} target temperature"
+        "name": "Target temperature"
       },
       "hc_humidity": {
-        "name": "Heating circuit{idx} humidity"
+        "name": "Humidity"
       },
       "hc_mixer_valve": {
-        "name": "Heating circuit{idx} mixer valve"
+        "name": "Mixer valve"
       },
       "hc_room_temperature": {
-        "name": "Heating circuit{idx} room temperature"
+        "name": "Room temperature"
       },
       "hc_state": {
-        "name": "Heating circuit{idx} state",
+        "name": "State",
         "state": {
           "0": "Heating is off",
           "1": "Reduced mode",
@@ -782,73 +782,73 @@
         }
       },
       "hc_supply_temperature": {
-        "name": "Heating circuit{idx} supply temperature"
+        "name": "Supply temperature"
       },
       "hp_compressor_speed": {
-        "name": "Heat pump compressor speed"
+        "name": "Compressor speed"
       },
       "hp_cop_cooling": {
-        "name": "Heat pump cop cooling"
+        "name": "Cop cooling"
       },
       "hp_cop_heating": {
-        "name": "Heat pump cop heating"
+        "name": "Cop heating"
       },
       "hp_electrical_energy_cooling": {
-        "name": "Heat pump electrical energy cooling"
+        "name": "Electrical energy cooling"
       },
       "hp_electrical_energy_drinking_water": {
-        "name": "Heat pump electrical energy drinking water"
+        "name": "Electrical energy drinking water"
       },
       "hp_electrical_energy_heating": {
-        "name": "Heat pump electrical energy heating"
+        "name": "Electrical energy heating"
       },
       "hp_electrical_energy_total": {
-        "name": "Heat pump electrical energy total"
+        "name": "Electrical energy total"
       },
       "hp_electrical_power": {
-        "name": "Heat pump electrical power"
+        "name": "Electrical power"
       },
       "hp_flow_rate": {
-        "name": "Heat pump flow rate"
+        "name": "Flow rate"
       },
       "hp_outdoor_temperature": {
-        "name": "Heat pump outdoor temperature"
+        "name": "Outdoor temperature"
       },
       "hp_performance_overall": {
-        "name": "Heat pump performance overall"
+        "name": "Performance overall"
       },
       "hp_performance_overall_drinking_water": {
-        "name": "Heat pump performance overall drinking water"
+        "name": "Performance overall drinking water"
       },
       "hp_performance_overall_heating": {
-        "name": "Heat pump performance overall heating"
+        "name": "Performance overall heating"
       },
       "hp_return_temperature": {
-        "name": "Heat pump return temperature"
+        "name": "Return temperature"
       },
       "hp_supply_temperature": {
-        "name": "Heat pump supply temperature"
+        "name": "Supply temperature"
       },
       "hp_thermal_energy_cooling": {
-        "name": "Heat pump thermal energy cooling"
+        "name": "Thermal energy cooling"
       },
       "hp_thermal_energy_drinking_water": {
-        "name": "Heat pump thermal energy drinking water"
+        "name": "Thermal energy drinking water"
       },
       "hp_thermal_energy_heating": {
-        "name": "Heat pump thermal energy heating"
+        "name": "Thermal energy heating"
       },
       "hp_thermal_energy_total": {
-        "name": "Heat pump thermal energy total"
+        "name": "Thermal energy total"
       },
       "hp_thermal_power_cooling": {
-        "name": "Heat pump thermal power cooling"
+        "name": "Thermal power cooling"
       },
       "hp_thermal_power_heating": {
-        "name": "Heat pump thermal power heating"
+        "name": "Thermal power heating"
       },
       "hp_vampair_state": {
-        "name": "Heat pump vampair state",
+        "name": "Vampair state",
         "state": {
           "0": "Standby",
           "1": "Heating",
@@ -866,52 +866,52 @@
         }
       },
       "pv_grid_export": {
-        "name": "Photovoltaic grid export"
+        "name": "Grid export"
       },
       "pv_grid_import": {
-        "name": "Photovoltaic grid import"
+        "name": "Grid import"
       },
       "pv_heatpump_consumption": {
-        "name": "Photovoltaic heatpump consumption"
+        "name": "Heatpump consumption"
       },
       "pv_house_consumption": {
-        "name": "Photovoltaic house consumption"
+        "name": "House consumption"
       },
       "pv_power": {
-        "name": "Photovoltaic power"
+        "name": "Power"
       },
       "so_buffer_sensor_1": {
-        "name": "Solar{idx} buffer sensor 1"
+        "name": "Buffer sensor 1"
       },
       "so_buffer_sensor_2": {
-        "name": "Solar{idx} buffer sensor 2"
+        "name": "Buffer sensor 2"
       },
       "so_buffer_sensor_3": {
-        "name": "Solar{idx} buffer sensor 3"
+        "name": "Buffer sensor 3"
       },
       "so_collector_return_temperature": {
-        "name": "Solar{idx} collector return temperature"
+        "name": "Collector return temperature"
       },
       "so_collector_supply_temperature": {
-        "name": "Solar{idx} collector supply temperature"
+        "name": "Collector supply temperature"
       },
       "so_collector_temperature_1": {
-        "name": "Solar{idx} collector temperature 1"
+        "name": "Collector temperature 1"
       },
       "so_collector_temperature_2": {
-        "name": "Solar{idx} collector temperature 2"
+        "name": "Collector temperature 2"
       },
       "so_current_power": {
-        "name": "Solar{idx} current power"
+        "name": "Current power"
       },
       "so_current_yield_heat_meter": {
-        "name": "Solar{idx} current yield heat meter"
+        "name": "Current yield heat meter"
       },
       "so_flow_heat_meter": {
-        "name": "Solar{idx} flow heat meter"
+        "name": "Flow heat meter"
       },
       "so_state": {
-        "name": "Solar{idx} state",
+        "name": "State",
         "state": {
           "0": "Solar circuit in operation",
           "1": "Collector sensor short circuit",
@@ -956,18 +956,44 @@
         }
       },
       "so_today_yield": {
-        "name": "Solar{idx} today yield"
+        "name": "Today yield"
       }
     },
     "switch": {
       "hp_evu_lock": {
-        "name": "Heat pump evu lock"
+        "name": "Evu lock"
       }
     },
     "water_heater": {
       "bo_domestic_hot_water": {
-        "name": "Boiler{idx} domestic hot water"
+        "name": "Domestic hot water"
       }
+    }
+  },
+  "device": {
+    "heating_circuit": {
+      "name": "Heating circuit{idx}"
+    },
+    "buffer": {
+      "name": "Buffer{idx}"
+    },
+    "boiler": {
+      "name": "Boiler{idx}"
+    },
+    "fresh_water_module": {
+      "name": "Fresh water module{idx}"
+    },
+    "solar": {
+      "name": "Solar{idx}"
+    },
+    "heatpump": {
+      "name": "Heat pump"
+    },
+    "photovoltaic": {
+      "name": "Photovoltaic"
+    },
+    "biomassboiler": {
+      "name": "Biomass boiler"
     }
   }
 }

--- a/custom_components/solarfocus/switch.py
+++ b/custom_components/solarfocus/switch.py
@@ -12,12 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import (
-    CONF_HEATPUMP,
-    HEAT_PUMP_COMPONENT,
-    HEAT_PUMP_COMPONENT_PREFIX,
-    HEAT_PUMP_PREFIX,
-)
+from .const import CONF_HEATPUMP, HEAT_PUMP_COMPONENT, HEAT_PUMP_COMPONENT_PREFIX
 from .coordinator import SolarfocusConfigEntry
 from .entity import (
     SolarfocusEntity,
@@ -50,8 +45,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_HEATPUMP]:
         for description in HEATPUMP_SWITCH_TYPES:
             _description = create_description(
-                HEAT_PUMP_PREFIX,
-                HEAT_PUMP_COMPONENT,
+                                HEAT_PUMP_COMPONENT,
                 HEAT_PUMP_COMPONENT_PREFIX,
                 "",
                 description,

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -129,47 +129,47 @@
   "entity": {
     "binary_sensor": {
       "bb_door_contact": {
-        "name": "Kessel Türkontakt offen/geschlossen"
+        "name": "Türkontakt offen/geschlossen"
       },
       "bu_pump": {
-        "name": "Pufferspeicher{idx} Ladepumpe"
+        "name": "Ladepumpe"
       },
       "fm_valve": {
-        "name": "Frischwassermodul{idx} Ventilstellung"
+        "name": "Ventilstellung"
       },
       "hc_circulator_pump": {
-        "name": "Heizkreis{idx} Pumpe Ein/Aus"
+        "name": "Pumpe Ein/Aus"
       },
       "hc_limit_thermostat": {
-        "name": "Heizkreis{idx} Begrenzungsthermostat offen/geschlossen"
+        "name": "Begrenzungsthermostat offen/geschlossen"
       },
       "hp_boiler_charge": {
-        "name": "Wärmepumpe Boilerladung"
+        "name": "Boilerladung"
       },
       "hp_defrost_active": {
-        "name": "Wärmepumpe Defrost aktiv"
+        "name": "Defrost aktiv"
       },
       "hp_evu_lock_active": {
-        "name": "Wärmepumpe EVU - Lock aktiv"
+        "name": "EVU - Lock aktiv"
       },
       "pv_overcharge_active": {
-        "name": "Photovoltaik PV-Überladung aktiv"
+        "name": "PV-Überladung aktiv"
       },
       "pv_overcharge_possible": {
-        "name": "Photovoltaik PV Überladung möglich"
+        "name": "PV Überladung möglich"
       }
     },
     "button": {
       "bo_circulation": {
-        "name": "Boiler{idx} Zirkulation anfordern"
+        "name": "Zirkulation anfordern"
       },
       "bo_single_charge": {
-        "name": "Boiler{idx} Einmalladung"
+        "name": "Einmalladung"
       }
     },
     "climate": {
       "hc_thermostat": {
-        "name": "Heizkreis{idx} Thermostat",
+        "name": "Thermostat",
         "state": {
           "off": "Aus",
           "heat": "Heizen",
@@ -204,36 +204,36 @@
     },
     "number": {
       "bo_target_temperature": {
-        "name": "Boiler{idx} Solltemperatur"
+        "name": "Solltemperatur"
       },
       "hc_indoor_humidity_external": {
-        "name": "Heizkreis{idx} Raumfeuchte ist extern"
+        "name": "Raumfeuchte ist extern"
       },
       "hc_indoor_temperature_external": {
-        "name": "Heizkreis{idx} Raumtemperatur Ist extern"
+        "name": "Raumtemperatur Ist extern"
       },
       "hc_target_room_temperature": {
-        "name": "Heizkreis{idx} Raumtemperatur Soll"
+        "name": "Raumtemperatur Soll"
       },
       "hc_target_supply_temperature": {
-        "name": "Heizkreis{idx} Vorlaufsolltemperatur Heizen"
+        "name": "Vorlaufsolltemperatur Heizen"
       },
       "pv_grid_im_export": {
-        "name": "Photovoltaik Netzbezug / Einspeisung"
+        "name": "Netzbezug / Einspeisung"
       },
       "pv_hems_target_electrical_power": {
-        "name": "Photovoltaik Elektrische Sollleistung HEMS"
+        "name": "Elektrische Sollleistung HEMS"
       },
       "pv_photovoltaic": {
-        "name": "Photovoltaik Erzeugte Leistung der PV-Anlage"
+        "name": "Erzeugte Leistung der PV-Anlage"
       },
       "pv_smart_meter": {
-        "name": "Photovoltaik Smart Meter"
+        "name": "Smart Meter"
       }
     },
     "select": {
       "bo_holding_mode": {
-        "name": "Boiler{idx} Freigabeart",
+        "name": "Freigabeart",
         "state": {
           "0": "Immer Aus",
           "1": "Immer Ein",
@@ -243,14 +243,14 @@
         }
       },
       "hc_cooling": {
-        "name": "Heizkreis{idx} Kühlen Ein/Aus",
+        "name": "Kühlen Ein/Aus",
         "state": {
           "0": "Heizen",
           "1": "Kühlen"
         }
       },
       "hc_heating_mode": {
-        "name": "Heizkreis{idx} Modus",
+        "name": "Modus",
         "state": {
           "0": "Heizen",
           "1": "Kühlen",
@@ -258,7 +258,7 @@
         }
       },
       "hc_mode": {
-        "name": "Heizkreis{idx} Betriebsart",
+        "name": "Betriebsart",
         "state": {
           "0": "Dauerbetrieb",
           "1": "Absenkbetrieb",
@@ -267,7 +267,7 @@
         }
       },
       "hp_smart_grid": {
-        "name": "Wärmepumpe Betriebsart SG - Ready",
+        "name": "Betriebsart SG - Ready",
         "state": {
           "0": "Deaktiviert",
           "1": "Gesperrt",
@@ -279,10 +279,10 @@
     },
     "sensor": {
       "bb_ash_container": {
-        "name": "Kessel Ascheboxfüllstand"
+        "name": "Ascheboxfüllstand"
       },
       "bb_boiler_operating_mode": {
-        "name": "Kessel Betriebsart",
+        "name": "Betriebsart",
         "state": {
           "0": "Stückholz",
           "1": "Stückholz Automatik",
@@ -293,20 +293,20 @@
         }
       },
       "bb_cleaning": {
-        "name": "Kessel Reinigung"
+        "name": "Reinigung"
       },
       "bb_heat_energy_total": {
-        "name": "Kessel Produzierte Wärmemenge gesamt"
+        "name": "Produzierte Wärmemenge gesamt"
       },
       "bb_log_wood": {
-        "name": "Kessel Stückholz",
+        "name": "Stückholz",
         "state": {
           "0": "Stückholz anheizen/ nachlegen nicht notwendig/möglich",
           "1": "Stückholz kann angeheizt/ nachgelegt werden"
         }
       },
       "bb_message_number": {
-        "name": "Kessel Nachrichtennummer",
+        "name": "Nachrichtennummer",
         "state": {
           "0": "Keine Meldung",
           "1": "Interner Speicher ist ungültig",
@@ -432,22 +432,22 @@
         }
       },
       "bb_octoplus_buffer_temperature_bottom": {
-        "name": "Kessel octoplus Speichertemperatur unten"
+        "name": "Octoplus Speichertemperatur unten"
       },
       "bb_octoplus_buffer_temperature_top": {
-        "name": "Kessel octoplus Speichertemperatur oben"
+        "name": "Octoplus Speichertemperatur oben"
       },
       "bb_outdoor_temperature": {
-        "name": "Kessel Außentemperatur"
+        "name": "Außentemperatur"
       },
       "bb_pellet_usage_last_fill": {
-        "name": "Kessel Pelletverbrauch seit letzter Lagerraumbefüllung"
+        "name": "Pelletverbrauch seit letzter Lagerraumbefüllung"
       },
       "bb_pellet_usage_total": {
-        "name": "Kessel Pelletverbrauch gesamt"
+        "name": "Pelletverbrauch gesamt"
       },
       "bb_status": {
-        "name": "Kessel Statuszeile",
+        "name": "Statuszeile",
         "state": {
           "0": "Bereitschaft",
           "1": "Zündphase",
@@ -599,10 +599,10 @@
         }
       },
       "bb_temperature": {
-        "name": "Kessel Temperatur"
+        "name": "Temperatur"
       },
       "bo_circulation": {
-        "name": "Boiler{idx} Zirkulation anfordern",
+        "name": "Zirkulation anfordern",
         "state": {
           "-1": "Gesperrt",
           "0": "Aus",
@@ -610,7 +610,7 @@
         }
       },
       "bo_mode": {
-        "name": "Boiler{idx} Freigabeart - Ist",
+        "name": "Freigabeart - Ist",
         "state": {
           "0": "Immer Aus",
           "1": "Immer Ein",
@@ -620,7 +620,7 @@
         }
       },
       "bo_single_charge": {
-        "name": "Boiler{idx} Einmalladung",
+        "name": "Einmalladung",
         "state": {
           "-1": "Gesperrt",
           "0": "Aus",
@@ -628,7 +628,7 @@
         }
       },
       "bo_state": {
-        "name": "Boiler{idx} Status",
+        "name": "Status",
         "state": {
           "0": "Boilerstatus nicht vorhanden",
           "1": "Bereitschaft",
@@ -660,22 +660,22 @@
         }
       },
       "bo_temperature": {
-        "name": "Boiler{idx} Temperatur"
+        "name": "Temperatur"
       },
       "bu_bottom_temperature": {
-        "name": "Pufferspeicher{idx} Temperatur unten"
+        "name": "Temperatur unten"
       },
       "bu_external_bottom_temperature_x35": {
-        "name": "Pufferspeicher{idx} Temperatur unten X35 extern"
+        "name": "Temperatur unten X35 extern"
       },
       "bu_external_middle_temperature_x36": {
-        "name": "Pufferspeicher{idx} Temperatur unten/Mitte X36 extern"
+        "name": "Temperatur unten/Mitte X36 extern"
       },
       "bu_external_top_temperature_x44": {
-        "name": "Pufferspeicher{idx} Temperatur oben X44 extern"
+        "name": "Temperatur oben X44 extern"
       },
       "bu_mode": {
-        "name": "Pufferspeicher{idx} Freigabeart",
+        "name": "Freigabeart",
         "state": {
           "0": "Immer Aus",
           "1": "Immer Ein",
@@ -683,7 +683,7 @@
         }
       },
       "bu_state": {
-        "name": "Pufferspeicher{idx} Status",
+        "name": "Status",
         "state": {
           "0": "Status nicht vorhanden",
           "1": "Bereitschaft",
@@ -705,16 +705,16 @@
         }
       },
       "bu_top_temperature": {
-        "name": "Pufferspeicher{idx} Temperatur oben"
+        "name": "Temperatur oben"
       },
       "bu_x35_temperature": {
-        "name": "Pufferspeicher{idx} Temperatur X35"
+        "name": "Temperatur X35"
       },
       "fm_flow_rate": {
-        "name": "Frischwassermodul{idx} WW-Durchfluss"
+        "name": "WW-Durchfluss"
       },
       "fm_state": {
-        "name": "Frischwassermodul{idx} Statuszeile",
+        "name": "Statuszeile",
         "state": {
           "0": "Vorlauffühler nicht angeschlossen",
           "1": "Pumpe ausgeschaltet",
@@ -724,22 +724,22 @@
         }
       },
       "fm_supply_temperature": {
-        "name": "Frischwassermodul{idx} WW-Vorlauftemperatur"
+        "name": "WW-Vorlauftemperatur"
       },
       "fm_target_temperature": {
-        "name": "Frischwassermodul{idx} WW-Solltemperatur"
+        "name": "WW-Solltemperatur"
       },
       "hc_humidity": {
-        "name": "Heizkreis{idx} Feuchte"
+        "name": "Feuchte"
       },
       "hc_mixer_valve": {
-        "name": "Heizkreis{idx} Mischerstellung"
+        "name": "Mischerstellung"
       },
       "hc_room_temperature": {
-        "name": "Heizkreis{idx} Raumtemperatur"
+        "name": "Raumtemperatur"
       },
       "hc_state": {
-        "name": "Heizkreis{idx} Status",
+        "name": "Status",
         "state": {
           "0": "Heizkreis ist ausgeschaltet",
           "1": "Absenkbetrieb",
@@ -804,73 +804,73 @@
         }
       },
       "hc_supply_temperature": {
-        "name": "Heizkreis{idx} Vorlauftemperatur"
+        "name": "Vorlauftemperatur"
       },
       "hp_compressor_speed": {
-        "name": "Wärmepumpe Kompressordrehzahl"
+        "name": "Kompressordrehzahl"
       },
       "hp_cop_cooling": {
-        "name": "Wärmepumpe Arbeitszahl Kühlung"
+        "name": "Arbeitszahl Kühlung"
       },
       "hp_cop_heating": {
-        "name": "Wärmepumpe Arbeitszahl Heizung"
+        "name": "Arbeitszahl Heizung"
       },
       "hp_electrical_energy_cooling": {
-        "name": "Wärmepumpe el. Energie Kühlung"
+        "name": "El. Energie Kühlung"
       },
       "hp_electrical_energy_drinking_water": {
-        "name": "Wärmepumpe elektr. Energie Trinkwassererwärmung"
+        "name": "Elektr. Energie Trinkwassererwärmung"
       },
       "hp_electrical_energy_heating": {
-        "name": "Wärmepumpe elektr. Energie Heizung"
+        "name": "Elektr. Energie Heizung"
       },
       "hp_electrical_energy_total": {
-        "name": "Wärmepumpe Gesamtenergie elektrisch Heizung + Trinkwassererwärmung"
+        "name": "Gesamtenergie elektrisch Heizung + Trinkwassererwärmung"
       },
       "hp_electrical_power": {
-        "name": "Wärmepumpe aktuell aufgenommene elektr. Leistung"
+        "name": "Aktuell aufgenommene elektr. Leistung"
       },
       "hp_flow_rate": {
-        "name": "Wärmepumpe Durchfluss"
+        "name": "Durchfluss"
       },
       "hp_outdoor_temperature": {
-        "name": "Wärmepumpe Außentemperatur"
+        "name": "Außentemperatur"
       },
       "hp_performance_overall": {
-        "name": "Wärmepumpe Arbeitszahl gesamt"
+        "name": "Arbeitszahl gesamt"
       },
       "hp_performance_overall_drinking_water": {
-        "name": "Wärmepumpe Gesamtarbeitszahl Trinkwassererwärmung"
+        "name": "Gesamtarbeitszahl Trinkwassererwärmung"
       },
       "hp_performance_overall_heating": {
-        "name": "Wärmepumpe Gesamtarbeitszahl Heizung"
+        "name": "Gesamtarbeitszahl Heizung"
       },
       "hp_return_temperature": {
-        "name": "Wärmepumpe Rücklauftemperatur"
+        "name": "Rücklauftemperatur"
       },
       "hp_supply_temperature": {
-        "name": "Wärmepumpe Vorlauftemperatur"
+        "name": "Vorlauftemperatur"
       },
       "hp_thermal_energy_cooling": {
-        "name": "Wärmepumpe thermische Energie Kühlung"
+        "name": "Thermische Energie Kühlung"
       },
       "hp_thermal_energy_drinking_water": {
-        "name": "Wärmepumpe thermische Energie Trinkwassererwärmung"
+        "name": "Thermische Energie Trinkwassererwärmung"
       },
       "hp_thermal_energy_heating": {
-        "name": "Wärmepumpe thermische Energie Heizung"
+        "name": "Thermische Energie Heizung"
       },
       "hp_thermal_energy_total": {
-        "name": "Wärmepumpe Gesamtenergie thermisch Heizung + Trinkwassererwärmung"
+        "name": "Gesamtenergie thermisch Heizung + Trinkwassererwärmung"
       },
       "hp_thermal_power_cooling": {
-        "name": "Wärmepumpe aktuelle thermische Leistung Kühlen"
+        "name": "Aktuelle thermische Leistung Kühlen"
       },
       "hp_thermal_power_heating": {
-        "name": "Wärmepumpe aktuelle thermische Leistung Heizen"
+        "name": "Aktuelle thermische Leistung Heizen"
       },
       "hp_vampair_state": {
-        "name": "Wärmepumpe vampair Status",
+        "name": "Vampair Status",
         "state": {
           "0": "Bereitschaft",
           "1": "Heizbetrieb",
@@ -888,52 +888,52 @@
         }
       },
       "pv_grid_export": {
-        "name": "Photovoltaik Einspeisung"
+        "name": "Einspeisung"
       },
       "pv_grid_import": {
-        "name": "Photovoltaik Netzbezug"
+        "name": "Netzbezug"
       },
       "pv_heatpump_consumption": {
-        "name": "Photovoltaik Verbrauch WP"
+        "name": "Verbrauch WP"
       },
       "pv_house_consumption": {
-        "name": "Photovoltaik Verbrauch"
+        "name": "Verbrauch"
       },
       "pv_power": {
-        "name": "Photovoltaik Leistung PV"
+        "name": "Leistung PV"
       },
       "so_buffer_sensor_1": {
-        "name": "Solar{idx} Speicherfühler 1"
+        "name": "Speicherfühler 1"
       },
       "so_buffer_sensor_2": {
-        "name": "Solar{idx} Speicherfühler 2"
+        "name": "Speicherfühler 2"
       },
       "so_buffer_sensor_3": {
-        "name": "Solar{idx} Speicherfühler 3"
+        "name": "Speicherfühler 3"
       },
       "so_collector_return_temperature": {
-        "name": "Solar{idx} Kollektorrücklauftemperatur"
+        "name": "Kollektorrücklauftemperatur"
       },
       "so_collector_supply_temperature": {
-        "name": "Solar{idx} Kollektorvorlauftemperatur"
+        "name": "Kollektorvorlauftemperatur"
       },
       "so_collector_temperature_1": {
-        "name": "Solar{idx} Kollektortemperatur 1"
+        "name": "Kollektortemperatur 1"
       },
       "so_collector_temperature_2": {
-        "name": "Solar{idx} Kollektortemperatur 2"
+        "name": "Kollektortemperatur 2"
       },
       "so_current_power": {
-        "name": "Solar{idx} aktuelle Leistung"
+        "name": "Aktuelle Leistung"
       },
       "so_current_yield_heat_meter": {
-        "name": "Solar{idx} Ertrag WMZ"
+        "name": "Ertrag WMZ"
       },
       "so_flow_heat_meter": {
-        "name": "Solar{idx} Durchfluss WMZ"
+        "name": "Durchfluss WMZ"
       },
       "so_state": {
-        "name": "Solar{idx} Statuszeile",
+        "name": "Statuszeile",
         "state": {
           "0": "Solarkreis in Betrieb",
           "201": "Kollektorfühler Kurzschluss!",
@@ -978,18 +978,44 @@
         }
       },
       "so_today_yield": {
-        "name": "Solar{idx} Tagesertrag"
+        "name": "Tagesertrag"
       }
     },
     "switch": {
       "hp_evu_lock": {
-        "name": "Wärmepumpe EVU - Lock"
+        "name": "EVU - Lock"
       }
     },
     "water_heater": {
       "bo_domestic_hot_water": {
-        "name": "Boiler{idx} Warmwasser"
+        "name": "Warmwasser"
       }
+    }
+  },
+  "device": {
+    "heating_circuit": {
+      "name": "Heizkreis{idx}"
+    },
+    "buffer": {
+      "name": "Pufferspeicher{idx}"
+    },
+    "boiler": {
+      "name": "Boiler{idx}"
+    },
+    "fresh_water_module": {
+      "name": "Frischwassermodul{idx}"
+    },
+    "solar": {
+      "name": "Solar{idx}"
+    },
+    "heatpump": {
+      "name": "Wärmepumpe"
+    },
+    "photovoltaic": {
+      "name": "Photovoltaik"
+    },
+    "biomassboiler": {
+      "name": "Kessel"
     }
   }
 }

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -130,47 +130,47 @@
   "entity": {
     "binary_sensor": {
       "bb_door_contact": {
-        "name": "Biomass boiler door contact"
+        "name": "Door contact"
       },
       "bu_pump": {
-        "name": "Buffer{idx} pump"
+        "name": "Pump"
       },
       "fm_valve": {
-        "name": "Fresh water module{idx} valve"
+        "name": "Valve"
       },
       "hc_circulator_pump": {
-        "name": "Heating circuit{idx} circulator pump"
+        "name": "Circulator pump"
       },
       "hc_limit_thermostat": {
-        "name": "Heating circuit{idx} limit thermostat"
+        "name": "Limit thermostat"
       },
       "hp_boiler_charge": {
-        "name": "Heat pump boiler charge"
+        "name": "Boiler charge"
       },
       "hp_defrost_active": {
-        "name": "Heat pump defrost active"
+        "name": "Defrost active"
       },
       "hp_evu_lock_active": {
-        "name": "Heat pump evu lock active"
+        "name": "Evu lock active"
       },
       "pv_overcharge_active": {
-        "name": "Photovoltaic overcharge active"
+        "name": "Overcharge active"
       },
       "pv_overcharge_possible": {
-        "name": "Photovoltaic overcharge possible"
+        "name": "Overcharge possible"
       }
     },
     "button": {
       "bo_circulation": {
-        "name": "Boiler{idx} circulation"
+        "name": "Circulation"
       },
       "bo_single_charge": {
-        "name": "Boiler{idx} single charge"
+        "name": "Single charge"
       }
     },
     "climate": {
       "hc_thermostat": {
-        "name": "Heating circuit{idx} thermostat",
+        "name": "Thermostat",
         "state_attributes": {
           "preset_mode": {
             "state": {
@@ -185,36 +185,36 @@
     },
     "number": {
       "bo_target_temperature": {
-        "name": "Boiler{idx} target temperature"
+        "name": "Target temperature"
       },
       "hc_indoor_humidity_external": {
-        "name": "Heating circuit{idx} indoor humidity external"
+        "name": "Indoor humidity external"
       },
       "hc_indoor_temperature_external": {
-        "name": "Heating circuit{idx} indoor temperature external"
+        "name": "Indoor temperature external"
       },
       "hc_target_room_temperature": {
-        "name": "Heating circuit{idx} target room temperature"
+        "name": "Target room temperature"
       },
       "hc_target_supply_temperature": {
-        "name": "Heating circuit{idx} target supply temperature"
+        "name": "Target supply temperature"
       },
       "pv_grid_im_export": {
-        "name": "Photovoltaic grid im export"
+        "name": "Grid im export"
       },
       "pv_hems_target_electrical_power": {
-        "name": "Photovoltaic hems target electrical power"
+        "name": "Hems target electrical power"
       },
       "pv_photovoltaic": {
-        "name": "Photovoltaic photovoltaic"
+        "name": "Photovoltaic"
       },
       "pv_smart_meter": {
-        "name": "Photovoltaic smart meter"
+        "name": "Smart meter"
       }
     },
     "select": {
       "bo_holding_mode": {
-        "name": "Boiler{idx} holding mode",
+        "name": "Holding mode",
         "state": {
           "0": "Always off",
           "1": "Always on",
@@ -224,14 +224,14 @@
         }
       },
       "hc_cooling": {
-        "name": "Heating circuit{idx} cooling",
+        "name": "Cooling",
         "state": {
           "0": "Heating",
           "1": "Cooling"
         }
       },
       "hc_heating_mode": {
-        "name": "Heating circuit{idx} heating mode",
+        "name": "Heating mode",
         "state": {
           "0": "Heating",
           "1": "Cooling",
@@ -239,7 +239,7 @@
         }
       },
       "hc_mode": {
-        "name": "Heating circuit{idx} mode",
+        "name": "Mode",
         "state": {
           "0": "Continuous operation",
           "1": "Reduced operation",
@@ -248,7 +248,7 @@
         }
       },
       "hp_smart_grid": {
-        "name": "Heat pump smart grid",
+        "name": "Smart grid",
         "state": {
           "0": "Deactivated",
           "1": "No operation",
@@ -260,10 +260,10 @@
     },
     "sensor": {
       "bb_ash_container": {
-        "name": "Biomass boiler ash container"
+        "name": "Ash container"
       },
       "bb_boiler_operating_mode": {
-        "name": "Biomass boiler boiler operating mode",
+        "name": "Boiler operating mode",
         "state": {
           "0": "Log wood",
           "1": "Log wood automatic",
@@ -274,20 +274,20 @@
         }
       },
       "bb_cleaning": {
-        "name": "Biomass boiler cleaning"
+        "name": "Cleaning"
       },
       "bb_heat_energy_total": {
-        "name": "Biomass boiler heat energy total"
+        "name": "Heat energy total"
       },
       "bb_log_wood": {
-        "name": "Biomass boiler log wood",
+        "name": "Log wood",
         "state": {
           "0": "Begin to heat log wood / putting more wood not required / possible",
           "1": "More Log wood can be put on the fire"
         }
       },
       "bb_message_number": {
-        "name": "Biomass boiler message number",
+        "name": "Message number",
         "state": {
           "0": "No Message",
           "1": "Internal memory is invalid",
@@ -413,22 +413,22 @@
         }
       },
       "bb_octoplus_buffer_temperature_bottom": {
-        "name": "Biomass boiler octoplus buffer temperature bottom"
+        "name": "Octoplus buffer temperature bottom"
       },
       "bb_octoplus_buffer_temperature_top": {
-        "name": "Biomass boiler octoplus buffer temperature top"
+        "name": "Octoplus buffer temperature top"
       },
       "bb_outdoor_temperature": {
-        "name": "Biomass boiler outdoor temperature"
+        "name": "Outdoor temperature"
       },
       "bb_pellet_usage_last_fill": {
-        "name": "Biomass boiler pellet usage last fill"
+        "name": "Pellet usage last fill"
       },
       "bb_pellet_usage_total": {
-        "name": "Biomass boiler pellet usage total"
+        "name": "Pellet usage total"
       },
       "bb_status": {
-        "name": "Biomass boiler status",
+        "name": "Status",
         "state": {
           "0": "Standby",
           "1": "Ignition phase",
@@ -577,10 +577,10 @@
         }
       },
       "bb_temperature": {
-        "name": "Biomass boiler temperature"
+        "name": "Temperature"
       },
       "bo_circulation": {
-        "name": "Boiler{idx} circulation",
+        "name": "Circulation",
         "state": {
           "-1": "Locked",
           "0": "Off",
@@ -588,7 +588,7 @@
         }
       },
       "bo_mode": {
-        "name": "Boiler{idx} mode",
+        "name": "Mode",
         "state": {
           "0": "Always Off",
           "1": "Always On",
@@ -598,7 +598,7 @@
         }
       },
       "bo_single_charge": {
-        "name": "Boiler{idx} single charge",
+        "name": "Single charge",
         "state": {
           "-1": "Locked",
           "0": "Off",
@@ -606,7 +606,7 @@
         }
       },
       "bo_state": {
-        "name": "Boiler{idx} state",
+        "name": "State",
         "state": {
           "0": "Boiler state unavailable",
           "1": "Standby",
@@ -638,22 +638,22 @@
         }
       },
       "bo_temperature": {
-        "name": "Boiler{idx} temperature"
+        "name": "Temperature"
       },
       "bu_bottom_temperature": {
-        "name": "Buffer{idx} bottom temperature"
+        "name": "Bottom temperature"
       },
       "bu_external_bottom_temperature_x35": {
-        "name": "Buffer{idx} external bottom temperature x35"
+        "name": "External bottom temperature x35"
       },
       "bu_external_middle_temperature_x36": {
-        "name": "Buffer{idx} external middle temperature x36"
+        "name": "External middle temperature x36"
       },
       "bu_external_top_temperature_x44": {
-        "name": "Buffer{idx} external top temperature x44"
+        "name": "External top temperature x44"
       },
       "bu_mode": {
-        "name": "Buffer{idx} mode",
+        "name": "Mode",
         "state": {
           "0": "Always Off",
           "1": "Always On",
@@ -661,7 +661,7 @@
         }
       },
       "bu_state": {
-        "name": "Buffer{idx} state",
+        "name": "State",
         "state": {
           "0": "State unavailable",
           "1": "Standby",
@@ -683,16 +683,16 @@
         }
       },
       "bu_top_temperature": {
-        "name": "Buffer{idx} top temperature"
+        "name": "Top temperature"
       },
       "bu_x35_temperature": {
-        "name": "Buffer{idx} x35 temperature"
+        "name": "X35 temperature"
       },
       "fm_flow_rate": {
-        "name": "Fresh water module{idx} flow rate"
+        "name": "Flow rate"
       },
       "fm_state": {
-        "name": "Fresh water module{idx} state",
+        "name": "State",
         "state": {
           "0": "Flow sensor not connected",
           "1": "Pump turned off",
@@ -702,22 +702,22 @@
         }
       },
       "fm_supply_temperature": {
-        "name": "Fresh water module{idx} supply temperature"
+        "name": "Supply temperature"
       },
       "fm_target_temperature": {
-        "name": "Fresh water module{idx} target temperature"
+        "name": "Target temperature"
       },
       "hc_humidity": {
-        "name": "Heating circuit{idx} humidity"
+        "name": "Humidity"
       },
       "hc_mixer_valve": {
-        "name": "Heating circuit{idx} mixer valve"
+        "name": "Mixer valve"
       },
       "hc_room_temperature": {
-        "name": "Heating circuit{idx} room temperature"
+        "name": "Room temperature"
       },
       "hc_state": {
-        "name": "Heating circuit{idx} state",
+        "name": "State",
         "state": {
           "0": "Heating is off",
           "1": "Reduced mode",
@@ -782,73 +782,73 @@
         }
       },
       "hc_supply_temperature": {
-        "name": "Heating circuit{idx} supply temperature"
+        "name": "Supply temperature"
       },
       "hp_compressor_speed": {
-        "name": "Heat pump compressor speed"
+        "name": "Compressor speed"
       },
       "hp_cop_cooling": {
-        "name": "Heat pump cop cooling"
+        "name": "Cop cooling"
       },
       "hp_cop_heating": {
-        "name": "Heat pump cop heating"
+        "name": "Cop heating"
       },
       "hp_electrical_energy_cooling": {
-        "name": "Heat pump electrical energy cooling"
+        "name": "Electrical energy cooling"
       },
       "hp_electrical_energy_drinking_water": {
-        "name": "Heat pump electrical energy drinking water"
+        "name": "Electrical energy drinking water"
       },
       "hp_electrical_energy_heating": {
-        "name": "Heat pump electrical energy heating"
+        "name": "Electrical energy heating"
       },
       "hp_electrical_energy_total": {
-        "name": "Heat pump electrical energy total"
+        "name": "Electrical energy total"
       },
       "hp_electrical_power": {
-        "name": "Heat pump electrical power"
+        "name": "Electrical power"
       },
       "hp_flow_rate": {
-        "name": "Heat pump flow rate"
+        "name": "Flow rate"
       },
       "hp_outdoor_temperature": {
-        "name": "Heat pump outdoor temperature"
+        "name": "Outdoor temperature"
       },
       "hp_performance_overall": {
-        "name": "Heat pump performance overall"
+        "name": "Performance overall"
       },
       "hp_performance_overall_drinking_water": {
-        "name": "Heat pump performance overall drinking water"
+        "name": "Performance overall drinking water"
       },
       "hp_performance_overall_heating": {
-        "name": "Heat pump performance overall heating"
+        "name": "Performance overall heating"
       },
       "hp_return_temperature": {
-        "name": "Heat pump return temperature"
+        "name": "Return temperature"
       },
       "hp_supply_temperature": {
-        "name": "Heat pump supply temperature"
+        "name": "Supply temperature"
       },
       "hp_thermal_energy_cooling": {
-        "name": "Heat pump thermal energy cooling"
+        "name": "Thermal energy cooling"
       },
       "hp_thermal_energy_drinking_water": {
-        "name": "Heat pump thermal energy drinking water"
+        "name": "Thermal energy drinking water"
       },
       "hp_thermal_energy_heating": {
-        "name": "Heat pump thermal energy heating"
+        "name": "Thermal energy heating"
       },
       "hp_thermal_energy_total": {
-        "name": "Heat pump thermal energy total"
+        "name": "Thermal energy total"
       },
       "hp_thermal_power_cooling": {
-        "name": "Heat pump thermal power cooling"
+        "name": "Thermal power cooling"
       },
       "hp_thermal_power_heating": {
-        "name": "Heat pump thermal power heating"
+        "name": "Thermal power heating"
       },
       "hp_vampair_state": {
-        "name": "Heat pump vampair state",
+        "name": "Vampair state",
         "state": {
           "0": "Standby",
           "1": "Heating",
@@ -866,52 +866,52 @@
         }
       },
       "pv_grid_export": {
-        "name": "Photovoltaic grid export"
+        "name": "Grid export"
       },
       "pv_grid_import": {
-        "name": "Photovoltaic grid import"
+        "name": "Grid import"
       },
       "pv_heatpump_consumption": {
-        "name": "Photovoltaic heatpump consumption"
+        "name": "Heatpump consumption"
       },
       "pv_house_consumption": {
-        "name": "Photovoltaic house consumption"
+        "name": "House consumption"
       },
       "pv_power": {
-        "name": "Photovoltaic power"
+        "name": "Power"
       },
       "so_buffer_sensor_1": {
-        "name": "Solar{idx} buffer sensor 1"
+        "name": "Buffer sensor 1"
       },
       "so_buffer_sensor_2": {
-        "name": "Solar{idx} buffer sensor 2"
+        "name": "Buffer sensor 2"
       },
       "so_buffer_sensor_3": {
-        "name": "Solar{idx} buffer sensor 3"
+        "name": "Buffer sensor 3"
       },
       "so_collector_return_temperature": {
-        "name": "Solar{idx} collector return temperature"
+        "name": "Collector return temperature"
       },
       "so_collector_supply_temperature": {
-        "name": "Solar{idx} collector supply temperature"
+        "name": "Collector supply temperature"
       },
       "so_collector_temperature_1": {
-        "name": "Solar{idx} collector temperature 1"
+        "name": "Collector temperature 1"
       },
       "so_collector_temperature_2": {
-        "name": "Solar{idx} collector temperature 2"
+        "name": "Collector temperature 2"
       },
       "so_current_power": {
-        "name": "Solar{idx} current power"
+        "name": "Current power"
       },
       "so_current_yield_heat_meter": {
-        "name": "Solar{idx} current yield heat meter"
+        "name": "Current yield heat meter"
       },
       "so_flow_heat_meter": {
-        "name": "Solar{idx} flow heat meter"
+        "name": "Flow heat meter"
       },
       "so_state": {
-        "name": "Solar{idx} state",
+        "name": "State",
         "state": {
           "0": "Solar circuit in operation",
           "1": "Collector sensor short circuit",
@@ -956,18 +956,44 @@
         }
       },
       "so_today_yield": {
-        "name": "Solar{idx} today yield"
+        "name": "Today yield"
       }
     },
     "switch": {
       "hp_evu_lock": {
-        "name": "Heat pump evu lock"
+        "name": "Evu lock"
       }
     },
     "water_heater": {
       "bo_domestic_hot_water": {
-        "name": "Boiler{idx} domestic hot water"
+        "name": "Domestic hot water"
       }
+    }
+  },
+  "device": {
+    "heating_circuit": {
+      "name": "Heating circuit{idx}"
+    },
+    "buffer": {
+      "name": "Buffer{idx}"
+    },
+    "boiler": {
+      "name": "Boiler{idx}"
+    },
+    "fresh_water_module": {
+      "name": "Fresh water module{idx}"
+    },
+    "solar": {
+      "name": "Solar{idx}"
+    },
+    "heatpump": {
+      "name": "Heat pump"
+    },
+    "photovoltaic": {
+      "name": "Photovoltaic"
+    },
+    "biomassboiler": {
+      "name": "Biomass boiler"
     }
   }
 }

--- a/custom_components/solarfocus/water_heater.py
+++ b/custom_components/solarfocus/water_heater.py
@@ -18,7 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import BOILER_COMPONENT, BOILER_COMPONENT_PREFIX, BOILER_PREFIX, CONF_BOILER
+from .const import BOILER_COMPONENT, BOILER_COMPONENT_PREFIX, CONF_BOILER
 from .coordinator import SolarfocusConfigEntry
 from .entity import SolarfocusEntity, SolarfocusEntityDescription, create_description
 
@@ -70,8 +70,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_BOILER]):
         for description in WATER_HEATER_TYPES:
             _description = create_description(
-                BOILER_PREFIX,
-                BOILER_COMPONENT,
+                                BOILER_COMPONENT,
                 BOILER_COMPONENT_PREFIX,
                 str(i + 1),
                 description,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "solarfocus"
-version = "6.0.0rc1"
+version = "6.0.0rc2"
 description = "Custom component for integrating Solarfocus heating systems into Home Assistant."
 authors = [{ name = "Jeroen Laverman", email = "jjlaverman@web.de" }]
 requires-python = ">=3.14.2,<3.15"

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -484,7 +484,7 @@ async def test_the_thermostat_restores_its_setpoint_from_storage(
         hass,
         (
             (
-                State("climate.solarfocus_heating_circuit_1_thermostat", HVACMode.OFF),
+                State("climate.heating_circuit_1_thermostat", HVACMode.OFF),
                 {"target_temperatures": {"heat": 41.5}, "active_mode": "heat"},
             ),
         ),

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -82,8 +82,7 @@ def build_climate(
     entity = SolarfocusClimateEntity(
         build_coordinator(build_config_entry(), api),
         create_description(
-            HEATING_CIRCUIT_PREFIX,
-            HEATING_CIRCUIT_COMPONENT,
+                        HEATING_CIRCUIT_COMPONENT,
             HEATING_CIRCUIT_COMPONENT_PREFIX,
             "1",
             CLIMATE_TYPES[0],

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -7,7 +7,6 @@ These tests pin the mapping down for one entity of every platform.
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from pysolarfocus import ApiVersions, Systems
 import pytest
 
 from custom_components.solarfocus.binary_sensor import (
@@ -22,6 +21,7 @@ from custom_components.solarfocus.const import (
     BOILER_COMPONENT,
     BOILER_COMPONENT_PREFIX,
     BOILER_PREFIX,
+    CONF_BOILER,
     DOMAIN,
     HEAT_PUMP_COMPONENT,
     HEAT_PUMP_COMPONENT_PREFIX,
@@ -29,6 +29,7 @@ from custom_components.solarfocus.const import (
     HEATING_CIRCUIT_COMPONENT,
     HEATING_CIRCUIT_COMPONENT_PREFIX,
     HEATING_CIRCUIT_PREFIX,
+    MANUFACTURER,
 )
 from custom_components.solarfocus.entity import create_description
 from custom_components.solarfocus.number import (
@@ -103,31 +104,54 @@ def test_unique_id_combines_the_device_name_and_the_key() -> None:
     assert entity.translation_key == f"bo_{BOILER_SENSOR_TYPES[0].key}"
 
 
-def test_device_info_describes_the_heating_system() -> None:
-    """All entities belong to a single device, identified by the entry id.
+def test_device_info_puts_the_entity_on_its_own_component() -> None:
+    """A boiler entity belongs to a boiler, not to the whole heating system.
 
-    The title of the entry identified it until version 9, which is why renaming
-    an entry built a second device beside the first.
+    The identifier is always indexed, `..._bo1`, even where the name of the
+    device drops the index - so raising the count of a component renames its
+    first device rather than orphaning it.
     """
     entry = build_config_entry()
+    coordinator = build_coordinator(entry)
+    coordinator.hub_device_id = "hub"
     entity = SolarfocusSensor(
-        build_coordinator(entry),
+        coordinator,
         create_description(
             BOILER_PREFIX,
             BOILER_COMPONENT,
             BOILER_COMPONENT_PREFIX,
-            "1",
+            "2",
             BOILER_SENSOR_TYPES[0],
         ),
     )
 
     device_info = entity.device_info
 
-    assert device_info["identifiers"] == {(DOMAIN, entry.entry_id)}
-    assert entry.entry_id != entry.title
-    assert device_info["manufacturer"] == "Solarfocus"
-    assert device_info["model"] == Systems.VAMPAIR.value
-    assert device_info["sw_version"] == ApiVersions.V_23_020.value
+    assert device_info["identifiers"] == {(DOMAIN, f"{entry.entry_id}_bo2")}
+    assert device_info["translation_key"] == CONF_BOILER
+    assert device_info["translation_placeholders"] == {"idx": " 2"}
+    assert device_info["model"] == BOILER_PREFIX
+    assert device_info["manufacturer"] == MANUFACTURER
+    # Every component hangs off the controller
+    assert device_info["via_device_id"] == "hub"
+
+
+def test_a_component_that_exists_once_is_not_numbered() -> None:
+    """There is one heat pump, so its device is `Heat pump`, not `Heat pump 1`."""
+    coordinator = build_coordinator(build_config_entry())
+    coordinator.hub_device_id = "hub"
+    entity = SolarfocusSwitchEntity(
+        coordinator,
+        create_description(
+            HEAT_PUMP_PREFIX,
+            HEAT_PUMP_COMPONENT,
+            HEAT_PUMP_COMPONENT_PREFIX,
+            "",
+            HEATPUMP_SWITCH_TYPES[0],
+        ),
+    )
+
+    assert entity.device_info["translation_placeholders"] == {"idx": ""}
 
 
 def test_device_info_values_are_strings() -> None:
@@ -147,7 +171,7 @@ def test_device_info_values_are_strings() -> None:
 
     device_info = entity.device_info
 
-    for field in ("name", "model", "sw_version", "manufacturer"):
+    for field in ("model", "manufacturer"):
         assert isinstance(device_info[field], str), (
             f"{field} is {type(device_info[field]).__name__}, not str"
         )

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -25,10 +25,8 @@ from custom_components.solarfocus.const import (
     DOMAIN,
     HEAT_PUMP_COMPONENT,
     HEAT_PUMP_COMPONENT_PREFIX,
-    HEAT_PUMP_PREFIX,
     HEATING_CIRCUIT_COMPONENT,
     HEATING_CIRCUIT_COMPONENT_PREFIX,
-    HEATING_CIRCUIT_PREFIX,
     MANUFACTURER,
 )
 from custom_components.solarfocus.entity import create_description
@@ -63,12 +61,12 @@ from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, UnitOfTemperature
 from .conftest import build_config_entry, build_coordinator
 
 
-def _make(entity_class, description, prefix, component, component_prefix, idx="1"):
+def _make(entity_class, description, component, component_prefix, idx="1"):
     """Create an entity of the given class on a mocked coordinator."""
     coordinator = build_coordinator(build_config_entry())
     entity = entity_class(
         coordinator,
-        create_description(prefix, component, component_prefix, idx, description),
+        create_description(component, component_prefix, idx, description),
     )
     entity.async_write_ha_state = MagicMock()
     return entity
@@ -80,7 +78,6 @@ def boiler_water_heater_fixture() -> SolarfocusWaterHeaterEntity:
     return _make(
         SolarfocusWaterHeaterEntity,
         WATER_HEATER_TYPES[0],
-        BOILER_PREFIX,
         BOILER_COMPONENT,
         BOILER_COMPONENT_PREFIX,
         idx="2",
@@ -95,7 +92,6 @@ def test_unique_id_combines_the_device_name_and_the_key() -> None:
     entity = _make(
         SolarfocusSensor,
         BOILER_SENSOR_TYPES[0],
-        BOILER_PREFIX,
         BOILER_COMPONENT,
         BOILER_COMPONENT_PREFIX,
     )
@@ -117,8 +113,7 @@ def test_device_info_puts_the_entity_on_its_own_component() -> None:
     entity = SolarfocusSensor(
         coordinator,
         create_description(
-            BOILER_PREFIX,
-            BOILER_COMPONENT,
+                        BOILER_COMPONENT,
             BOILER_COMPONENT_PREFIX,
             "2",
             BOILER_SENSOR_TYPES[0],
@@ -143,8 +138,7 @@ def test_a_component_that_exists_once_is_not_numbered() -> None:
     entity = SolarfocusSwitchEntity(
         coordinator,
         create_description(
-            HEAT_PUMP_PREFIX,
-            HEAT_PUMP_COMPONENT,
+                        HEAT_PUMP_COMPONENT,
             HEAT_PUMP_COMPONENT_PREFIX,
             "",
             HEATPUMP_SWITCH_TYPES[0],
@@ -164,7 +158,6 @@ def test_device_info_values_are_strings() -> None:
     entity = _make(
         SolarfocusSensor,
         BOILER_SENSOR_TYPES[0],
-        BOILER_PREFIX,
         BOILER_COMPONENT,
         BOILER_COMPONENT_PREFIX,
     )
@@ -182,7 +175,6 @@ def test_entity_is_unavailable_after_a_failed_update() -> None:
     entity = _make(
         SolarfocusSensor,
         BOILER_SENSOR_TYPES[0],
-        BOILER_PREFIX,
         BOILER_COMPONENT,
         BOILER_COMPONENT_PREFIX,
     )
@@ -199,7 +191,6 @@ def test_indexed_components_are_addressed_by_position() -> None:
     entity = _make(
         SolarfocusSensor,
         BOILER_SENSOR_TYPES[0],
-        BOILER_PREFIX,
         BOILER_COMPONENT,
         BOILER_COMPONENT_PREFIX,
         idx="3",
@@ -216,7 +207,6 @@ def test_components_without_an_index_are_read_directly() -> None:
     entity = _make(
         SolarfocusSwitchEntity,
         HEATPUMP_SWITCH_TYPES[0],
-        HEAT_PUMP_PREFIX,
         HEAT_PUMP_COMPONENT,
         HEAT_PUMP_COMPONENT_PREFIX,
         idx="",
@@ -231,7 +221,6 @@ async def test_async_update_requests_a_coordinator_refresh() -> None:
     entity = _make(
         SolarfocusSensor,
         BOILER_SENSOR_TYPES[0],
-        BOILER_PREFIX,
         BOILER_COMPONENT,
         BOILER_COMPONENT_PREFIX,
     )
@@ -247,7 +236,6 @@ async def test_entity_follows_the_coordinator_while_added() -> None:
     entity = _make(
         SolarfocusSensor,
         BOILER_SENSOR_TYPES[0],
-        BOILER_PREFIX,
         BOILER_COMPONENT,
         BOILER_COMPONENT_PREFIX,
     )
@@ -273,7 +261,6 @@ def test_sensor_reports_the_component_value() -> None:
     entity = _make(
         SolarfocusSensor,
         description,
-        BOILER_PREFIX,
         BOILER_COMPONENT,
         BOILER_COMPONENT_PREFIX,
     )
@@ -296,7 +283,6 @@ def test_binary_sensor_compares_against_its_on_state(
     entity = _make(
         SolarfocusBinarySensorEntity,
         SolarfocusBinarySensorEntityDescription(key="pump", on_state=on_state),
-        HEATING_CIRCUIT_PREFIX,
         HEATING_CIRCUIT_COMPONENT,
         HEATING_CIRCUIT_COMPONENT_PREFIX,
     )
@@ -313,7 +299,6 @@ async def test_number_writes_the_value() -> None:
     entity = _make(
         SolarfocusNumberEntity,
         BOILER_NUMBER_TYPES[0],
-        BOILER_PREFIX,
         BOILER_COMPONENT,
         BOILER_COMPONENT_PREFIX,
     )
@@ -329,7 +314,6 @@ def test_number_reads_the_value() -> None:
     entity = _make(
         SolarfocusNumberEntity,
         BOILER_NUMBER_TYPES[0],
-        BOILER_PREFIX,
         BOILER_COMPONENT,
         BOILER_COMPONENT_PREFIX,
     )
@@ -346,7 +330,6 @@ async def test_select_writes_and_reports_the_option() -> None:
     entity = _make(
         SolarfocusSelectEntity,
         HEATPUMP_SELECT_TYPES[0],
-        HEAT_PUMP_PREFIX,
         HEAT_PUMP_COMPONENT,
         HEAT_PUMP_COMPONENT_PREFIX,
         idx="",
@@ -371,7 +354,6 @@ async def test_switch_turns_the_lock_on_and_off() -> None:
     entity = _make(
         SolarfocusSwitchEntity,
         HEATPUMP_SWITCH_TYPES[0],
-        HEAT_PUMP_PREFIX,
         HEAT_PUMP_COMPONENT,
         HEAT_PUMP_COMPONENT_PREFIX,
         idx="",
@@ -392,7 +374,6 @@ def test_switch_reports_its_state() -> None:
     entity = _make(
         SolarfocusSwitchEntity,
         HEATPUMP_SWITCH_TYPES[0],
-        HEAT_PUMP_PREFIX,
         HEAT_PUMP_COMPONENT,
         HEAT_PUMP_COMPONENT_PREFIX,
         idx="",
@@ -416,7 +397,6 @@ async def test_button_triggers_its_item(description) -> None:
     entity = _make(
         SolarfocusButtonEntity,
         description,
-        BOILER_PREFIX,
         BOILER_COMPONENT,
         BOILER_COMPONENT_PREFIX,
     )
@@ -522,7 +502,6 @@ def test_set_native_value_writes_and_refreshes_the_component() -> None:
     entity = _make(
         SolarfocusNumberEntity,
         BOILER_NUMBER_TYPES[0],
-        BOILER_PREFIX,
         BOILER_COMPONENT,
         BOILER_COMPONENT_PREFIX,
     )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,7 +6,11 @@ from pysolarfocus import ApiVersions, Systems
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.solarfocus import async_migrate_entry, async_reload_entry
+from custom_components.solarfocus import (
+    async_migrate_entry,
+    async_reload_entry,
+    async_remove_config_entry_device,
+)
 from custom_components.solarfocus.const import (
     CONF_BIOMASS_BOILER,
     CONF_BOILER,
@@ -761,8 +765,9 @@ async def test_a_renamed_entry_keeps_its_device(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
+    hub = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
     before = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
-    assert len(before) == 1
+    assert hub is not None
 
     hass.config_entries.async_update_entry(entry, title="Heizung Keller")
     await hass.async_block_till_done()
@@ -770,8 +775,10 @@ async def test_a_renamed_entry_keeps_its_device(
     await hass.async_block_till_done()
 
     after = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
-    assert len(after) == 1
-    assert after[0].id == before[0].id
+
+    # The same hub, and the same components under it - a rename adds nothing
+    assert device_registry.async_get_device({(DOMAIN, entry.entry_id)}).id == hub.id
+    assert {device.id for device in after} == {device.id for device in before}
 
 
 async def test_a_renamed_entry_still_duplicates_its_entities(
@@ -804,3 +811,210 @@ async def test_a_renamed_entry_still_duplicates_its_entities(
 
     assert len(after) == 2 * len(before)
     assert any(registered.entity_id.endswith("_2") for registered in after)
+
+
+async def test_every_component_is_its_own_device_under_the_hub(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry
+) -> None:
+    """The layout a user sees: a controller, and the components of it.
+
+    Two heating circuits, one buffer and a heat pump is five devices - not one
+    page holding every entity of a heating system.
+    """
+    entry = build_config_entry(
+        Systems.VAMPAIR, heating_circuit=2, buffer=1, heatpump=True
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+    identifiers = {next(iter(device.identifiers))[1] for device in devices}
+
+    assert identifiers == {
+        entry.entry_id,
+        f"{entry.entry_id}_hc1",
+        f"{entry.entry_id}_hc2",
+        f"{entry.entry_id}_bu1",
+        f"{entry.entry_id}_hp",
+    }
+
+    hub = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+    components = [device for device in devices if device.id != hub.id]
+
+    assert components
+    assert all(device.via_device_id == hub.id for device in components)
+    assert hub.via_device_id is None
+
+
+async def test_every_entity_sits_on_the_component_it_reads(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry,
+    entity_registry,
+) -> None:
+    """An entity of heating circuit 2 belongs to the device of heating circuit 2."""
+    entry = build_config_entry(
+        Systems.VAMPAIR, heating_circuit=2, boiler=1, heatpump=True
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    misplaced = []
+    for registered in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
+        device = device_registry.async_get(registered.device_id)
+        identifier = next(iter(device.identifiers))[1]
+        component = registered.unique_id.split("_")[1]
+        if not identifier.endswith(f"_{component}"):
+            misplaced.append((registered.entity_id, identifier))
+
+    assert not misplaced
+
+
+async def test_the_entity_id_is_the_device_and_the_english_key(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, entity_registry
+) -> None:
+    """Home Assistant composes the id; the integration only supplies half of it.
+
+    The device half follows the language of the installation, because a device
+    name is translated like any other. The entity half is the words of the key,
+    which `create_description` keeps English on purpose - so a German
+    installation reads `sensor.heizkreis_1_supply_temperature`, not
+    `sensor.heizkreis_1_vorlauftemperatur`.
+
+    Entities already in the registry keep the ids they were given, so an
+    installation upgrading from 5.1.0 keeps its `sensor.solarfocus_*` ids and
+    only newly added components get these.
+    """
+    await hass.config.async_update(language="de")
+
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, solar=1)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    ids = {
+        registered.entity_id
+        for registered in er.async_entries_for_config_entry(
+            entity_registry, entry.entry_id
+        )
+    }
+
+    assert "sensor.heizkreis_1_supply_temperature" in ids
+    # One solar circuit is not numbered, in the device name and so in the id
+    assert "sensor.solar_collector_temperature_1" in ids
+    # The words of a key are never translated
+    assert not [entity_id for entity_id in ids if "vorlauf" in entity_id]
+
+
+async def test_lowering_a_count_removes_the_device_and_its_entities(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry,
+    entity_registry,
+) -> None:
+    """A component a user takes away must not leave anything behind.
+
+    The device of a component that is gone still names a config entry that
+    exists, so nothing removes it on its own - and its entities sit there
+    holding the value they had when the component was last polled.
+    """
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=3)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    third = device_registry.async_get_device({(DOMAIN, f"{entry.entry_id}_hc3")})
+    assert third is not None
+    assert er.async_entries_for_device(entity_registry, third.id)
+
+    hass.config_entries.async_update_entry(
+        entry, options={**entry.options, CONF_HEATING_CIRCUIT: 2}
+    )
+    await hass.async_block_till_done()
+
+    assert device_registry.async_get_device({(DOMAIN, f"{entry.entry_id}_hc3")}) is None
+    assert not er.async_entries_for_device(
+        entity_registry, third.id, include_disabled_entities=True
+    )
+    # The ones that are left are untouched
+    assert device_registry.async_get_device({(DOMAIN, f"{entry.entry_id}_hc2")})
+
+
+async def test_switching_a_component_off_removes_its_device(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry
+) -> None:
+    """The same for the components that are a switch rather than a count."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, photovoltaic=True)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert device_registry.async_get_device({(DOMAIN, f"{entry.entry_id}_pv")})
+
+    hass.config_entries.async_update_entry(
+        entry, options={**entry.options, CONF_PHOTOVOLTAIC: False}
+    )
+    await hass.async_block_till_done()
+
+    assert device_registry.async_get_device({(DOMAIN, f"{entry.entry_id}_pv")}) is None
+
+
+async def test_raising_a_count_adds_a_device(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry
+) -> None:
+    """The other direction, and the hub keeps every one of them."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    hass.config_entries.async_update_entry(
+        entry, options={**entry.options, CONF_HEATING_CIRCUIT: 2}
+    )
+    await hass.async_block_till_done()
+
+    hub = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+    second = device_registry.async_get_device({(DOMAIN, f"{entry.entry_id}_hc2")})
+
+    assert second is not None
+    assert second.via_device_id == hub.id
+
+
+async def test_removing_the_entry_removes_every_device(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry
+) -> None:
+    """The components go with the controller they hang off."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=2, heatpump=True)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+
+    assert await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+
+
+async def test_a_device_can_only_be_deleted_once_its_component_is_gone(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry
+) -> None:
+    """Deleting a configured device by hand would only have it built again.
+
+    A stale one is the user's to remove, which is what the delete button on a
+    device page asks this.
+    """
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    live = device_registry.async_get_device({(DOMAIN, f"{entry.entry_id}_hc1")})
+    hub = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+    stale = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, f"{entry.entry_id}_bu4")},
+    )
+
+    assert await async_remove_config_entry_device(hass, entry, live) is False
+    assert await async_remove_config_entry_device(hass, entry, hub) is False
+    assert await async_remove_config_entry_device(hass, entry, stale) is True

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1018,3 +1018,110 @@ async def test_a_device_can_only_be_deleted_once_its_component_is_gone(
     assert await async_remove_config_entry_device(hass, entry, live) is False
     assert await async_remove_config_entry_device(hass, entry, hub) is False
     assert await async_remove_config_entry_device(hass, entry, stale) is True
+
+
+async def test_a_new_component_device_lands_in_the_area_of_its_controller(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry,
+    area_registry,
+) -> None:
+    """Splitting the components off must not take them out of their room.
+
+    Everything of an entry used to sit on one device, so a user who put that
+    device in a room put every entity of their heating system in it. A new
+    device is in no area, and an automation or a voice command scoped to a room
+    stops matching what is in none.
+    """
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    heizraum = area_registry.async_get_or_create("Heizraum")
+    hub = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+    device_registry.async_update_device(hub.id, area_id=heizraum.id)
+
+    # A component that appears afterwards, as all of them did on the upgrade
+    hass.config_entries.async_update_entry(
+        entry, options={**entry.options, CONF_HEATING_CIRCUIT: 2}
+    )
+    await hass.async_block_till_done()
+
+    second = device_registry.async_get_device({(DOMAIN, f"{entry.entry_id}_hc2")})
+
+    assert second.area_id == heizraum.id
+
+
+async def test_a_component_the_user_moved_stays_where_they_put_it(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry,
+    area_registry,
+) -> None:
+    """Inheriting the area is for devices that are new, and only then."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    heizraum = area_registry.async_get_or_create("Heizraum")
+    wohnzimmer = area_registry.async_get_or_create("Wohnzimmer")
+    hub = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+    circuit = device_registry.async_get_device({(DOMAIN, f"{entry.entry_id}_hc1")})
+    device_registry.async_update_device(hub.id, area_id=heizraum.id)
+    device_registry.async_update_device(circuit.id, area_id=wohnzimmer.id)
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        device_registry.async_get_device({(DOMAIN, f"{entry.entry_id}_hc1")}).area_id
+        == wohnzimmer.id
+    )
+
+
+async def test_the_solar_entities_follow_the_key_the_count_uses(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, entity_registry
+) -> None:
+    """One solar circuit is keyed without its index, several are keyed with it.
+
+    Crossing that line renames every entity of the first circuit. Left alone,
+    the set under the other key stays in the registry for good - on a device
+    that is still configured, so it is never removed with it - reading the
+    value it had when the count changed.
+    """
+    entry = build_config_entry(
+        Systems.VAMPAIR, api_version=ApiVersions.V_25_030.value, solar=1
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    def _solar_keys() -> set[str]:
+        return {
+            registered.unique_id.removeprefix(f"{DEFAULT_NAME}_")
+            for registered in er.async_entries_for_config_entry(
+                entity_registry, entry.entry_id
+            )
+            if "_so" in registered.unique_id
+        }
+
+    unnumbered = _solar_keys()
+    assert unnumbered
+    assert all(key.startswith("so_") for key in unnumbered)
+
+    hass.config_entries.async_update_entry(
+        entry, options={**entry.options, CONF_SOLAR: 2}
+    )
+    await hass.async_block_till_done()
+
+    # The first circuit was renamed rather than left behind and built again
+    numbered = _solar_keys()
+    assert all(key.startswith(("so1_", "so2_")) for key in numbered)
+    assert {key.replace("so1_", "so_") for key in numbered if key.startswith("so1_")} == (
+        unnumbered
+    )
+
+    hass.config_entries.async_update_entry(
+        entry, options={**entry.options, CONF_SOLAR: 1}
+    )
+    await hass.async_block_till_done()
+
+    assert _solar_keys() == unnumbered

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -31,8 +31,7 @@ def _entities(api_version: str):
     entities = [
         SimpleNamespace(
             entity_description=create_description(
-                PHOTOVOLTAIC_PREFIX,
-                PHOTOVOLTAIC_COMPONENT,
+                                PHOTOVOLTAIC_COMPONENT,
                 PHOTOVOLTAIC_COMPONENT_PREFIX,
                 "",
                 description,
@@ -57,8 +56,7 @@ def test_photovoltaic_numbers_match_library_holding_registers():
 def test_photovoltaic_number_keys_and_names():
     """Entity keys and translation keys are prefixed with the component."""
     description = create_description(
-        PHOTOVOLTAIC_PREFIX,
-        PHOTOVOLTAIC_COMPONENT,
+                PHOTOVOLTAIC_COMPONENT,
         PHOTOVOLTAIC_COMPONENT_PREFIX,
         "",
         PHOTOVOLTAIC_NUMBER_TYPES[0],

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -69,7 +69,7 @@ def test_photovoltaic_number_keys_and_names():
     assert description.translation_key == "pv_smart_meter"
     # The name comes from the translation of the key now, and the photovoltaic
     # component exists once, so there is no index to substitute into it
-    assert description.translation_placeholders == {"idx": ""}
+    assert description.device_idx == ""
     assert description.component == PHOTOVOLTAIC_COMPONENT
 
 

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -228,7 +228,7 @@ async def test_single_solar_instance_keeps_the_unnumbered_key(
     for entity in entities:
         assert entity.entity_description.key.startswith(f"{SOLAR_COMPONENT_PREFIX}_")
         # An empty index is what keeps the number out of the translated name
-        assert entity.entity_description.translation_placeholders == {"idx": ""}
+        assert entity.entity_description.device_idx == ""
         # The index is still needed to address the component in the library
         assert entity.entity_description.component_idx == "1"
 

--- a/tests/test_sensor_enum_options.py
+++ b/tests/test_sensor_enum_options.py
@@ -141,7 +141,7 @@ async def test_the_state_of_an_enum_sensor_is_one_of_its_options(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.solarfocus_heat_pump_vampair_state")
+    state = hass.states.get("sensor.heat_pump_vampair_state")
 
     assert state.state == "3"
     assert state.state in state.attributes["options"]
@@ -164,7 +164,7 @@ async def test_an_enum_sensor_survives_a_register_holding_a_bool(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.solarfocus_boiler_1_single_charge")
+    state = hass.states.get("sensor.boiler_1_single_charge")
 
     assert state.state == "1"
     assert state.state in state.attributes["options"]

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -33,6 +33,7 @@ from custom_components.solarfocus.const import (
     BIOMASS_BOILER_PREFIX,
     BOILER_PREFIX,
     BUFFER_PREFIX,
+    COMPONENT_DEVICES,
     DOMAIN,
     FRESH_WATER_MODULE_PREFIX,
     HEAT_PUMP_PREFIX,
@@ -410,30 +411,60 @@ async def test_every_entity_has_a_translated_name(hass: HomeAssistant) -> None:
     assert not missing
 
 
-async def test_no_entity_name_changed(hass: HomeAssistant) -> None:
-    """The names are the ones the integration has always shown.
+async def test_an_entity_name_is_the_words_of_its_key(hass: HomeAssistant) -> None:
+    """The component is the device now, so it is not in the name any more.
 
-    Moving them into the translations is not meant to rename anything: every
-    name is still its component, its index and the words of its key, which is
-    what `create_description` built. A user's dashboards keep working and the
-    friendly names in their history stay continuous.
+    A name used to be its component, its index and the words of its key -
+    `Buffer 1 top temperature` on a device called `Solarfocus`. The component
+    is a device of its own now and the index is in its name, so what is left
+    for the entity is the words of its key: `Top temperature` on `Buffer 1`.
+    Home Assistant puts the two back together wherever the device is not
+    already the context.
+
+    English only. The German names are the register documentation's wording and
+    were never the words of a key.
     """
     entity = _load("strings.json")["entity"]
 
-    renamed = []
+    wrong = []
     async for domain, description in _descriptions(hass):
-        placeholders = description.translation_placeholders
         name = entity[domain][description.translation_key]["name"]
-        expected = " ".join(
-            (
-                f"{COMPONENT_PREFIXES[description.component_prefix]}"
-                f"{placeholders['idx']} {description.item.replace('_', ' ')}"
-            ).split()
-        )
-        if name.format(**placeholders) != expected:
-            renamed.append((domain, description.translation_key, name, expected))
+        expected = description.item.replace("_", " ")
+        if name.lower() != expected.lower():
+            wrong.append((domain, description.translation_key, name, expected))
 
-    assert not renamed
+    assert not wrong
+
+
+@pytest.mark.parametrize("filename", FILENAMES)
+async def test_no_entity_name_repeats_its_component(
+    hass: HomeAssistant, filename: str
+) -> None:
+    """The name a user reads would say the component twice otherwise.
+
+    The device is `Heating circuit 2` and the entity on it is `Supply
+    temperature`; a name that still began with its component would show as
+    `Heating circuit 2 Heating circuit 2 supply temperature`. This is what
+    fails when a new entity is added with the old habit, in any of the files.
+    """
+    data = _load(filename)
+    # The name of the device this entity's own component is on, in the language
+    # of the file being read, so the German names are held to the German words.
+    component_of = {
+        prefix: data["device"][device_key]["name"].replace("{idx}", "").strip()
+        for prefix, (device_key, _) in COMPONENT_DEVICES.items()
+    }
+
+    repeated = [
+        (platform, key, block["name"])
+        for platform, keys in data["entity"].items()
+        for key, block in keys.items()
+        if block["name"]
+        .lower()
+        .startswith(component_of[key.split("_")[0]].lower() + " ")
+    ]
+
+    assert not repeated
 
 
 async def test_home_assistant_shows_the_translated_name(
@@ -453,31 +484,33 @@ async def test_home_assistant_shows_the_translated_name(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    second = hass.states.get("sensor.solarfocus_heating_circuit_2_room_temperature")
-    solar = hass.states.get("sensor.solarfocus_solar_collector_temperature_1")
+    second = hass.states.get("sensor.heating_circuit_2_room_temperature")
+    solar = hass.states.get("sensor.solar_collector_temperature_1")
 
     assert second.attributes["friendly_name"] == (
-        "Solarfocus Heating circuit 2 room temperature"
+        "Heating circuit 2 Room temperature"
     )
     # One solar circuit keeps the unnumbered name it had before there could be
     # four; the trailing 1 is the collector sensor, part of the register name
     assert solar.attributes["friendly_name"] == (
-        "Solarfocus Solar collector temperature 1"
+        "Solar Collector temperature 1"
     )
 
 
 async def test_a_german_installation_keeps_the_english_entity_ids(
     hass: HomeAssistant, enable_custom_integrations, mock_api, api
 ) -> None:
-    """The name is translated, the entity id is not.
+    """The reading an entity id names stays English in every language.
 
-    Home Assistant builds an entity id from the name in the user's own language
-    for the languages it generates native ids for, German among them. Left to
-    it, a German installation would name its entities
-    `sensor.solarfocus_heizkreis_1_vorlauftemperatur` - and only the ones added
-    from then on, because the entities already in the registry keep the id they
-    were given. Every id ever written into a dashboard, an automation or an
-    answer in an issue is the English one.
+    Home Assistant composes an entity id out of the name of the device and the
+    entity half the integration suggests. The device half is translated like
+    any device name, so a German installation reads `heizkreis_1`; the entity
+    half is the words of the key rather than the translated name, so it is
+    `supply_temperature` and never `vorlauftemperatur`.
+
+    Entities already in the registry keep the id they were given, so an
+    installation upgrading from 5.1.0 keeps its `sensor.solarfocus_*` ids
+    whatever this produces for the ones added from now on.
     """
     await hass.config.async_update(language="de")
 
@@ -489,18 +522,19 @@ async def test_a_german_installation_keeps_the_english_entity_ids(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.solarfocus_heating_circuit_1_room_temperature")
+    state = hass.states.get("sensor.heizkreis_1_room_temperature")
 
     assert state is not None
-    assert state.attributes["friendly_name"] == "Solarfocus Heizkreis 1 Raumtemperatur"
+    assert state.attributes["friendly_name"] == "Heizkreis 1 Raumtemperatur"
 
-    german = [
+    # The device half follows the language, the reading never does
+    translated = [
         entry.entity_id
         for entry in er.async_get(hass).entities.values()
-        if "heizkreis" in entry.entity_id or "vorlauf" in entry.entity_id
+        if "vorlauf" in entry.entity_id or "raumtemperatur" in entry.entity_id
     ]
 
-    assert not german
+    assert not translated
 
 
 def _unreadable(text: str) -> list[str]:

--- a/uv.lock
+++ b/uv.lock
@@ -2292,7 +2292,7 @@ wheels = [
 
 [[package]]
 name = "solarfocus"
-version = "6.0.0rc1"
+version = "6.0.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
Phases 2, 3 and 4 of #208, in one PR because none of them works on its own: the device takes its name from the component, until the entity name stops repeating it a user reads **`Heizkreis 1 Heizkreis 1 Raumtemperatur`**, and a device the configuration no longer covers would stay in the registry for good.

## What a user sees

Every heating circuit, buffer, boiler, fresh water module and solar circuit is a device, as are the heat pump, the photovoltaic and the biomass boiler, all attached to the eco<sup>manager-touch</sup> as their hub. A vampair with two circuits, one buffer and a heat pump goes from one device to five.

| | Before | After |
|---|---|---|
| Device | `Solarfocus` | `Pufferspeicher 1`, under `Solarfocus` |
| Entity name | `Pufferspeicher 1 Temperatur oben` | `Temperatur oben` |
| Shown as | `Solarfocus Pufferspeicher 1 Temperatur oben` | `Pufferspeicher 1 Temperatur oben` |
| Entity id (existing) | `sensor.solarfocus_buffer_1_top_temperature` | **unchanged** |
| Entity id (newly added) | — | `sensor.buffer_1_top_temperature` |

A device is what Home Assistant assigns an area to, so a heating circuit can now sit in the room it heats.

## No migration

The hub keeps the `(DOMAIN, entry_id)` identifier the entry has had since version 9, so an existing installation keeps its device — with its area, its name and the automations pointing at it — and the components appear underneath it. An entity that names a different device is moved there by Home Assistant on the next load, so there is nothing to migrate and no entry version bump.

This also resolves a checklist item by making it unnecessary: the old collective device does not need removing, it *becomes* the hub.

Components link with `via_device_id` rather than `via_device`, which 2026.8 deprecates.

## Two things the checklist did not anticipate

**Entity ids move for newly added entities.** Home Assistant composes an id out of the name of the device and the name of the entity, and both change here. Entities already in the registry keep their ids, so **an upgrade moves nothing** — but a component added afterwards, or a fresh installation, gets `sensor.heating_circuit_1_supply_temperature` where an upgraded installation has `sensor.solarfocus_heating_circuit_1_supply_temperature`. The two styles coexist.

The first version of this PR pinned the ids to the old scheme by having every entity set its own `entity_id`. That was reverted deliberately: it opts out of `entity_id_parts`, the registry setting that lets a user choose whether an id carries the floor, area and device, and it goes against Home Assistant's own guidance that entities should not set `entity_id`. Following the platform is worth more than freezing the ids.

What the integration still controls is the entity half, and it supplies the **words of the key** rather than the translated name — so the part that names the reading stays English in every language: `sensor.heizkreis_1_supply_temperature`, never `..._vorlauftemperatur`.

The README documents the two id styles under Known Limitations rather than leaving it to be found.

**Phase 2 could not ship alone**, hence phase 4 here: 103 entity names lost their component and their index across the three string files, and the index moved to the device name via `device_idx`.

## Devices come and go with the configuration (phase 3)

Lowering a count from four to two left two devices behind. Nothing takes them away on their own — they still name a config entry that exists — and every entity that was on them sits there reading the value it held when the component was last polled.

The set of devices an entry should have is built from its options, and anything outside it is removed on load. Removing the device is what removes those entities: the entity registry takes them with it, which is confirmed in the HA source rather than assumed.

`async_remove_config_entry_device` lets a user delete a stale device by hand from its device page, and refuses a configured one — deleting that would only have it built again on the next load, as a new device they have to put back in its area.

## Quality scale

`dynamic-devices` and `stale-devices` are **`done`** rather than `exempt`. Their exemptions read "one device per config entry", which stops being true here.

## Tests

1047 passing. New:

- the device registry for a known configuration holds exactly the expected devices, each linked to the hub
- every entity sits on the device its unique id says it belongs to
- **`test_the_entity_id_is_the_device_and_the_english_key`** — a German installation gets `heizkreis_1_supply_temperature`, and no id carries a translated reading
- `test_an_entity_name_is_the_words_of_its_key` — the English names are exactly that, nothing more
- `test_no_entity_name_repeats_its_component` — fails in any language for a name starting with its own device, checked against that file's device names

🤖 Generated with [Claude Code](https://claude.com/claude-code)
