### PR TITLE
Call the controller eco manager-touch, and match the pump icons

### DIFF
--- a/custom_components/solarfocus/__init__.py
+++ b/custom_components/solarfocus/__init__.py
@@ -33,6 +33,7 @@ from .const import (
     CONF_PHOTOVOLTAIC,
     CONF_SOLAR,
     CONF_SOLARFOCUS_SYSTEM,
+    CONTROLLER_NAME,
     DOMAIN,
     MANUFACTURER,
     build_unique_id,
@@ -330,11 +331,17 @@ def _async_hub_device(
 
     It is registered here rather than left to an entity, because a component
     device points at it by device id, which is only known once it exists.
+
+    The name is what the controller is called - `Solarfocus` is the make, and
+    the model page of the device already says it. Which heating system this one
+    belongs to is the name of the entry, not of the device: two systems in one
+    Home Assistant are two entries, and a user who wants to tell their devices
+    apart by name renames this one, which the registry keeps separately.
     """
     return dr.async_get(hass).async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, entry.entry_id)},
-        name="Solarfocus",
+        name=CONTROLLER_NAME,
         model=api.system.value,
         sw_version=api.api_version.value,
         manufacturer=MANUFACTURER,

--- a/custom_components/solarfocus/const.py
+++ b/custom_components/solarfocus/const.py
@@ -60,6 +60,11 @@ FRESH_WATER_MODULE_COMPONENT_PREFIX = "fm"
 
 MANUFACTURER = "Solarfocus"
 
+# What the controller every component hangs off is called. `Solarfocus` is the
+# make and the device page says so already; this is the product, and it is the
+# same box whichever heating system is wired to it.
+CONTROLLER_NAME = "eco manager-touch"
+
 # The device the entities of a component belong to, keyed by the prefix every
 # entity description already carries: the key its name is translated under, and
 # the model shown on its device page - a heating circuit has no model of its own

--- a/custom_components/solarfocus/icons.json
+++ b/custom_components/solarfocus/icons.json
@@ -1,6 +1,24 @@
 {
   "entity": {
     "binary_sensor": {
+      "bu_pump": {
+        "default": "mdi:pump",
+        "state": {
+          "off": "mdi:pump-off"
+        }
+      },
+      "hc_circulator_pump": {
+        "default": "mdi:pump",
+        "state": {
+          "off": "mdi:pump-off"
+        }
+      },
+      "hp_boiler_charge": {
+        "default": "mdi:pump",
+        "state": {
+          "off": "mdi:pump-off"
+        }
+      },
       "hp_defrost_active": {
         "default": "mdi:snowflake",
         "state": {
@@ -10,10 +28,10 @@
     },
     "button": {
       "bo_circulation": {
-        "default": "mdi:reload"
+        "default": "mdi:sync"
       },
       "bo_single_charge": {
-        "default": "mdi:water-boiler"
+        "default": "mdi:fire"
       }
     },
     "number": {

--- a/custom_components/solarfocus/manifest.json
+++ b/custom_components/solarfocus/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/lavermanjj/home-assistant-solarfocus/issues",
   "requirements": ["pysolarfocus==5.2.2"],
   "ssdp": [],
-  "version": "6.0.0-rc2",
+  "version": "6.0.0-rc3",
   "zeroconf": []
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -21,8 +21,10 @@ from custom_components.solarfocus.const import (
     CONF_PHOTOVOLTAIC,
     CONF_SOLAR,
     CONF_SOLARFOCUS_SYSTEM,
+    CONTROLLER_NAME,
     DEFAULT_NAME,
     DOMAIN,
+    MANUFACTURER,
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
@@ -845,6 +847,55 @@ async def test_every_component_is_its_own_device_under_the_hub(
     assert components
     assert all(device.via_device_id == hub.id for device in components)
     assert hub.via_device_id is None
+
+
+async def test_the_hub_is_the_controller(
+    hass: HomeAssistant, enable_custom_integrations, api, mock_api, device_registry
+) -> None:
+    """The device every component hangs off is the box they are wired to.
+
+    It is the same controller whichever heating system it drives, so the name
+    does not vary with the system - `Solarfocus` is the make, and the model of
+    the device says which system it is.
+    """
+    api.system = Systems.THERMINATOR
+
+    entry = build_config_entry(Systems.THERMINATOR, biomassboiler=True)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    hub = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+
+    assert hub.name == CONTROLLER_NAME
+    assert hub.manufacturer == MANUFACTURER
+    assert hub.model == Systems.THERMINATOR.value
+
+
+async def test_the_hub_keeps_the_name_the_user_gave_it(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry
+) -> None:
+    """Telling two heating systems apart by name is renaming their controllers.
+
+    The registry holds the name a user gave a device separately from the one the
+    integration reports, and theirs is what the frontend shows - so a reload
+    does not undo it.
+    """
+    entry = build_config_entry(Systems.VAMPAIR, heatpump=True)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    hub = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+    device_registry.async_update_device(hub.id, name_by_user="Heizung Keller")
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    renamed = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+
+    assert renamed.name_by_user == "Heizung Keller"
+    assert renamed.name == CONTROLLER_NAME
 
 
 async def test_every_entity_sits_on_the_component_it_reads(


### PR DESCRIPTION
## The controller has a name of its own

The device every component hangs off was called `Solarfocus`, which is the make rather than the thing. It is an eco manager-touch whichever heating system is wired to it, and the make is already on the device page next to the model — so the name now says the product:

| | before | after |
|---|---|---|
| name | Solarfocus | eco manager-touch |
| manufacturer | Solarfocus | Solarfocus |
| model | Vampair | Vampair |
| sw_version | 23.020 | 23.020 |

Telling two heating systems apart stays what it was: renaming the controller. The registry keeps the name a user gave a device separately from the one the integration reports, and theirs is what the frontend shows, so a reload does not undo it. That is what the second of the two new tests is for.

## Four icons that said different things about the same thing

- **`Zirkulation anfordern`** was `mdi:reload` as a button and `mdi:sync` as a sensor. The button follows the sensor.
- **`Ladepumpe`**, **`Boilerladung`** and **`Pumpe Ein/Aus`** had no icon at all and fell back to the one of their device class. They are pumps, so they get the state-based `mdi:pump` / `mdi:pump-off` that `Einmalladung` already reports with.
- The **`Einmalladung`** button was a second water boiler next to the boiler it sits on. What it does is fire the boiler once, so `mdi:fire`.

## Not in here

The name of the integration and the name of a config entry both stay `Solarfocus`. Naming an entry after the system it reads was considered and dropped: the field sits on the same form as the host, the system and the api version, so it cannot default to them, and entity unique ids are still built from the entry title (#212).

---

Sets the version to `6.0.0-rc3`. No release.

1052 tests pass; `ruff` and `pylint` are clean on `custom_components`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)