### PR TITLE
Set the version to 6.0.0-rc3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "solarfocus"
-version = "6.0.0rc2"
+version = "6.0.0rc3"
 description = "Custom component for integrating Solarfocus heating systems into Home Assistant."
 authors = [{ name = "Jeroen Laverman", email = "jjlaverman@web.de" }]
 requires-python = ">=3.14.2,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -2292,7 +2292,7 @@ wheels = [
 
 [[package]]
 name = "solarfocus"
-version = "6.0.0rc2"
+version = "6.0.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
`custom_components/solarfocus/manifest.json` was already set to `6.0.0-rc3` in #219, while `pyproject.toml` still said `6.0.0rc2`. This brings pyproject and `uv.lock` along so the version is the same in all three places before the tag.

No code change; 1052 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)