### PR TITLE
Line up the arguments of create_description again

### DIFF
--- a/custom_components/solarfocus/binary_sensor.py
+++ b/custom_components/solarfocus/binary_sensor.py
@@ -61,7 +61,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_HEATING_CIRCUIT]):
         for description in HEATING_CIRCUIT_BINARY_SENSOR_TYPES:
             _description = create_description(
-                                HEATING_CIRCUIT_COMPONENT,
+                HEATING_CIRCUIT_COMPONENT,
                 HEATING_CIRCUIT_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -73,7 +73,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_BUFFER]):
         for description in BUFFER_BINARY_SENSOR_TYPES:
             _description = create_description(
-                                BUFFER_COMPONENT,
+                BUFFER_COMPONENT,
                 BUFFER_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -85,7 +85,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_HEATPUMP]:
         for description in HEATPUMP_BINARY_SENSOR_TYPES:
             _description = create_description(
-                                HEAT_PUMP_COMPONENT,
+                HEAT_PUMP_COMPONENT,
                 HEAT_PUMP_COMPONENT_PREFIX,
                 "",
                 description,
@@ -97,7 +97,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_BIOMASS_BOILER]:
         for description in BIOMASS_BOILER_BINARY_SENSOR_TYPES:
             _description = create_description(
-                                BIOMASS_BOILER_COMPONENT,
+                BIOMASS_BOILER_COMPONENT,
                 BIOMASS_BOILER_COMPONENT_PREFIX,
                 "",
                 description,
@@ -109,7 +109,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_PHOTOVOLTAIC]:
         for description in PHOTOVOLTAIC_BINARY_SENSOR_TYPES:
             _description = create_description(
-                                PHOTOVOLTAIC_COMPONENT,
+                PHOTOVOLTAIC_COMPONENT,
                 PHOTOVOLTAIC_COMPONENT_PREFIX,
                 "",
                 description,
@@ -121,7 +121,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_FRESH_WATER_MODULE]):
         for description in FRESH_WATER_MODULE_BINARY_SENSOR_TYPES:
             _description = create_description(
-                                FRESH_WATER_MODULE_COMPONENT,
+                FRESH_WATER_MODULE_COMPONENT,
                 FRESH_WATER_MODULE_COMPONENT_PREFIX,
                 str(i + 1),
                 description,

--- a/custom_components/solarfocus/button.py
+++ b/custom_components/solarfocus/button.py
@@ -43,7 +43,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_BOILER]):
         for description in BOILER_BUTTON_TYPES:
             _description = create_description(
-                                BOILER_COMPONENT,
+                BOILER_COMPONENT,
                 BOILER_COMPONENT_PREFIX,
                 str(i + 1),
                 description,

--- a/custom_components/solarfocus/climate.py
+++ b/custom_components/solarfocus/climate.py
@@ -101,7 +101,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_HEATING_CIRCUIT]):
         for description in CLIMATE_TYPES:
             _description = create_description(
-                                HEATING_CIRCUIT_COMPONENT,
+                HEATING_CIRCUIT_COMPONENT,
                 HEATING_CIRCUIT_COMPONENT_PREFIX,
                 str(i + 1),
                 description,

--- a/custom_components/solarfocus/number.py
+++ b/custom_components/solarfocus/number.py
@@ -55,7 +55,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_HEATING_CIRCUIT]):
         for description in HEATING_CIRCUIT_NUMBER_TYPES:
             _description = create_description(
-                                HEATING_CIRCUIT_COMPONENT,
+                HEATING_CIRCUIT_COMPONENT,
                 HEATING_CIRCUIT_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -67,7 +67,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_BOILER]):
         for description in BOILER_NUMBER_TYPES:
             _description = create_description(
-                                BOILER_COMPONENT,
+                BOILER_COMPONENT,
                 BOILER_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -79,7 +79,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_PHOTOVOLTAIC]:
         for description in PHOTOVOLTAIC_NUMBER_TYPES:
             _description = create_description(
-                                PHOTOVOLTAIC_COMPONENT,
+                PHOTOVOLTAIC_COMPONENT,
                 PHOTOVOLTAIC_COMPONENT_PREFIX,
                 "",
                 description,

--- a/custom_components/solarfocus/select.py
+++ b/custom_components/solarfocus/select.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_HEATING_CIRCUIT]):
         for description in HEATING_CIRCUIT_SELECT_TYPES:
             _description = create_description(
-                                HEATING_CIRCUIT_COMPONENT,
+                HEATING_CIRCUIT_COMPONENT,
                 HEATING_CIRCUIT_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -63,7 +63,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_BOILER]):
         for description in BOILER_SELECT_TYPES:
             _description = create_description(
-                                BOILER_COMPONENT,
+                BOILER_COMPONENT,
                 BOILER_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -75,7 +75,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_HEATPUMP]:
         for description in HEATPUMP_SELECT_TYPES:
             _description = create_description(
-                                HEAT_PUMP_COMPONENT,
+                HEAT_PUMP_COMPONENT,
                 HEAT_PUMP_COMPONENT_PREFIX,
                 "",
                 description,

--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -90,7 +90,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_HEATING_CIRCUIT]):
         for description in HEATING_CIRCUIT_SENSOR_TYPES:
             _description = create_description(
-                                HEATING_CIRCUIT_COMPONENT,
+                HEATING_CIRCUIT_COMPONENT,
                 HEATING_CIRCUIT_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -102,7 +102,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_BOILER]):
         for description in BOILER_SENSOR_TYPES:
             _description = create_description(
-                                BOILER_COMPONENT,
+                BOILER_COMPONENT,
                 BOILER_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -114,7 +114,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_BUFFER]):
         for description in BUFFER_SENSOR_TYPES:
             _description = create_description(
-                                BUFFER_COMPONENT,
+                BUFFER_COMPONENT,
                 BUFFER_COMPONENT_PREFIX,
                 str(i + 1),
                 description,
@@ -126,7 +126,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_HEATPUMP]:
         for description in HEATPUMP_SENSOR_TYPES:
             _description = create_description(
-                                HEAT_PUMP_COMPONENT,
+                HEAT_PUMP_COMPONENT,
                 HEAT_PUMP_COMPONENT_PREFIX,
                 "",
                 description,
@@ -138,7 +138,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_BIOMASS_BOILER]:
         for description in BIOMASS_BOILER_SENSOR_TYPES:
             _description = create_description(
-                                BIOMASS_BOILER_COMPONENT,
+                BIOMASS_BOILER_COMPONENT,
                 BIOMASS_BOILER_COMPONENT_PREFIX,
                 "",
                 description,
@@ -150,7 +150,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_PHOTOVOLTAIC]:
         for description in PHOTOVOLTAIC_SENSOR_TYPES:
             _description = create_description(
-                                PHOTOVOLTAIC_COMPONENT,
+                PHOTOVOLTAIC_COMPONENT,
                 PHOTOVOLTAIC_COMPONENT_PREFIX,
                 "",
                 description,
@@ -169,7 +169,7 @@ async def async_setup_entry(
                 # But for single instance, don't show the number in the entity name
                 idx = str(i + 1)
                 _description = create_description(
-                                        SOLAR_COMPONENT,
+                    SOLAR_COMPONENT,
                     SOLAR_COMPONENT_PREFIX,
                     idx,
                     description,
@@ -188,7 +188,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_FRESH_WATER_MODULE]):
         for description in FRESH_WATER_MODULE_SENSOR_TYPES:
             _description = create_description(
-                                FRESH_WATER_MODULE_COMPONENT,
+                FRESH_WATER_MODULE_COMPONENT,
                 FRESH_WATER_MODULE_COMPONENT_PREFIX,
                 str(i + 1),
                 description,

--- a/custom_components/solarfocus/switch.py
+++ b/custom_components/solarfocus/switch.py
@@ -45,7 +45,7 @@ async def async_setup_entry(
     if config_entry.options[CONF_HEATPUMP]:
         for description in HEATPUMP_SWITCH_TYPES:
             _description = create_description(
-                                HEAT_PUMP_COMPONENT,
+                HEAT_PUMP_COMPONENT,
                 HEAT_PUMP_COMPONENT_PREFIX,
                 "",
                 description,

--- a/custom_components/solarfocus/water_heater.py
+++ b/custom_components/solarfocus/water_heater.py
@@ -70,7 +70,7 @@ async def async_setup_entry(
     for i in range(config_entry.options[CONF_BOILER]):
         for description in WATER_HEATER_TYPES:
             _description = create_description(
-                                BOILER_COMPONENT,
+                BOILER_COMPONENT,
                 BOILER_COMPONENT_PREFIX,
                 str(i + 1),
                 description,


### PR DESCRIPTION
Cosmetic. Dropping the unused first argument of `create_description` in #213 left the second argument sitting at the old one's indentation across 24 call sites. Ruff does not check continuation-line alignment, so nothing flagged it.

No behaviour change; 1050 tests still passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)