### PR TITLE
Offer Pellet Elegance and Octoplus, and let the system be corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,12 +255,17 @@ which asks for the connection on its own and leaves your component layout untouc
 | Host | Address of the controller, e.g. after a DHCP change. |
 | Port | Modbus TCP port. |
 | Polling interval (s) | Seconds between two reads, the same setting as above. |
-| Solarfocus System | Correct a system picked wrongly at setup, e.g. a pellet<sup>elegance</sup> added as an EcoTop before it was offered. Entities are identified by the name of the entry and their own key, neither of which holds the system, so every entity the two systems share keeps its history. Entities only the old system has are removed, and entities only the new one has appear empty until the next poll. |
+| Solarfocus System | Correct a system picked wrongly at setup, e.g. a pellet<sup>elegance</sup> added as an EcoTop before it was offered. Entities are identified by the name of the entry and their own key, neither of which holds the system, so every entity the two systems share keeps its history. Entities only the new system has appear empty until the next poll. See below for what happens to the ones only the old system had. |
 | Solarfocus API Version | Raise this after a software update of the heating system to get the entities that version added. Setting it higher than the controller runs makes it answer the wrong registers, see [Troubleshooting](#troubleshooting). |
 
 Changing between the vampair and any of the biomass boilers also switches the heat source the
-entry reads, since no system has both. Changing between two biomass boilers leaves your
-component layout exactly as it is.
+entry reads, since no system has both. That removes the device of the old heat source and every
+entity on it, history included — a vampair corrected to a Therminator loses its heat pump
+entities. Changing between two biomass boilers leaves your component layout exactly as it is.
+
+Either way, an entity the new system does not have simply stops being created. Its entry in the
+entity registry stays behind and shows as unavailable, because nothing removes entities one at a
+time — only whole devices. Delete those by hand if you want them gone.
 
 ### Removing the Integration
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The eco<sup>manager-touch</sup> can integrate the following heating systems
 - [Thermin<sup>nator</sup>](https://www.solarfocus.com/en/products/biomassheating) biomass boilers
 - [Ecotop<sup>light</sup> / Ecotop<sup>zero</sup>](https://www.solarfocus.com/de/produkte/biomasseheizung/pelletkessel/ecotop) biomass boilers (_beta_)
 - [Octo<sup>plus</sup>](https://www.solarfocus.com/en/products/biomassheating/pellet-boiler/octoplus) biomass boilers
-- [pellet<sup>elegance</sup>](https://www.solarfocus.com/pelletelegance) biomass boilers (select ecotop)
+- [pellet<sup>elegance</sup>](https://www.solarfocus.com/pelletelegance) biomass boilers
 
 | Components | Supported |
 |---|---|
@@ -216,7 +216,7 @@ The first step of the setup asks for:
 | Host | `solarfocus` | Hostname or IP address of the eco<sup>manager-touch</sup>. |
 | Port | `502` | Modbus TCP port of the controller. |
 | Polling interval (s) | `10` | Seconds between two reads of the heating system. Values below 5 are rejected. |
-| Solarfocus System | `Heat pump vampair` | `vampair`, `Therminator II` or `EcoTop`. This decides which components the second step offers and which entities exist, and it is the one setting that cannot be changed afterwards. |
+| Solarfocus System | `Heat pump vampair` | `vampair`, `Therminator II`, `EcoTop`, `Pellet Elegance` or `Octoplus`. This decides which components the second step offers and which entities exist. It can be corrected afterwards, see [Changing the Connection](#changing-the-connection). |
 | Solarfocus API Version | `23.020` | Software version of your eco<sup>manager-touch</sup>, see [Software](#software). Entities that need a newer version than the one selected are not created. |
 
 The second step asks which components your installation has. Everything here can be changed
@@ -237,7 +237,7 @@ immediately.
 | Fresh water module | 0 - 4 | Number of fresh water modules (_Frischwassermodule_), from version `23.020`. |
 | Solar | 0 - 4 | Number of solar circuits. More than one requires version `25.030`; below that only the first one is built, whatever the count says. |
 | Heat Pump | on / off | vampair systems only. |
-| Biomass boiler | on / off | Therminator and EcoTop systems only. |
+| Biomass boiler | on / off | Every system except the vampair. |
 | Photovoltaic | on / off | Photovoltaic sensors and the `number` entities used to feed values back, see [Photovoltaic](#photovoltaic). |
 
 Setting a count to 0 (or a switch to off) stops that component from being polled and removes
@@ -245,17 +245,22 @@ its entities.
 
 ### Changing the Connection
 
-The address of the controller, its Modbus TCP port and the API version are what it takes to
-read the system at all, so they are not in the form above. Change them via **Settings →
-Devices & Services → Solarfocus → the three-dot menu of the entry → Reconfigure**, which
-asks for the connection on its own and leaves your component layout untouched.
+The address of the controller, its Modbus TCP port, which system it is and the API version are
+what it takes to read the system at all, so they are not in the form above. Change them via
+**Settings → Devices & Services → Solarfocus → the three-dot menu of the entry → Reconfigure**,
+which asks for the connection on its own and leaves your component layout untouched.
 
 | Setting | Description |
 |---|---|
 | Host | Address of the controller, e.g. after a DHCP change. |
 | Port | Modbus TCP port. |
 | Polling interval (s) | Seconds between two reads, the same setting as above. |
+| Solarfocus System | Correct a system picked wrongly at setup, e.g. a pellet<sup>elegance</sup> added as an EcoTop before it was offered. Entities are identified by the name of the entry and their own key, neither of which holds the system, so every entity the two systems share keeps its history. Entities only the old system has are removed, and entities only the new one has appear empty until the next poll. |
 | Solarfocus API Version | Raise this after a software update of the heating system to get the entities that version added. Setting it higher than the controller runs makes it answer the wrong registers, see [Troubleshooting](#troubleshooting). |
+
+Changing between the vampair and any of the biomass boilers also switches the heat source the
+entry reads, since no system has both. Changing between two biomass boilers leaves your
+component layout exactly as it is.
 
 ### Removing the Integration
 
@@ -403,8 +408,6 @@ These are properties of the integration or the Modbus interface, not bugs:
   address or a DNS name.
 - **No authentication.** Modbus TCP has none. Anyone with access to the network segment of the
   controller can read and write the same registers.
-- **The system type cannot be changed.** Switching between vampair, Therminator and EcoTop means
-  deleting the entry and setting it up again.
 - **The name of an entry is part of the identity of its entities.** Renaming the config entry
   after setup gives the entities new unique ids: the old ones are orphaned and a duplicate set
   appears with a `_2` suffix. Rename the entities or one of the devices instead, both of which

--- a/custom_components/solarfocus/binary_sensor.py
+++ b/custom_components/solarfocus/binary_sensor.py
@@ -211,20 +211,26 @@ HEATPUMP_BINARY_SENSOR_TYPES = [
 # Register 2405 is reported the other way round on a therminator than on an
 # EcoTop, which is why the door is described twice. Both descriptions carry the
 # same key, so they build the same `unique_id` and only one of the two may ever
-# survive the system filter: each names the single system it was measured on.
+# survive the system filter: each names the systems it was measured on.
 #
-# That leaves Pellet Elegance and Octoplus without a door contact, deliberately.
-# The one Pellet Elegance measured for #217 answered 2 with the door open and 2
-# with it closed, which is neither of the states below, on a boiler whose owner
-# reports the contact does not work. Until someone with a working contact says
-# which way round it reads, an entity here could only be wrong in one of the two
-# directions - and a door sensor stuck on "closed" is the worse one.
+# A Pellet Elegance (15 kW, v25.110) was read at the door for #217 and answers
+# 1 open, 0 closed - the therminator way round, so it joins that description.
+# The other Pellet Elegance in that thread reads 2 in both positions, on a
+# boiler whose owner reports the contact does not work; 2 is neither state
+# below, so it stays "closed" rather than flapping, which is the right way for
+# an unfitted contact to fail.
+#
+# The Octoplus is still unmeasured and so still has no door contact. Guessing
+# between two polarities gives a sensor that is confidently wrong half the
+# time, which is worse than not having one.
 BIOMASS_BOILER_BINARY_SENSOR_TYPES = [
     SolarfocusBinarySensorEntityDescription(
         key="door_contact",
         device_class=BinarySensorDeviceClass.DOOR,
         on_state="1",
-        unsupported_systems=every_system_but(Systems.THERMINATOR),
+        unsupported_systems=every_system_but(
+            Systems.THERMINATOR, Systems.PELLETELEGANCE
+        ),
     ),
     SolarfocusBinarySensorEntityDescription(
         key="door_contact",

--- a/custom_components/solarfocus/binary_sensor.py
+++ b/custom_components/solarfocus/binary_sensor.py
@@ -39,6 +39,7 @@ from .entity import (
     SolarfocusEntity,
     SolarfocusEntityDescription,
     create_description,
+    every_system_but,
     filterVersionAndSystem,
 )
 
@@ -207,18 +208,29 @@ HEATPUMP_BINARY_SENSOR_TYPES = [
     ),
 ]
 
+# Register 2405 is reported the other way round on a therminator than on an
+# EcoTop, which is why the door is described twice. Both descriptions carry the
+# same key, so they build the same `unique_id` and only one of the two may ever
+# survive the system filter: each names the single system it was measured on.
+#
+# That leaves Pellet Elegance and Octoplus without a door contact, deliberately.
+# The one Pellet Elegance measured for #217 answered 2 with the door open and 2
+# with it closed, which is neither of the states below, on a boiler whose owner
+# reports the contact does not work. Until someone with a working contact says
+# which way round it reads, an entity here could only be wrong in one of the two
+# directions - and a door sensor stuck on "closed" is the worse one.
 BIOMASS_BOILER_BINARY_SENSOR_TYPES = [
     SolarfocusBinarySensorEntityDescription(
         key="door_contact",
         device_class=BinarySensorDeviceClass.DOOR,
         on_state="1",
-        unsupported_systems=[Systems.ECOTOP, Systems.VAMPAIR],
+        unsupported_systems=every_system_but(Systems.THERMINATOR),
     ),
     SolarfocusBinarySensorEntityDescription(
         key="door_contact",
         device_class=BinarySensorDeviceClass.DOOR,
         on_state="0",
-        unsupported_systems=[Systems.THERMINATOR, Systems.VAMPAIR],
+        unsupported_systems=every_system_but(Systems.ECOTOP),
     ),
 ]
 

--- a/custom_components/solarfocus/config_flow.py
+++ b/custom_components/solarfocus/config_flow.py
@@ -50,6 +50,10 @@ SOLARFOCUS_SYSTEMS = [
         value="Therminator", label=" Biomass boiler therminator II"
     ),
     selector.SelectOptionDict(value="Ecotop", label=" Biomass boiler EcoTop"),
+    selector.SelectOptionDict(
+        value="Pellet Elegance", label=" Biomass boiler Pellet Elegance"
+    ),
+    selector.SelectOptionDict(value="Octoplus", label=" Biomass boiler Octoplus"),
 ]
 
 # CONF_API_VERSION
@@ -81,8 +85,33 @@ _COMPONENT_COUNT_ZERO_FOUR_SELECTOR = vol.All(
     vol.Coerce(int),
 )
 
+
+def _heat_source(was: str, now: str) -> dict[str, bool]:
+    """Return the component flags a change of system forces, if any.
+
+    The heat pump and the biomass boiler are the one part of the component
+    layout that the system decides rather than the user: the component step
+    only ever offers whichever of the two the chosen system has. So crossing
+    between them has to switch the flags over, or the entry would go on reading
+    a heat source its system does not have and stop reading the one it does.
+    The new one arrives switched on, as it does in the component step.
+
+    A change that stays on the same side of that line - the EcoTop read as a
+    Pellet Elegance this is mostly here for - leaves both alone. Someone who
+    turned the biomass boiler off meant it.
+    """
+    if (was == Systems.VAMPAIR) == (now == Systems.VAMPAIR):
+        return {}
+    heat_pump = now == Systems.VAMPAIR
+    return {CONF_HEATPUMP: heat_pump, CONF_BIOMASS_BOILER: not heat_pump}
+
+
 def _connection_schema(current: Mapping[str, Any]) -> vol.Schema:
-    """Return the form for where the heating system is and how often to ask it."""
+    """Return the form for what it takes to read the heating system at all.
+
+    Where it is, which system it is, which register layout it speaks, and how
+    often to ask it.
+    """
     return vol.Schema(
         {
             vol.Required(CONF_HOST, default=current[CONF_HOST]): cv.string,
@@ -90,6 +119,13 @@ def _connection_schema(current: Mapping[str, Any]) -> vol.Schema:
             vol.Optional(
                 CONF_SCAN_INTERVAL, default=current[CONF_SCAN_INTERVAL]
             ): cv.positive_int,
+            vol.Required(
+                CONF_SOLARFOCUS_SYSTEM, default=current[CONF_SOLARFOCUS_SYSTEM]
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=SOLARFOCUS_SYSTEMS, mode=selector.SelectSelectorMode.DROPDOWN
+                ),
+            ),
             vol.Required(
                 CONF_API_VERSION, default=current[CONF_API_VERSION]
             ): selector.SelectSelector(
@@ -270,10 +306,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> config_entries.ConfigFlowResult:
         """Handle the Component Selection step."""
         if user_input is None:
-            # `SOLARFOCUS_SYSTEMS` offers the vampair and the two biomass
-            # boilers and nothing else, so the boiler form covers everything
-            # that is not the heat pump. Falling out of this without a form
-            # would leave the step reading an input the user has not given yet.
+            # The vampair is the only heat pump in `SOLARFOCUS_SYSTEMS`, so the
+            # boiler form covers everything else. Falling out of this without a
+            # form would leave the step reading an input the user has not given
+            # yet.
             if self.data[CONF_SOLARFOCUS_SYSTEM] == Systems.VAMPAIR:
                 return self.async_show_form(
                     step_id="component", data_schema=STEP_COMP_VAMPAIR_SELECTION_SCHEMA
@@ -283,10 +319,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 data_schema=STEP_COMP_THERMINATOR_SELECTION_SCHEMA,
             )
 
+        # Split on the heat pump here as well, so this reads back exactly the
+        # flag the form above asked for. Naming the biomass systems instead
+        # would leave a system neither branch knows about falling through with
+        # both flags unset, into a `KeyError` on the entry below.
         if self.data[CONF_SOLARFOCUS_SYSTEM] == Systems.VAMPAIR:
             self.data[CONF_HEATPUMP] = user_input[CONF_HEATPUMP]
             self.data[CONF_BIOMASS_BOILER] = False
-        elif self.data[CONF_SOLARFOCUS_SYSTEM] in [Systems.THERMINATOR, Systems.ECOTOP]:
+        else:
             self.data[CONF_BIOMASS_BOILER] = user_input[CONF_BIOMASS_BOILER]
             self.data[CONF_HEATPUMP] = False
 
@@ -315,13 +355,20 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:
-        """Point an entry at the address its heating system is on now.
+        """Correct what an entry says its heating system is and where it is.
 
-        The options flow can already change these four settings, but it asks for
-        the whole component layout in the same form: a user whose controller
-        moved to another address has to answer for every component of their
-        heating system in order to say so, and a wrong answer there removes
+        The options flow can already change the address and the interval, but it
+        asks for the whole component layout in the same form: a user whose
+        controller moved to another address has to answer for every component of
+        their heating system in order to say so, and a wrong answer there removes
         entities. This is the connection on its own.
+
+        Which system it is belongs here too. It was asked once, in the user step,
+        and never again, so anyone who picked the wrong one - or picked the
+        nearest of the three that used to be offered - could only fix it by
+        deleting the entry and losing its history. An entity `unique_id` is built
+        from the title of the entry and the key of the entity, and the system is
+        in neither, so changing it here keeps every entity the two systems share.
         """
         entry = self._get_reconfigure_entry()
 
@@ -342,12 +389,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         else:
             try:
                 await validate_input(
-                    self.hass,
-                    {
-                        CONF_NAME: entry.data[CONF_NAME],
-                        CONF_SOLARFOCUS_SYSTEM: entry.data[CONF_SOLARFOCUS_SYSTEM],
-                        **user_input,
-                    },
+                    self.hass, {CONF_NAME: entry.data[CONF_NAME], **user_input}
                 )
             except CannotConnect:
                 errors["base"] = "cannot_connect"
@@ -371,7 +413,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     # here is the collision that migration avoided.
                     unique_id=None if entry.unique_id is None else unique_id,
                     data={**entry.data, **connection},
-                    options={**entry.options, CONF_SCAN_INTERVAL: scan_interval},
+                    options={
+                        **entry.options,
+                        **_heat_source(
+                            entry.data[CONF_SOLARFOCUS_SYSTEM],
+                            user_input[CONF_SOLARFOCUS_SYSTEM],
+                        ),
+                        CONF_SCAN_INTERVAL: scan_interval,
+                    },
                 )
 
         return self.async_show_form(

--- a/custom_components/solarfocus/entity.py
+++ b/custom_components/solarfocus/entity.py
@@ -86,6 +86,18 @@ def create_description[_DescriptionT: SolarfocusEntityDescription](
     )
 
 
+def every_system_but(*supported: Systems) -> list[Systems]:
+    """Return every system except the ones given.
+
+    Some registers are documented for a single system - the register document
+    writes them "Kesselbetriebsart therminator" or "Speichertemperatur Oben
+    octoplus". Naming the system that has the register says that far more
+    plainly than listing the four that do not, and it keeps a system added to
+    the enum later out of a register the document never granted it.
+    """
+    return [system for system in Systems if system not in supported]
+
+
 def filterVersionAndSystem[_EntityT: SolarfocusEntity](
     config_entry: SolarfocusConfigEntry, entities: list[_EntityT]
 ) -> Generator[_EntityT]:

--- a/custom_components/solarfocus/manifest.json
+++ b/custom_components/solarfocus/manifest.json
@@ -9,7 +9,7 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/lavermanjj/home-assistant-solarfocus/issues",
-  "requirements": ["pysolarfocus==5.2.3"],
+  "requirements": ["pysolarfocus==5.2.4"],
   "ssdp": [],
   "version": "6.0.0-rc3",
   "zeroconf": []

--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -59,6 +59,7 @@ from .entity import (
     SolarfocusEntity,
     SolarfocusEntityDescription,
     create_description,
+    every_system_but,
     filterVersionAndSystem,
 )
 
@@ -574,27 +575,31 @@ BIOMASS_BOILER_SENSOR_TYPES = [
         key="boiler_operating_mode",
         device_class=SensorDeviceClass.ENUM,
         options=enum_options(range(0, 6)),
-        unsupported_systems=[Systems.VAMPAIR, Systems.ECOTOP],
+        unsupported_systems=every_system_but(Systems.THERMINATOR),
     ),
     SolarfocusSensorEntityDescription(
         key="octoplus_buffer_temperature_bottom",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        unsupported_systems=[Systems.VAMPAIR, Systems.ECOTOP],
+        # Register 2410 is the buffer only on an octoplus. On every other
+        # Sigmatek boiler bar the vampair it is the return flow temperature -
+        # a different measurement at the same address, which wants an entity
+        # of its own rather than this one under a name that would misread it.
+        unsupported_systems=every_system_but(Systems.OCTOPLUS),
     ),
     SolarfocusSensorEntityDescription(
         key="octoplus_buffer_temperature_top",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        unsupported_systems=[Systems.VAMPAIR, Systems.ECOTOP],
+        unsupported_systems=every_system_but(Systems.OCTOPLUS),
     ),
     SolarfocusSensorEntityDescription(
         key="log_wood",
         device_class=SensorDeviceClass.ENUM,
         options=enum_options(range(0, 2)),
-        unsupported_systems=[Systems.VAMPAIR, Systems.ECOTOP],
+        unsupported_systems=every_system_but(Systems.THERMINATOR),
     ),
     SolarfocusSensorEntityDescription(
         key="pellet_usage_last_fill",

--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -78,17 +78,19 @@
       },
       "reconfigure": {
         "title": "Solarfocus connection",
-        "description": "Change where this entry looks for your heating system. Which components it reads stays as it is.",
+        "description": "Change where this entry looks for your heating system, and which system it is. Which components it reads stays as it is.",
         "data": {
           "host": "Host",
           "port": "Port",
           "scan_interval": "Polling interval (s)",
+          "system": "Solarfocus System",
           "api_version": "Solarfocus API Version"
         },
         "data_description": {
           "host": "The hostname or IP address of the eco manager-touch.",
           "port": "The Modbus TCP port of the controller, 502 unless it was changed.",
           "scan_interval": "How often every configured component is read, in seconds. Five is the lowest accepted.",
+          "system": "Which Solarfocus system this is. Changing it keeps the entities both systems have in common, with their history.",
           "api_version": "The version the controller shows under Fachmann - Modbus. A higher one than it runs creates entities it cannot answer."
         }
       }

--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -78,7 +78,7 @@
       },
       "reconfigure": {
         "title": "Solarfocus connection",
-        "description": "Change where this entry looks for your heating system, and which system it is. Which components it reads stays as it is.",
+        "description": "Change where this entry looks for your heating system, and which system it is. Your component layout is kept - except when you change between the vampair and a biomass boiler, which switches the heat source over and removes the entities of the old one.",
         "data": {
           "host": "Host",
           "port": "Port",

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -89,17 +89,19 @@
       },
       "reconfigure": {
         "title": "Solarfocus-Verbindung",
-        "description": "Ändern, wo dieser Eintrag die Heizungsanlage sucht. Welche Komponenten gelesen werden, bleibt unverändert.",
+        "description": "Ändern, wo dieser Eintrag die Heizungsanlage sucht und um welche Anlage es sich handelt. Welche Komponenten gelesen werden, bleibt unverändert.",
         "data": {
           "host": "Host",
           "port": "Port",
           "scan_interval": "Abfrage Intervall (s)",
+          "system": "Solarfocus System",
           "api_version": "Solarfocus API Version"
         },
         "data_description": {
           "host": "Hostname oder IP-Adresse des eco manager-touch.",
           "port": "Der Modbus-TCP-Port des Reglers, 502 sofern er nicht geändert wurde.",
           "scan_interval": "Wie oft jede konfigurierte Komponente gelesen wird, in Sekunden. Fünf ist der kleinste akzeptierte Wert.",
+          "system": "Um welche Solarfocus-Anlage es sich handelt. Eine Änderung behält die Entitäten, die beide Anlagen gemeinsam haben, samt Verlauf.",
           "api_version": "Die Version, die der Regler unter Fachmann - Modbus anzeigt. Eine höhere als die tatsächliche erzeugt Entitäten, die er nicht beantworten kann."
         }
       }

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -89,7 +89,7 @@
       },
       "reconfigure": {
         "title": "Solarfocus-Verbindung",
-        "description": "Ändern, wo dieser Eintrag die Heizungsanlage sucht und um welche Anlage es sich handelt. Welche Komponenten gelesen werden, bleibt unverändert.",
+        "description": "Ändern, wo dieser Eintrag die Heizungsanlage sucht und um welche Anlage es sich handelt. Die Komponentenauswahl bleibt erhalten - außer beim Wechsel zwischen vampair und einem Biomassekessel: Dabei wird die Wärmequelle umgestellt und die Entitäten der alten entfernt.",
         "data": {
           "host": "Host",
           "port": "Port",

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -78,17 +78,19 @@
       },
       "reconfigure": {
         "title": "Solarfocus connection",
-        "description": "Change where this entry looks for your heating system. Which components it reads stays as it is.",
+        "description": "Change where this entry looks for your heating system, and which system it is. Which components it reads stays as it is.",
         "data": {
           "host": "Host",
           "port": "Port",
           "scan_interval": "Polling interval (s)",
+          "system": "Solarfocus System",
           "api_version": "Solarfocus API Version"
         },
         "data_description": {
           "host": "The hostname or IP address of the eco manager-touch.",
           "port": "The Modbus TCP port of the controller, 502 unless it was changed.",
           "scan_interval": "How often every configured component is read, in seconds. Five is the lowest accepted.",
+          "system": "Which Solarfocus system this is. Changing it keeps the entities both systems have in common, with their history.",
           "api_version": "The version the controller shows under Fachmann - Modbus. A higher one than it runs creates entities it cannot answer."
         }
       }

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -78,7 +78,7 @@
       },
       "reconfigure": {
         "title": "Solarfocus connection",
-        "description": "Change where this entry looks for your heating system, and which system it is. Which components it reads stays as it is.",
+        "description": "Change where this entry looks for your heating system, and which system it is. Your component layout is kept - except when you change between the vampair and a biomass boiler, which switches the heat source over and removes the entities of the old one.",
         "data": {
           "host": "Host",
           "port": "Port",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.8.0,<2027",
-    "pysolarfocus>=5.2.3,<6",
+    "pysolarfocus>=5.2.4,<6",
     "packaging~=24.0",
     "pylint>=3.3.3",
     "pytest-homeassistant-custom-component>=0.13.355,<0.14",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -137,7 +137,18 @@ async def test_full_flow_vampair(
     assert len(setup_entry.mock_calls) == 1
 
 
-@pytest.mark.parametrize("system", [Systems.THERMINATOR, Systems.ECOTOP])
+@pytest.mark.parametrize(
+    "system",
+    [
+        Systems.THERMINATOR,
+        Systems.ECOTOP,
+        # Regression test for #217: the component step branched on the three
+        # systems the dropdown used to offer and had no else, so a fourth left
+        # both heat source flags unset and raised `KeyError` on the next line.
+        Systems.PELLETELEGANCE,
+        Systems.OCTOPLUS,
+    ],
+)
 async def test_full_flow_biomass_systems(
     hass: HomeAssistant, enable_custom_integrations, mock_api, system: Systems
 ) -> None:
@@ -589,6 +600,114 @@ async def test_reconfigure_leaves_the_components_alone(
     assert entry.options[CONF_HEATING_CIRCUIT] == 3
     assert entry.options[CONF_BUFFER] == 2
     assert entry.options[CONF_HEATPUMP] is True
+
+
+async def test_reconfigure_changes_the_system(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """Regression test for #217.
+
+    Which system an entry is was asked once in the user step and never again,
+    so an owner who picked the nearest of the three that used to be offered
+    could only correct it by deleting the entry and losing its history.
+    """
+    entry = build_config_entry(
+        Systems.ECOTOP, heating_circuit=1, biomassboiler=True
+    )
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {**RECONFIGURE_INPUT, CONF_SOLARFOCUS_SYSTEM: Systems.PELLETELEGANCE},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_SOLARFOCUS_SYSTEM] == Systems.PELLETELEGANCE
+
+
+async def test_reconfigure_starts_from_the_current_system(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """The system is being corrected, not chosen again from scratch."""
+    entry = build_config_entry(Systems.ECOTOP, biomassboiler=True)
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+
+    defaults = {
+        key.schema: key.default() for key in result["data_schema"].schema if key.default
+    }
+
+    assert defaults[CONF_SOLARFOCUS_SYSTEM] == Systems.ECOTOP
+
+
+async def test_reconfigure_between_biomass_systems_keeps_the_heat_source(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """Both have a biomass boiler, so there is nothing to switch over.
+
+    Someone who turned the biomass boiler off in the options meant it, and
+    correcting the model of the boiler is no reason to turn it back on.
+    """
+    entry = build_config_entry(
+        Systems.ECOTOP, heating_circuit=1, biomassboiler=False
+    )
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+    await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {**RECONFIGURE_INPUT, CONF_SOLARFOCUS_SYSTEM: Systems.PELLETELEGANCE},
+    )
+    await hass.async_block_till_done()
+
+    assert entry.options[CONF_BIOMASS_BOILER] is False
+    assert entry.options[CONF_HEATPUMP] is False
+
+
+async def test_reconfigure_to_a_heat_pump_switches_the_heat_source(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """The component step only ever offers the heat source the system has.
+
+    So crossing between them here has to switch the flags over, or the entry
+    would go on reading a biomass boiler the vampair does not have.
+    """
+    entry = build_config_entry(
+        Systems.ECOTOP, heating_circuit=1, biomassboiler=True
+    )
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+    await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {**RECONFIGURE_INPUT, CONF_SOLARFOCUS_SYSTEM: Systems.VAMPAIR},
+    )
+    await hass.async_block_till_done()
+
+    assert entry.options[CONF_HEATPUMP] is True
+    assert entry.options[CONF_BIOMASS_BOILER] is False
+
+
+async def test_reconfigure_to_a_biomass_system_switches_the_heat_source(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """And the same crossing the other way."""
+    entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+    await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {**RECONFIGURE_INPUT, CONF_SOLARFOCUS_SYSTEM: Systems.PELLETELEGANCE},
+    )
+    await hass.async_block_till_done()
+
+    assert entry.options[CONF_BIOMASS_BOILER] is True
+    assert entry.options[CONF_HEATPUMP] is False
 
 
 async def test_reconfigure_refuses_the_address_of_another_entry(

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -171,3 +171,64 @@ def test_buffer_x35_excluded_where_missing() -> None:
     unsupported = description.unsupported_systems or []
     for system in (Systems.VAMPAIR, Systems.PELLETELEGANCE, Systems.OCTOPLUS):
         assert system in unsupported
+
+
+@pytest.mark.parametrize("system", list(Systems), ids=lambda s: s.name)
+def test_no_key_is_described_twice_for_one_system(system: Systems) -> None:
+    """One system may only ever reach one description per key.
+
+    A description list is allowed to carry the same key more than once - the
+    biomass boiler door is described twice because register 2405 is reported
+    the other way round on a therminator than on an EcoTop. What the duplicates
+    must not do is survive the system filter together: the key is half of the
+    `unique_id`, so Home Assistant would create the first entity and drop the
+    second, with nothing to say which of the two it kept.
+    """
+    for descriptions, component in DESCRIPTION_LISTS:
+        reached = [
+            description.key
+            for description in descriptions
+            if system not in (description.unsupported_systems or [])
+        ]
+        duplicates = {key for key in reached if reached.count(key) > 1}
+        assert not duplicates, (
+            f"{component} describes {sorted(duplicates)} more than once for "
+            f"system {system.name}; only one of them can become an entity."
+        )
+
+
+# Register -> the one system the register document grants it to. The document
+# names each of these after a single system: "Kesselbetriebsart therminator",
+# "Speichertemperatur Oben octoplus", "Stueckholz therminator". Register 2410 is
+# the octoplus buffer bottom, and on the other Sigmatek boilers the return flow
+# temperature - a different measurement that wants its own entity, not this one.
+SINGLE_SYSTEM_BIOMASS_REGISTERS = [
+    ("boiler_operating_mode", Systems.THERMINATOR),
+    ("log_wood", Systems.THERMINATOR),
+    ("octoplus_buffer_temperature_top", Systems.OCTOPLUS),
+    ("octoplus_buffer_temperature_bottom", Systems.OCTOPLUS),
+]
+
+
+@pytest.mark.parametrize(("key", "supported"), SINGLE_SYSTEM_BIOMASS_REGISTERS)
+def test_single_system_biomass_registers_reach_only_that_system(
+    key: str, supported: Systems
+) -> None:
+    """Regression test for #217.
+
+    These four were excluded from the vampair and the EcoTop and given to
+    everything else, which handed a pellet boiler a log wood register and a
+    therminator two buffer temperatures its controller does not have.
+    """
+    description = next(
+        d for d in sensor.BIOMASS_BOILER_SENSOR_TYPES if d.key == key
+    )
+    unsupported = description.unsupported_systems or []
+
+    assert supported not in unsupported
+    for system in Systems:
+        if system is not supported:
+            assert system in unsupported, (
+                f"{key} is documented for {supported.name} only, but reaches "
+                f"{system.name}."
+            )

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -232,3 +232,52 @@ def test_single_system_biomass_registers_reach_only_that_system(
                 f"{key} is documented for {supported.name} only, but reaches "
                 f"{system.name}."
             )
+
+
+# What register 2405 was measured to hold, and on which boiler. A door contact
+# is worth pinning down: get the polarity backwards and the entity still works,
+# it just says the opposite of the truth, which is how #91 and #101 have stayed
+# open for two years.
+MEASURED_DOOR_POLARITIES = [
+    (Systems.THERMINATOR, "1"),
+    (Systems.ECOTOP, "0"),
+    # 15 kW on v25.110, read at the door for #217: 1 open, 0 closed.
+    (Systems.PELLETELEGANCE, "1"),
+]
+
+
+@pytest.mark.parametrize(("system", "on_state"), MEASURED_DOOR_POLARITIES)
+def test_the_door_contact_reads_the_way_it_was_measured(
+    system: Systems, on_state: str
+) -> None:
+    """Exactly one door description reaches a system, with the measured polarity."""
+    reaching = [
+        d
+        for d in binary_sensor.BIOMASS_BOILER_BINARY_SENSOR_TYPES
+        if d.key == "door_contact"
+        and system not in (d.unsupported_systems or [])
+    ]
+
+    assert len(reaching) == 1, (
+        f"{system.name} reaches {len(reaching)} door descriptions; they share a "
+        f"key, so only one can ever become an entity."
+    )
+    assert reaching[0].on_state == on_state
+
+
+def test_the_octoplus_has_no_door_contact() -> None:
+    """Nobody has read 2405 on an octoplus.
+
+    The two polarities above are both attested on real boilers, so picking one
+    for an unmeasured system is a coin toss that produces a door sensor which
+    is confidently wrong half the time. Better to have no entity until someone
+    reads the register with the door open and with it closed.
+    """
+    reaching = [
+        d
+        for d in binary_sensor.BIOMASS_BOILER_BINARY_SENSOR_TYPES
+        if d.key == "door_contact"
+        and Systems.OCTOPLUS not in (d.unsupported_systems or [])
+    ]
+
+    assert not reaching

--- a/tests/test_library_polling.py
+++ b/tests/test_library_polling.py
@@ -1,0 +1,97 @@
+"""Check what the integration offers against what pysolarfocus actually reads.
+
+An entity is only as good as the poll behind it, and the library's `update_*`
+methods return True both when they read a component and when they decided the
+system has none to read. A component the library quietly skips therefore
+produces entities that sit at their default value forever and a refresh that
+reports success: no exception, no unavailable entity, no repair issue, and
+nothing in the rest of this suite notices.
+
+That is what happened when Pellet Elegance and Octoplus were first added to the
+dropdown - `update_biomassboiler` named THERMINATOR and ECOTOP, so both new
+systems showed a boiler at 0.0 degrees and called it fine. These tests tie the
+dropdown to the library, so offering a system the library does not poll fails
+here instead of in somebody's dashboard.
+"""
+
+import pytest
+from pysolarfocus import ApiVersions, SolarfocusAPI, Systems
+
+from custom_components.solarfocus.config_flow import SOLARFOCUS_SYSTEMS
+from custom_components.solarfocus.const import CONF_BIOMASS_BOILER, CONF_HEATPUMP
+from custom_components.solarfocus.coordinator import COMPONENT_UPDATES
+
+# The systems a user can actually pick, read off the dropdown itself so that
+# adding one to the form brings it under these tests with it.
+OFFERED_SYSTEMS = [Systems(option["value"]) for option in SOLARFOCUS_SYSTEMS]
+
+# The heat source the config flow switches on for a system, and the attribute on
+# the API that the matching `update_*` call is supposed to read.
+HEAT_SOURCE_COMPONENTS = {
+    CONF_HEATPUMP: "heatpump",
+    CONF_BIOMASS_BOILER: "biomassboiler",
+}
+
+LATEST_API_VERSION = list(ApiVersions)[-1]
+
+
+def _heat_source_of(system: Systems) -> str:
+    """Return the component flag `async_step_component` enables for a system."""
+    return CONF_HEATPUMP if system == Systems.VAMPAIR else CONF_BIOMASS_BOILER
+
+
+def _update_method(flag: str) -> str:
+    """Return the API method the coordinator calls for a component flag."""
+    return next(method for conf, method in COMPONENT_UPDATES if conf == flag)
+
+
+@pytest.mark.parametrize("system", OFFERED_SYSTEMS, ids=lambda s: s.name)
+def test_the_heat_source_of_every_offered_system_is_read(
+    system: Systems, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Whichever heat source a system is set up with has to actually be polled."""
+    api = SolarfocusAPI(
+        ip="127.0.0.1", system=system, api_version=LATEST_API_VERSION
+    )
+    flag = _heat_source_of(system)
+    component = getattr(api, HEAT_SOURCE_COMPONENTS[flag])
+
+    reads: list[str] = []
+    monkeypatch.setattr(
+        type(component), "update", lambda self: reads.append(system.name) or True
+    )
+
+    assert getattr(api, _update_method(flag))() is True
+    assert reads, (
+        f"{system.name} is offered in the dropdown and set up with "
+        f"{flag}, but pysolarfocus never reads its {HEAT_SOURCE_COMPONENTS[flag]}. "
+        f"Every entity on it would sit at its default value and the refresh "
+        f"would still report success."
+    )
+
+
+@pytest.mark.parametrize("system", OFFERED_SYSTEMS, ids=lambda s: s.name)
+def test_the_heat_source_a_system_does_not_have_is_skipped(
+    system: Systems, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """And the other one is left alone, rather than read and reported as real."""
+    api = SolarfocusAPI(
+        ip="127.0.0.1", system=system, api_version=LATEST_API_VERSION
+    )
+    absent = (
+        CONF_BIOMASS_BOILER
+        if _heat_source_of(system) == CONF_HEATPUMP
+        else CONF_HEATPUMP
+    )
+    component = getattr(api, HEAT_SOURCE_COMPONENTS[absent])
+
+    reads: list[str] = []
+    monkeypatch.setattr(
+        type(component), "update", lambda self: reads.append(system.name) or True
+    )
+
+    assert getattr(api, _update_method(absent))() is True
+    assert not reads, (
+        f"{system.name} has no {HEAT_SOURCE_COMPONENTS[absent]}, but pysolarfocus "
+        f"reads one for it."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2016,15 +2016,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/08/64/a99f27d3b4347486c
 
 [[package]]
 name = "pysolarfocus"
-version = "5.2.3"
+version = "5.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "pymodbus" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/39/aad717044120e5fa2992e2565454526d9bf3ceff34cd09f43a76f951b7c1/pysolarfocus-5.2.3.tar.gz", hash = "sha256:b94f7c343e55ccd13526706a79176b3d6c8debd048c59c1257651b74ce8f7d4b", size = 742593, upload-time = "2026-08-19T05:25:50.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/00/9d6341ce69c153286f5d8c0b79be510bcca762facefc01a69099770ce7de/pysolarfocus-5.2.4.tar.gz", hash = "sha256:7e3c0f7da607917cea1dc0095eccd77e8d3ee93ca08d63286f81206552b9ce9b", size = 743217, upload-time = "2026-08-19T17:07:45.874Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/c0/fbc95803aea26320a2946e733ac520fc8c0e0913a9c4c3cc130c068b7e6b/pysolarfocus-5.2.3-py3-none-any.whl", hash = "sha256:8492183dc19d302dfb0a9875bea66cef82956c9773cc2e62c31171c297ed9b97", size = 31773, upload-time = "2026-08-19T05:25:49.713Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/fc/32437ef5e2e75a9a62f7d98ee08132a0d458ade9b122bc6ee3c8a6ed3e0e/pysolarfocus-5.2.4-py3-none-any.whl", hash = "sha256:6060a097098135e322562d57f6d66257459833dcc5986a0f274a6c994052e648", size = 31952, upload-time = "2026-08-19T17:07:44.934Z" },
 ]
 
 [[package]]
@@ -2465,7 +2465,7 @@ requires-dist = [
     { name = "packaging", specifier = "~=24.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pylint", specifier = ">=3.3.3" },
-    { name = "pysolarfocus", specifier = ">=5.2.3,<6" },
+    { name = "pysolarfocus", specifier = ">=5.2.4,<6" },
     { name = "pytest-homeassistant-custom-component", specifier = ">=0.13.355,<0.14" },
     { name = "pytest-socket", specifier = ">=0.8.0,<0.9" },
 ]


### PR DESCRIPTION
Closes #217. Needs pysolarfocus **5.2.4**, pinned here — see below.

The dropdown offered three of the five systems pysolarfocus knows, so an owner of a pellet<sup>elegance</sup> or an octo<sup>plus</sup> had to pick the nearest of the three and hope — which is how #215 was found, a Pellet Elegance set up as an EcoTop.

## Correction: the library did need a change

An earlier version of this description said "pysolarfocus needs no change". **That was wrong**, and code review caught it. I had checked `ComponentFactory` and `BiomassBoiler` — the two places #217 flagged — and never checked whether the boiler is *polled* at all:

```python
def update_biomassboiler(self) -> bool:
    if self._system in [Systems.THERMINATOR, Systems.ECOTOP]:
        return self.__component_manager.update("biomassboiler")
    return True
```

`PELLETELEGANCE` and `OCTOPLUS` fell past that branch and returned `True` — the same value a successful read returns. The factory still built the component, so nothing was missing and nothing raised; every `bb_*` entity just sat at its default of 0 (0.0 °C, enum `"0"`, 0 kg) while the refresh reported success. No exception, no unavailable entity, no repair issue. Measured against 5.2.3:

```
VAMPAIR          update_biomassboiler -> True, component read: False
THERMINATOR      update_biomassboiler -> True, component read: True
ECOTOP           update_biomassboiler -> True, component read: True
PELLETELEGANCE   update_biomassboiler -> True, component read: False
OCTOPLUS         update_biomassboiler -> True, component read: False
```

Fixed in LavermanJJ/pysolarfocus#59, released as **5.2.4** and pinned here.

`tests/test_library_polling.py` guards it from this side: it reads the systems straight off `SOLARFOCUS_SYSTEMS` and asserts the library *actually reads* the heat source each is set up with, rather than trusting the `True`. Offering a system the library does not poll now fails the build rather than somebody's dashboard.

## Confirmed on two boilers

#217 would not ship until someone confirmed a Pellet Elegance answers holding registers 33410-33412, because grouping it away from the EcoTop adds that read and a failing slice takes the whole holding read of the boiler with it — the `biomassboiler` repair issue fixed in 5.1.1. Two owners have now read them, on **different firmware**:

| | @digifuchsi, 20 kW, v26.022 | @Nugman, 15 kW, v25.110 |
| --- | --- | --- |
| `33410+3` Kaminkehrer | `0 0 0`, answered | `0 0 0`, answered |
| `34000+3` buffer extern | answered | answered |
| `1902` Puffer X35 | `2700` | `2700` |
| `2410` | `226` → 22.6 °C | `276` → 27.6 °C |
| `2411` | `1500` | `1500` |
| `2405` door | `2` / `2` (contact broken) | **`1` open / `0` closed** |

`1902` reading exactly `2700` on both, against buffers whose top and bottom are plausible tenths (52.1/45.6 and 61.7/59.1 °C), is a constant rather than a sensor — so no `bu_x35_temperature`, which is what the vampair-side buffer already gives these systems. `2410` is a plausible return flow temperature on both, and `2411` is the same constant on both.

## What changed

- **Pellet Elegance and Octoplus in the dropdown**, and in the reconfigure form.
- **`async_step_component` no longer raises.** It branched on the three systems with no `else`, so a fourth left both heat source flags unset and died on a `KeyError` on the next line. It now splits on "is this the heat pump", the same question the form above it asks.
- **Four biomass boiler registers gated to the one system that has them.** The register document names each after a single system — "Kesselbetriebsart therminator", "Speichertemperatur Oben octoplus", "Stückholz therminator" — and all four were instead excluded from the vampair and the EcoTop and handed to everything else.
- **The duplicate `bb_door_contact` is resolved**, and the Pellet Elegance now has one — see below.
- **The system can be corrected without losing history.** It was asked once in the user step and never again. An entity `unique_id` holds the title of the entry and the entity key, and the system is in neither.

## The door contact

Nugman's boiler settles it: **`1` open, `0` closed** — the therminator polarity — so the Pellet Elegance joins that description instead of being excluded. digifuchsi's reads `2` in both positions on a contact its owner reports as broken, which is neither state, so that boiler shows a permanent "closed": the right way for an unfitted contact to fail, and not a reason to withhold the entity from everyone else.

**The Octoplus still has none.** Both polarities are attested on real hardware, so guessing gives a sensor that is confidently wrong half the time.

`test_the_door_contact_reads_the_way_it_was_measured` pins all three measured polarities. Getting one backwards breaks nothing visible — the entity works and simply says the opposite of the truth — which is how #91 and #101 have stayed open for two years.

## Behaviour changes worth calling out

**Existing therminator entries lose two entities:** `bb_octoplus_buffer_temperature_bottom` and `bb_octoplus_buffer_temperature_top`. The document says a therminator has neither — 2410 is *nicht belegt* on it, 2411 is octoplus-only — so these were reporting whatever those addresses happen to hold. Worth a line in the release notes.

**Correcting the system is not free, and now says so.** Crossing between the vampair and a biomass boiler switches the heat source over, which on reload removes the old heat source device and every entity and hour of history on it. The form previously claimed "Which components it reads stays as it is"; it no longer does. And nothing here removes entities one at a time — only whole devices — so a Therminator corrected to an Octoplus keeps its boiler device and leaves the now-ungated `bb_boiler_operating_mode` and `bb_log_wood` behind as unavailable, to be deleted by hand. The README said they were removed; it no longer does.

## Left for a follow-up

Register 2410 is the return flow temperature on every Sigmatek boiler bar the vampair and the therminator — now confirmed on two boilers, currently wearing the name `bb_octoplus_buffer_temperature_bottom`. Gating it to the octoplus is the correct half and is here; naming it properly needs a pysolarfocus attribute first, so it is #223.

## Tests

`every_system_but(...)` replaces the hand-written exclusion lists, so a system added to the enum later is excluded from a single-system register by default rather than silently handed it. New tests, each confirmed to fail without the change it covers:

- `test_the_heat_source_of_every_offered_system_is_read` — the polling gate. Failed against 5.2.3 for exactly the two systems this branch adds; passes on 5.2.4.
- `test_the_door_contact_reads_the_way_it_was_measured` and `test_the_octoplus_has_no_door_contact`.
- `test_no_key_is_described_twice_for_one_system` — no system may reach two descriptions with the same key. Fails on `main` for `PELLETELEGANCE` and `OCTOPLUS`.
- `test_single_system_biomass_registers_reach_only_that_system` — the four registers above. Fails on `main` for all four.
- `test_full_flow_biomass_systems` extended to the two new systems — fails on `main` with the `KeyError`.
- Five reconfigure tests covering the system change and the heat source crossing.

**1071 pass.** pylint, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
