### PR TITLE
Put the service menu codes on the controller, computed rather than read

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ reading is always English.
 
 | Platform | Component | Entities |
 |---|---|---|
+| `sensor` | eco<sup>manager-touch</sup> | Service code and installer code, see [Service menu codes](#service-menu-codes) |
 | `sensor` | Heating circuit | Supply and room temperature, humidity, mixer valve, state |
 | `sensor` | Buffer | Top and bottom temperature, state, mode, external sensors X35 / X36 / X44 |
 | `sensor` | Boiler | Temperature, state, mode, single charge, circulation |
@@ -327,6 +328,7 @@ reading is always English.
 | `water_heater` | Boiler | Domestic hot water |
 | `number` | Heating circuit | Target supply and room temperature, external room temperature and humidity |
 | `number` | Boiler | Target temperature |
+| `number` | eco<sup>manager-touch</sup> | Installer code input, see [Service menu codes](#service-menu-codes) |
 | `number` | Photovoltaic | Smart meter, photovoltaic, grid import/export, HEMS target power, see [Photovoltaic](#photovoltaic) |
 | `select` | Heating circuit | Mode, heating mode, cooling |
 | `select` | Boiler | Holding mode |
@@ -338,6 +340,23 @@ Some noisier or less commonly used entities are created disabled; enable them on
 page if you need them. Which entities exist also depends on the configured API version and on
 the system - a Therminator has no heat pump sensors, and entities added in a later software
 version only appear once that version is selected.
+
+### Service menu codes
+
+The eco<sup>manager-touch</sup> asks for a code before it lets anyone into its service menus, and
+both codes are on the controller device rather than on a component. They read no register, which
+is why they keep reporting while the heating system is unreachable - which is when they tend to be
+wanted - and they change at local midnight rather than with the polling interval.
+
+| Entity | Platform | What it is |
+|---|---|---|
+| `Service code` | `sensor` | The code of the day: day of the month and month, each weighted with the day of the week. Nothing to enter. |
+| `Installer code input` | `number` | The number the installer menu shows on the display. Type it in; it is kept across restarts. |
+| `Installer code` | `sensor` | That number times the day of the week. Unknown until the number is entered. |
+
+**The two installer entities are created disabled**, since entering the number is something an
+installer does once - enable them on the device page of the eco<sup>manager-touch</sup> when you
+need them. `Service code` is enabled.
 
 ### States of the mode and status entities
 

--- a/README.md
+++ b/README.md
@@ -345,18 +345,22 @@ version only appear once that version is selected.
 
 The eco<sup>manager-touch</sup> asks for a code before it lets anyone into its service menus, and
 both codes are on the controller device rather than on a component. They read no register, which
-is why they keep reporting while the heating system is unreachable - which is when they tend to be
-wanted - and they change at local midnight rather than with the polling interval.
+is why they keep reporting once the integration is set up even when the heating system stops
+answering - which is when they tend to be wanted - and they change at local midnight rather than
+with the polling interval. (A Home Assistant restart while the heating system is unreachable is
+the exception: the integration retries its setup until it can read the system once, and until
+then none of its entities exist.)
 
 | Entity | Platform | What it is |
 |---|---|---|
 | `Service code` | `sensor` | The code of the day: day of the month and month, each weighted with the day of the week. Nothing to enter. |
-| `Installer code input` | `number` | The number the installer menu shows on the display. Type it in; it is kept across restarts. |
+| `Installer code input` | `number` | The two-digit number the installer menu shows on the display. Type it in; it is kept across restarts. |
 | `Installer code` | `sensor` | That number times the day of the week. Unknown until the number is entered. |
 
 **The two installer entities are created disabled**, since entering the number is something an
 installer does once - enable them on the device page of the eco<sup>manager-touch</sup> when you
-need them. `Service code` is enabled.
+need them. Enable **both**: `Installer code` has no source other than `Installer code input`, so
+on its own it stays unknown. `Service code` is enabled.
 
 ### States of the mode and status entities
 

--- a/custom_components/solarfocus/coordinator.py
+++ b/custom_components/solarfocus/coordinator.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_SOLAR,
     DOMAIN,
 )
+from .service_menu import DisplayedNumber
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,6 +63,10 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
         # points at it by id rather than by identifier, which Home Assistant
         # deprecates.
         self.hub_device_id: str | None = None
+        # The number the installer menu of the controller shows: typed in on
+        # one entity of it and multiplied by another. Not a register, so it
+        # lives here, where both platforms can reach it.
+        self.displayed_number = DisplayedNumber()
 
         super().__init__(
             hass,

--- a/custom_components/solarfocus/entity.py
+++ b/custom_components/solarfocus/entity.py
@@ -296,3 +296,50 @@ class SolarfocusEntity(Entity):
         )
 
         return native_value
+
+
+class SolarfocusControllerEntity(SolarfocusEntity):
+    """An entity of the controller itself rather than of one of its components.
+
+    The service menu codes are the only things this integration reports without
+    reading a register: they are arithmetic on the date and on what the display
+    of the controller shows. So they belong to the controller, they exist
+    whatever components the entry has configured, and none of what a component
+    entity does with the coordinator applies to them.
+    """
+
+    # There is nothing to poll: these follow the calendar and the user, not the
+    # heating system.
+    _attr_should_poll = False
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return True - these do not depend on the controller answering.
+
+        A heating system that cannot be read is exactly when its service menu is
+        wanted, so they stay available while every other entity of the entry
+        goes unavailable with the poll.
+        """
+        return True
+
+    @property
+    @override
+    def device_info(self) -> DeviceInfo:
+        """Return the controller, which is what these entities belong to.
+
+        The identifier only: `async_setup_entry` registers the device with its
+        name, model and software version, and repeating any of that here would
+        be a second place to change it.
+        """
+        return DeviceInfo(identifiers={(DOMAIN, self._entry_id)})
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Do not follow the poll, unlike every entity of a component.
+
+        There is no reading behind these, so a refresh of the coordinator has
+        nothing to tell them. Home Assistant's own hook is
+        `async_internal_added_to_hass`, which is untouched here - it is what
+        restores the number the user last entered.
+        """

--- a/custom_components/solarfocus/entity.py
+++ b/custom_components/solarfocus/entity.py
@@ -10,6 +10,7 @@ from packaging import version
 from pysolarfocus import Systems
 
 from homeassistant.const import CONF_API_VERSION
+from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
 
@@ -225,6 +226,18 @@ class SolarfocusEntity(Entity):
     @override
     async def async_added_to_hass(self) -> None:
         """Connect to dispatcher listening for entity data notifications."""
+        await super().async_added_to_hass()
+
+        self._async_follow_the_poll()
+
+    @callback
+    def _async_follow_the_poll(self) -> None:
+        """Write this entity on every refresh of the coordinator.
+
+        Its own hook rather than the body of `async_added_to_hass`, so the one
+        kind of entity that has nothing to hear from a poll can leave this out
+        without cutting the chain of hooks Home Assistant itself hangs there.
+        """
         self.async_on_remove(
             self.coordinator.async_add_listener(self.async_write_ha_state)
         )
@@ -320,6 +333,10 @@ class SolarfocusControllerEntity(SolarfocusEntity):
         A heating system that cannot be read is exactly when its service menu is
         wanted, so they stay available while every other entity of the entry
         goes unavailable with the poll.
+
+        Only once the entry is set up, though: a heating system that does not
+        answer the very first read leaves the whole entry retrying its setup,
+        and an entry that never sets up has no entities to keep available.
         """
         return True
 
@@ -334,12 +351,12 @@ class SolarfocusControllerEntity(SolarfocusEntity):
         """
         return DeviceInfo(identifiers={(DOMAIN, self._entry_id)})
 
+    @callback
     @override
-    async def async_added_to_hass(self) -> None:
+    def _async_follow_the_poll(self) -> None:
         """Do not follow the poll, unlike every entity of a component.
 
         There is no reading behind these, so a refresh of the coordinator has
-        nothing to tell them. Home Assistant's own hook is
-        `async_internal_added_to_hass`, which is untouched here - it is what
-        restores the number the user last entered.
+        nothing to tell them. Everything else `async_added_to_hass` does is left
+        alone - that chain is what restores the number the user last entered.
         """

--- a/custom_components/solarfocus/icons.json
+++ b/custom_components/solarfocus/icons.json
@@ -47,6 +47,9 @@
       "hc_target_supply_temperature": {
         "default": "mdi:thermostat"
       },
+      "installer_code_input": {
+        "default": "mdi:dialpad"
+      },
       "pv_grid_im_export": {
         "default": "mdi:transmission-tower"
       },
@@ -464,6 +467,9 @@
           "12": "mdi:power-off"
         }
       },
+      "installer_code": {
+        "default": "mdi:account-hard-hat"
+      },
       "pv_grid_export": {
         "default": "mdi:home-export-outline"
       },
@@ -478,6 +484,9 @@
       },
       "pv_power": {
         "default": "mdi:solar-power"
+      },
+      "service_code": {
+        "default": "mdi:shield-key"
       },
       "so_current_power": {
         "default": "mdi:lightning-bolt"

--- a/custom_components/solarfocus/number.py
+++ b/custom_components/solarfocus/number.py
@@ -181,15 +181,20 @@ DISPLAYED_NUMBER_TYPE = SolarfocusNumberEntityDescription(
     key="installer_code_input",
     translation_key="installer_code_input",
     object_id_name="installer code input",
-    entity_category=EntityCategory.DIAGNOSTIC,
+    # Configuration rather than diagnostic: this is the one entity of the two
+    # that is written to, and Home Assistant reads diagnostic as something a
+    # device reports rather than something anyone changes.
+    entity_category=EntityCategory.CONFIG,
     # Off unless it is asked for, like the code it feeds: entering it is a thing
     # an installer does once.
     entity_registry_enabled_default=False,
     native_min_value=0,
-    native_max_value=99999,
+    # The installer menu shows two digits, so 99 is the highest there is to
+    # type - and a wider range would only let a typo through.
+    native_max_value=99,
     native_step=1,
-    # Nothing documents how wide the number on the display is, so the box takes
-    # whatever is on it rather than a slider pretending to know the range.
+    # A box rather than a slider: the number is read off the display and typed
+    # in, not searched for by dragging.
     mode=NumberMode.BOX,
 )
 

--- a/custom_components/solarfocus/number.py
+++ b/custom_components/solarfocus/number.py
@@ -9,6 +9,7 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
     NumberMode,
+    RestoreNumber,
 )
 from homeassistant.const import PERCENTAGE, UnitOfPower, UnitOfTemperature
 from homeassistant.core import HomeAssistant
@@ -28,6 +29,7 @@ from .const import (
 )
 from .coordinator import SolarfocusConfigEntry, SolarfocusDataUpdateCoordinator
 from .entity import (
+    SolarfocusControllerEntity,
     SolarfocusEntity,
     SolarfocusEntityDescription,
     create_description,
@@ -50,7 +52,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Solarfocus config entry."""
     coordinator = config_entry.runtime_data
-    entities = []
+    # The controller has an entity of its own, which is not a number of a
+    # component, so the list is of what they have in common.
+    entities: list[SolarfocusEntity] = []
 
     for i in range(config_entry.options[CONF_HEATING_CIRCUIT]):
         for description in HEATING_CIRCUIT_NUMBER_TYPES:
@@ -87,6 +91,13 @@ async def async_setup_entry(
 
             entity = SolarfocusNumberEntity(coordinator, _description)
             entities.append(entity)
+
+    # The controller is a device of its own, and the number the installer menu
+    # shows is on it: it is typed in rather than read, so it exists whatever the
+    # entry has configured.
+    entities.append(
+        SolarfocusDisplayedNumberEntity(coordinator, DISPLAYED_NUMBER_TYPE)
+    )
 
     async_add_entities(filterVersionAndSystem(config_entry, entities))
 
@@ -125,6 +136,62 @@ class SolarfocusNumberEntity(SolarfocusEntity, NumberEntity):
         """Return the current state."""
         number = self.entity_description.item
         return cast(float | None, self._get_native_value(number))
+
+
+class SolarfocusDisplayedNumberEntity(SolarfocusControllerEntity, RestoreNumber):
+    """The number the installer menu of the controller shows.
+
+    The only writable entity here that writes nothing: the value goes to the
+    sensor that multiplies it, not to a register, because the display is asking
+    the user for it rather than answering.
+    """
+
+    entity_description: SolarfocusNumberEntityDescription
+
+    @property
+    @override
+    def native_value(self) -> float | None:
+        """Return the number last entered, or None while there is none."""
+        return self.coordinator.displayed_number.value
+
+    @override
+    async def async_set_native_value(self, value: float) -> None:
+        """Take the number that is on the display."""
+        self.coordinator.displayed_number.set(value)
+        self.async_write_ha_state()
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Take back the number that was entered before the restart.
+
+        The display keeps showing the same number until the installer menu is
+        left, so a restart in the middle of that is not a reason to type it
+        again. Writing it back to the shared value is what makes the sensor
+        report it too.
+        """
+        await super().async_added_to_hass()
+
+        if (restored := await self.async_get_last_number_data()) is not None:
+            self.coordinator.displayed_number.set(restored.native_value)
+
+
+# What the display shows, entered by hand. No register behind it, so it names no
+# component and carries no `item`.
+DISPLAYED_NUMBER_TYPE = SolarfocusNumberEntityDescription(
+    key="installer_code_input",
+    translation_key="installer_code_input",
+    object_id_name="installer code input",
+    entity_category=EntityCategory.DIAGNOSTIC,
+    # Off unless it is asked for, like the code it feeds: entering it is a thing
+    # an installer does once.
+    entity_registry_enabled_default=False,
+    native_min_value=0,
+    native_max_value=99999,
+    native_step=1,
+    # Nothing documents how wide the number on the display is, so the box takes
+    # whatever is on it rather than a slider pretending to know the range.
+    mode=NumberMode.BOX,
+)
 
 
 HEATING_CIRCUIT_NUMBER_TYPES = [

--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -306,7 +306,12 @@ class SolarfocusServiceCodeSensor(SolarfocusControllerSensor):
 
 
 class SolarfocusInstallerCodeSensor(SolarfocusControllerSensor):
-    """The installer code, for the number the display of the controller shows."""
+    """The installer code, for the number the display of the controller shows.
+
+    Half of a pair: the number it multiplies has no register behind it and no
+    other source than `Installer code input`, so this one reports nothing at all
+    while that entity is disabled. Enabling the two goes together.
+    """
 
     @override
     async def async_added_to_hass(self) -> None:
@@ -349,6 +354,8 @@ INSTALLER_CODE_SENSOR_TYPE = SolarfocusSensorEntityDescription(
     entity_category=EntityCategory.DIAGNOSTIC,
     # Off unless it is asked for: it reports nothing until the number from the
     # display has been entered, and that is a thing an installer does once.
+    # Enabling this one alone leaves it unknown - the number entity that feeds
+    # it is disabled by default too, and it is the only way in.
     entity_registry_enabled_default=False,
 )
 

--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Iterable
 from dataclasses import dataclass, replace
+from datetime import datetime
 import logging
 from typing import cast, override
 
@@ -23,9 +24,12 @@ from homeassistant.const import (
     UnitOfVolume,
     UnitOfVolumeFlowRate,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_time_change
 from homeassistant.helpers.typing import StateType
+from homeassistant.util import dt as dt_util
 
 from .const import (
     BIOMASS_BOILER_COMPONENT,
@@ -56,12 +60,14 @@ from .const import (
 )
 from .coordinator import SolarfocusConfigEntry, SolarfocusDataUpdateCoordinator
 from .entity import (
+    SolarfocusControllerEntity,
     SolarfocusEntity,
     SolarfocusEntityDescription,
     create_description,
     every_system_but,
     filterVersionAndSystem,
 )
+from .service_menu import installer_code, service_code
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -88,7 +94,9 @@ async def async_setup_entry(
 ) -> None:
     """Initialize sensor platform from config entry."""
     coordinator = config_entry.runtime_data
-    entities = []
+    # The controller has entities of its own, which are not sensors of a
+    # component, so the list is of what they have in common.
+    entities: list[SolarfocusEntity] = []
 
     _LOGGER.debug("Sensor async_setup_entry: %s", config_entry.data)
     _LOGGER.debug("Sensor async_setup_entry: %s", config_entry.options)
@@ -206,6 +214,14 @@ async def async_setup_entry(
             entity = SolarfocusSensor(coordinator, _description)
             entities.append(entity)
 
+    # The controller is a device of its own, and the service menu codes are on
+    # it: they are arithmetic rather than a reading of any component, so they
+    # exist whatever the entry has configured.
+    entities.append(SolarfocusServiceCodeSensor(coordinator, SERVICE_CODE_SENSOR_TYPE))
+    entities.append(
+        SolarfocusInstallerCodeSensor(coordinator, INSTALLER_CODE_SENSOR_TYPE)
+    )
+
     async_add_entities(filterVersionAndSystem(config_entry, entities))
 
 
@@ -248,6 +264,93 @@ class SolarfocusSensor(SolarfocusEntity, SensorEntity):
             return str(int(value))
 
         return cast(StateType, value)
+
+
+class SolarfocusControllerSensor(SolarfocusControllerEntity, SensorEntity):
+    """A sensor of the controller itself, recomputed when the date turns over."""
+
+    entity_description: SolarfocusSensorEntityDescription
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Write the new value when the date turns over.
+
+        Both codes are weighted with the day of the week, so both change at
+        midnight and neither changes with a poll. Local midnight, tracked as a
+        wall clock time rather than as a span of 24 hours, so the day they
+        change on is the day the controller is on across a daylight saving
+        change.
+        """
+        await super().async_added_to_hass()
+
+        self.async_on_remove(
+            async_track_time_change(
+                self.hass, self._async_new_day, hour=0, minute=0, second=0
+            )
+        )
+
+    @callback
+    def _async_new_day(self, now: datetime) -> None:
+        """Report the code of the day that just started."""
+        self.async_write_ha_state()
+
+
+class SolarfocusServiceCodeSensor(SolarfocusControllerSensor):
+    """The service code of the controller, for the day it is read on."""
+
+    @property
+    @override
+    def native_value(self) -> StateType:
+        """Return the code of today."""
+        return service_code(dt_util.now())
+
+
+class SolarfocusInstallerCodeSensor(SolarfocusControllerSensor):
+    """The installer code, for the number the display of the controller shows."""
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Also follow the number, which is the other half of this code."""
+        await super().async_added_to_hass()
+
+        self.async_on_remove(
+            self.coordinator.displayed_number.subscribe(self.async_write_ha_state)
+        )
+
+    @property
+    @override
+    def native_value(self) -> StateType:
+        """Return the code for what is on the display, if that has been entered.
+
+        Unknown until it is: there is no number to multiply, and reporting a 0
+        would read as a code rather than as the absence of one.
+        """
+        displayed = self.coordinator.displayed_number.value
+        if displayed is None:
+            return None
+
+        return installer_code(displayed, dt_util.now())
+
+
+# The two entities of this integration that read no register, so they name no
+# component and carry no `item` - `native_value` computes them. Diagnostic: they
+# say something about the controller rather than about the heating.
+SERVICE_CODE_SENSOR_TYPE = SolarfocusSensorEntityDescription(
+    key="service_code",
+    translation_key="service_code",
+    object_id_name="service code",
+    entity_category=EntityCategory.DIAGNOSTIC,
+)
+
+INSTALLER_CODE_SENSOR_TYPE = SolarfocusSensorEntityDescription(
+    key="installer_code",
+    translation_key="installer_code",
+    object_id_name="installer code",
+    entity_category=EntityCategory.DIAGNOSTIC,
+    # Off unless it is asked for: it reports nothing until the number from the
+    # display has been entered, and that is a thing an installer does once.
+    entity_registry_enabled_default=False,
+)
 
 
 HEATING_CIRCUIT_SENSOR_TYPES = [

--- a/custom_components/solarfocus/service_menu.py
+++ b/custom_components/solarfocus/service_menu.py
@@ -1,0 +1,81 @@
+"""The codes the service menu of the eco manager-touch asks for.
+
+Neither of them is a register. The controller asks for a code before it opens
+its service menu, and the code is arithmetic on the date - which is why this is
+the one corner of the integration that computes rather than reads, and why the
+entities of it sit on the controller rather than on any component.
+"""
+
+from collections.abc import Callable
+from datetime import datetime
+
+from homeassistant.core import CALLBACK_TYPE
+
+
+def weekday(when: datetime) -> int:
+    """Return the day of the week the way Solarfocus counts it: Sunday is 1.
+
+    Home Assistant counts from Monday, as Python does, so Sunday is the day the
+    two disagree about - and the one day in seven a code comes out wrong if the
+    shift is left out.
+    """
+    return 1 if when.weekday() == 6 else when.weekday() + 2
+
+
+def service_code(when: datetime) -> int:
+    """Return the code the service menu asks for on that date.
+
+    The day of the month and the month, each weighted with the day of the week.
+    """
+    day = weekday(when)
+
+    return when.day * (day + 1) + when.month * day
+
+
+def installer_code(displayed: float, when: datetime) -> int:
+    """Return the installer code for the number the display is showing.
+
+    The installer menu goes one step further than the service menu: it shows a
+    number of its own and takes back that number times the day of the week. So
+    unlike the service code this one cannot be computed from the date alone -
+    it needs what is on the display, which is what the number entity takes.
+    """
+    return int(displayed) * weekday(when)
+
+
+class DisplayedNumber:
+    """The number the installer menu shows, shared by the two entities of it.
+
+    The user types it into a number entity and a sensor multiplies it. Both are
+    on the controller and neither is a register, so the value lives here, on the
+    coordinator - the one thing per config entry that every platform is handed.
+
+    Nothing is stored here: the number entity restores what was typed before a
+    restart and writes it back, which is what makes the sensor report again.
+    """
+
+    def __init__(self) -> None:
+        """Start out with nothing entered."""
+        self._value: float | None = None
+        self._listeners: list[CALLBACK_TYPE] = []
+
+    @property
+    def value(self) -> float | None:
+        """Return the number last entered, or None while there is none."""
+        return self._value
+
+    def set(self, value: float | None) -> None:
+        """Take a new number, and tell whoever reports what it comes to."""
+        self._value = value
+
+        for listener in list(self._listeners):
+            listener()
+
+    def subscribe(self, listener: CALLBACK_TYPE) -> Callable[[], None]:
+        """Call `listener` on every change; the return removes it again."""
+        self._listeners.append(listener)
+
+        def unsubscribe() -> None:
+            self._listeners.remove(listener)
+
+        return unsubscribe

--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -201,6 +201,9 @@
       "hc_target_supply_temperature": {
         "name": "Target supply temperature"
       },
+      "installer_code_input": {
+        "name": "Installer code input"
+      },
       "pv_grid_im_export": {
         "name": "Grid im export"
       },
@@ -867,6 +870,9 @@
           "9": "External boiler active, Heat pump off"
         }
       },
+      "installer_code": {
+        "name": "Installer code"
+      },
       "pv_grid_export": {
         "name": "Grid export"
       },
@@ -881,6 +887,9 @@
       },
       "pv_power": {
         "name": "Power"
+      },
+      "service_code": {
+        "name": "Service code"
       },
       "so_buffer_sensor_1": {
         "name": "Buffer sensor 1"

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -220,6 +220,9 @@
       "hc_target_supply_temperature": {
         "name": "Vorlaufsolltemperatur Heizen"
       },
+      "installer_code_input": {
+        "name": "Installateurcode Eingabe"
+      },
       "pv_grid_im_export": {
         "name": "Netzbezug / Einspeisung"
       },
@@ -889,6 +892,9 @@
           "9": "Fremdkessel aktiv, Wärmepumpe aus"
         }
       },
+      "installer_code": {
+        "name": "Installateurcode"
+      },
       "pv_grid_export": {
         "name": "Einspeisung"
       },
@@ -903,6 +909,9 @@
       },
       "pv_power": {
         "name": "Leistung PV"
+      },
+      "service_code": {
+        "name": "Servicecode"
       },
       "so_buffer_sensor_1": {
         "name": "Speicherfühler 1"

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -201,6 +201,9 @@
       "hc_target_supply_temperature": {
         "name": "Target supply temperature"
       },
+      "installer_code_input": {
+        "name": "Installer code input"
+      },
       "pv_grid_im_export": {
         "name": "Grid im export"
       },
@@ -867,6 +870,9 @@
           "9": "External boiler active, Heat pump off"
         }
       },
+      "installer_code": {
+        "name": "Installer code"
+      },
       "pv_grid_export": {
         "name": "Grid export"
       },
@@ -881,6 +887,9 @@
       },
       "pv_power": {
         "name": "Power"
+      },
+      "service_code": {
+        "name": "Service code"
       },
       "so_buffer_sensor_1": {
         "name": "Buffer sensor 1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from custom_components.solarfocus.const import (
     DOMAIN,
     build_unique_id,
 )
+from custom_components.solarfocus.service_menu import DisplayedNumber
 from homeassistant.const import (
     CONF_API_VERSION,
     CONF_HOST,
@@ -146,4 +147,7 @@ def build_coordinator(entry, api: MagicMock | None = None) -> MagicMock:
     coordinator._entry = entry
     coordinator.api = api if api is not None else build_api()
     coordinator.last_update_success = True
+    # The real one, not a mock: the number the installer menu shows is shared
+    # between two entities, and what a test of either is about is that sharing.
+    coordinator.displayed_number = DisplayedNumber()
     return coordinator

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -914,6 +914,11 @@ async def test_every_entity_sits_on_the_component_it_reads(
     for registered in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
         device = device_registry.async_get(registered.device_id)
         identifier = next(iter(device.identifiers))[1]
+        if identifier == entry.entry_id:
+            # The controller itself, which carries the one entity that reads no
+            # component: the service code, computed from the date.
+            continue
+
         component = registered.unique_id.split("_")[1]
         if not identifier.endswith(f"_{component}"):
             misplaced.append((registered.entity_id, identifier))

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -55,14 +55,41 @@ def _keys(entities) -> list[str]:
     return [entity.entity_description.key for entity in entities]
 
 
+def _components(entities) -> list:
+    """Return the entities of the configured components.
+
+    The controller is a device too and has an entity of its own - the service
+    code, which is computed from the date rather than read from a component, so
+    it is there whatever is configured. Every test below counts components.
+    """
+    return [
+        entity for entity in entities if entity.entity_description.component_prefix
+    ]
+
+
 @pytest.mark.parametrize("platform", PLATFORMS, ids=lambda p: p.__name__.split(".")[-1])
 async def test_no_components_creates_no_entities(
     hass: HomeAssistant, platform
 ) -> None:
-    """An entry without any component must not create entities."""
+    """An entry without any component must not create entities of one."""
     entities = await _setup(hass, platform, build_config_entry())
 
-    assert entities == []
+    assert _components(entities) == []
+
+
+async def test_the_controller_always_gets_its_service_menu_entities(
+    hass: HomeAssistant,
+) -> None:
+    """The service menu codes belong to the controller, not to a component.
+
+    They are arithmetic on the date and on what the display shows, so they do
+    not depend on anything being configured, and an entry with no component at
+    all still has them.
+    """
+    entry = build_config_entry()
+
+    assert _keys(await _setup(hass, sensor, entry)) == ["service_code", "installer_code"]
+    assert _keys(await _setup(hass, number, entry)) == ["installer_code_input"]
 
 
 @pytest.mark.parametrize("platform", PLATFORMS, ids=lambda p: p.__name__.split(".")[-1])
@@ -151,8 +178,8 @@ async def test_sensors_are_created_per_component_instance(
     hass: HomeAssistant,
 ) -> None:
     """The number of sensors scales with the configured instances."""
-    single = await _setup(hass, sensor, build_config_entry(buffer=1))
-    double = await _setup(hass, sensor, build_config_entry(buffer=2))
+    single = _components(await _setup(hass, sensor, build_config_entry(buffer=1)))
+    double = _components(await _setup(hass, sensor, build_config_entry(buffer=2)))
 
     assert single
     assert len(double) == 2 * len(single)
@@ -222,7 +249,7 @@ async def test_single_solar_instance_keeps_the_unnumbered_key(
     """A single solar keeps its pre-multi-instance entity id."""
     entry = build_config_entry(solar=1, api_version="25.030")
 
-    entities = await _setup(hass, sensor, entry)
+    entities = _components(await _setup(hass, sensor, entry))
 
     assert entities
     for entity in entities:
@@ -237,7 +264,7 @@ async def test_multiple_solar_instances_are_numbered(hass: HomeAssistant) -> Non
     """From api version 25.030 on, several solar circuits can be configured."""
     entry = build_config_entry(solar=3, api_version="25.030")
 
-    entities = await _setup(hass, sensor, entry)
+    entities = _components(await _setup(hass, sensor, entry))
 
     assert len(entities) == 3 * len(sensor.SOLAR_SENSOR_TYPES)
     assert {entity.entity_description.component_idx for entity in entities} == {
@@ -253,7 +280,7 @@ async def test_older_api_versions_are_limited_to_one_solar(
     """Before 25.030 the device only exposes a single solar circuit."""
     entry = build_config_entry(solar=3, api_version="23.020")
 
-    entities = await _setup(hass, sensor, entry)
+    entities = _components(await _setup(hass, sensor, entry))
 
     assert len(entities) == len(sensor.SOLAR_SENSOR_TYPES)
     assert all(
@@ -268,7 +295,7 @@ async def test_legacy_boolean_solar_option_creates_one_instance(
     """An entry that still stores solar as a boolean must not break setup."""
     entry = build_config_entry(solar=True, api_version="25.030")
 
-    entities = await _setup(hass, sensor, entry)
+    entities = _components(await _setup(hass, sensor, entry))
 
     assert len(entities) == len(sensor.SOLAR_SENSOR_TYPES)
 

--- a/tests/test_service_menu.py
+++ b/tests/test_service_menu.py
@@ -1,0 +1,335 @@
+"""Test the two codes the service menu of the controller asks for.
+
+They are the only values this integration reports without reading a register:
+the service code is arithmetic on the date, the installer code multiplies the
+number the display shows by the day of the week. Both belong to the controller,
+both change at midnight rather than with a poll, and the number behind the
+second one is shared between the entity that takes it and the one that uses it.
+"""
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from pytest_homeassistant_custom_component.common import (
+    async_fire_time_changed,
+    mock_restore_cache_with_extra_data,
+)
+
+from custom_components.solarfocus.const import DOMAIN
+from custom_components.solarfocus.number import (
+    DISPLAYED_NUMBER_TYPE,
+    SolarfocusDisplayedNumberEntity,
+)
+from custom_components.solarfocus.sensor import (
+    INSTALLER_CODE_SENSOR_TYPE,
+    SERVICE_CODE_SENSOR_TYPE,
+    SolarfocusInstallerCodeSensor,
+    SolarfocusServiceCodeSensor,
+)
+from custom_components.solarfocus.service_menu import (
+    DisplayedNumber,
+    installer_code,
+    service_code,
+)
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+
+from .conftest import build_config_entry, build_coordinator
+
+SERVICE_CODE = "sensor.eco_manager_touch_service_code"
+INSTALLER_CODE = "sensor.eco_manager_touch_installer_code"
+INSTALLER_INPUT = "number.eco_manager_touch_installer_code_input"
+
+
+def _at(date: str):
+    """Return noon of that date, which is when nothing is about to turn over."""
+    return dt_util.parse_datetime(f"{date} 12:00:00")
+
+
+def _enable_on_the_controller(entity_registry, entry) -> None:
+    """Switch the two entities of the installer menu on, as a user would.
+
+    Both are created disabled, so a test that wants their states has to be a
+    user who enabled them - which is a registry entry that says so, written
+    before the entry is set up.
+    """
+    for domain, key, object_id in (
+        ("number", "installer_code_input", "eco manager touch installer code input"),
+        ("sensor", "installer_code", "eco manager touch installer code"),
+    ):
+        entity_registry.async_get_or_create(
+            domain,
+            DOMAIN,
+            f"{entry.title}_{key}",
+            suggested_object_id=object_id,
+            disabled_by=None,
+        )
+
+
+def _entity(entity_class, description, entry=None):
+    """Return one entity of the controller, on a mocked coordinator."""
+    entry = entry if entry is not None else build_config_entry()
+    return entity_class(build_coordinator(entry), description)
+
+
+# --- the arithmetic ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("date", "expected"),
+    [
+        # Wednesday: the fourth day of a week that starts on Sunday
+        ("2026-08-19", 19 * 5 + 8 * 4),
+        # Saturday, the last one
+        ("2026-08-22", 22 * 8 + 8 * 7),
+        # Sunday, the first - not the last, which is what the mapping is for
+        ("2026-08-23", 23 * 2 + 8 * 1),
+        ("2026-08-24", 24 * 3 + 8 * 2),
+        ("2026-01-01", 1 * 6 + 1 * 5),
+    ],
+)
+def test_the_service_code_is_the_date_weighted_by_the_weekday(
+    date: str, expected: int
+) -> None:
+    """Day and month, each weighted with the day of the week."""
+    assert service_code(_at(date)) == expected
+
+
+@pytest.mark.parametrize(
+    ("date", "factor"),
+    [
+        ("2026-08-19", 4),
+        ("2026-08-22", 7),
+        ("2026-08-23", 1),
+        ("2026-08-24", 2),
+    ],
+)
+def test_the_installer_code_multiplies_the_displayed_number(
+    date: str, factor: int
+) -> None:
+    """The number on the display, times the day of the week."""
+    assert installer_code(4711, _at(date)) == 4711 * factor
+
+
+def test_sunday_ends_the_week_for_python_and_starts_it_here() -> None:
+    """The mapping is the whole difference between the two counts.
+
+    Reading Sunday as the seventh day of the week rather than the first is the
+    one way these calculations go wrong without looking wrong, and it is wrong
+    on one day in seven.
+    """
+    assert service_code(_at("2026-08-23")) < service_code(_at("2026-08-22"))
+    assert installer_code(100, _at("2026-08-23")) == 100
+    assert installer_code(100, _at("2026-08-22")) == 700
+
+
+# --- the number the display shows -------------------------------------------
+
+
+def test_the_number_is_shared_with_whoever_reports_the_code(
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Setting it on the number entity is what the sensor reads."""
+    freezer.move_to("2026-08-19 12:00:00+00:00")
+    coordinator = build_coordinator(build_config_entry())
+    number = SolarfocusDisplayedNumberEntity(coordinator, DISPLAYED_NUMBER_TYPE)
+    sensor = SolarfocusInstallerCodeSensor(coordinator, INSTALLER_CODE_SENSOR_TYPE)
+
+    coordinator.displayed_number.set(20)
+
+    assert number.native_value == 20
+    assert sensor.native_value == 20 * 4
+
+
+def test_a_change_of_the_number_is_reported_to_its_subscribers() -> None:
+    """The sensor is written on every change, it does not wait for a poll."""
+    displayed = DisplayedNumber()
+    seen = []
+    unsubscribe = displayed.subscribe(lambda: seen.append(displayed.value))
+
+    displayed.set(12)
+    displayed.set(13)
+    unsubscribe()
+    displayed.set(14)
+
+    assert seen == [12, 13]
+
+
+def test_the_installer_code_is_unknown_until_the_number_is_entered() -> None:
+    """Nothing has been typed in, so there is no code - and 0 is not one."""
+    assert _entity(
+        SolarfocusInstallerCodeSensor, INSTALLER_CODE_SENSOR_TYPE
+    ).native_value is None
+
+
+async def test_the_number_writes_nothing_to_the_heating_system(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """The display is asking for the number, not reporting one."""
+    freezer.move_to("2026-08-19 12:00:00+00:00")
+    coordinator = build_coordinator(build_config_entry())
+    number = SolarfocusDisplayedNumberEntity(coordinator, DISPLAYED_NUMBER_TYPE)
+    number.async_write_ha_state = lambda: None
+    sensor = SolarfocusInstallerCodeSensor(coordinator, INSTALLER_CODE_SENSOR_TYPE)
+
+    await number.async_set_native_value(4711)
+
+    # Nothing of the library was touched - no register was read, committed or
+    # written on the way through
+    assert not coordinator.api.method_calls
+    assert number.native_value == 4711
+    assert sensor.native_value == 4711 * 4
+
+
+async def test_the_number_survives_a_restart(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, entity_registry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The display keeps showing the number, so Home Assistant keeps it too.
+
+    A restart in the middle of the installer menu is not a reason to type the
+    number in again, and restoring it is what lets the sensor report a code
+    before anything is entered at all.
+    """
+    freezer.move_to("2026-08-19 12:00:00+02:00")
+    entry = build_config_entry()
+    entry.add_to_hass(hass)
+    _enable_on_the_controller(entity_registry, entry)
+
+    mock_restore_cache_with_extra_data(
+        hass,
+        (
+            (
+                State(INSTALLER_INPUT, "4711"),
+                {
+                    "native_max_value": 99999,
+                    "native_min_value": 0,
+                    "native_step": 1,
+                    "native_unit_of_measurement": None,
+                    "native_value": 4711,
+                },
+            ),
+        ),
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(INSTALLER_INPUT).state == "4711"
+    assert hass.states.get(INSTALLER_CODE).state == str(4711 * 4)
+
+
+# --- the entities on the controller -----------------------------------------
+
+
+async def test_the_service_code_sensor_reports_the_code_of_today(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """The state is the code, computed when it is asked for."""
+    freezer.move_to("2026-08-19 12:00:00+00:00")
+
+    assert _entity(
+        SolarfocusServiceCodeSensor, SERVICE_CODE_SENSOR_TYPE
+    ).native_value == 127
+
+
+@pytest.mark.parametrize(
+    ("entity_class", "description"),
+    [
+        (SolarfocusServiceCodeSensor, SERVICE_CODE_SENSOR_TYPE),
+        (SolarfocusInstallerCodeSensor, INSTALLER_CODE_SENSOR_TYPE),
+        (SolarfocusDisplayedNumberEntity, DISPLAYED_NUMBER_TYPE),
+    ],
+)
+def test_they_sit_on_the_controller(entity_class, description) -> None:
+    """These are properties of the controller, not of any component."""
+    entry = build_config_entry()
+
+    assert _entity(entity_class, description, entry).device_info["identifiers"] == {
+        (DOMAIN, entry.entry_id)
+    }
+
+
+@pytest.mark.parametrize(
+    ("entity_class", "description"),
+    [
+        (SolarfocusServiceCodeSensor, SERVICE_CODE_SENSOR_TYPE),
+        (SolarfocusInstallerCodeSensor, INSTALLER_CODE_SENSOR_TYPE),
+        (SolarfocusDisplayedNumberEntity, DISPLAYED_NUMBER_TYPE),
+    ],
+)
+def test_they_stay_available_when_the_heating_cannot_be_read(
+    entity_class, description
+) -> None:
+    """A heating system that does not answer is when the service menu is wanted."""
+    entity = _entity(entity_class, description)
+    entity.coordinator.last_update_success = False
+
+    assert entity.available
+
+
+async def test_the_registry_agrees_where_they_belong(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry,
+    entity_registry,
+) -> None:
+    """The registry is what puts them on the page of the controller.
+
+    The two the installer needs are created disabled, so they are only there to
+    be found with the disabled ones included.
+    """
+    entry = build_config_entry()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    controller = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+    registered = {
+        entity.entity_id: entity
+        for entity in er.async_entries_for_device(
+            entity_registry, controller.id, include_disabled_entities=True
+        )
+    }
+
+    assert set(registered) == {SERVICE_CODE, INSTALLER_CODE, INSTALLER_INPUT}
+    assert all(
+        entity.device_id == controller.id
+        and entity.entity_category == er.EntityCategory.DIAGNOSTIC
+        for entity in registered.values()
+    )
+    assert registered[SERVICE_CODE].disabled_by is None
+    assert registered[INSTALLER_CODE].disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    assert registered[INSTALLER_INPUT].disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+
+async def test_the_codes_change_at_midnight(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, entity_registry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A code a day old opens nothing, and nothing polls these entities."""
+    await hass.config.async_set_time_zone("Europe/Vienna")
+    freezer.move_to("2026-08-19 23:59:00+02:00")
+
+    entry = build_config_entry()
+    entry.add_to_hass(hass)
+    _enable_on_the_controller(entity_registry, entry)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": INSTALLER_INPUT, "value": 4711},
+        blocking=True,
+    )
+
+    assert hass.states.get(SERVICE_CODE).state == "127"
+    assert hass.states.get(INSTALLER_CODE).state == str(4711 * 4)
+
+    freezer.move_to("2026-08-20 00:00:01+02:00")
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SERVICE_CODE).state == "160"
+    # Thursday, the fifth day of a week that starts on Sunday
+    assert hass.states.get(INSTALLER_CODE).state == str(4711 * 5)

--- a/tests/test_service_menu.py
+++ b/tests/test_service_menu.py
@@ -31,6 +31,7 @@ from custom_components.solarfocus.service_menu import (
     service_code,
 )
 from homeassistant.core import HomeAssistant, State
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
@@ -108,7 +109,7 @@ def test_the_installer_code_multiplies_the_displayed_number(
     date: str, factor: int
 ) -> None:
     """The number on the display, times the day of the week."""
-    assert installer_code(4711, _at(date)) == 4711 * factor
+    assert installer_code(47, _at(date)) == 47 * factor
 
 
 def test_sunday_ends_the_week_for_python_and_starts_it_here() -> None:
@@ -119,8 +120,8 @@ def test_sunday_ends_the_week_for_python_and_starts_it_here() -> None:
     on one day in seven.
     """
     assert service_code(_at("2026-08-23")) < service_code(_at("2026-08-22"))
-    assert installer_code(100, _at("2026-08-23")) == 100
-    assert installer_code(100, _at("2026-08-22")) == 700
+    assert installer_code(10, _at("2026-08-23")) == 10
+    assert installer_code(10, _at("2026-08-22")) == 70
 
 
 # --- the number the display shows -------------------------------------------
@@ -172,13 +173,13 @@ async def test_the_number_writes_nothing_to_the_heating_system(
     number.async_write_ha_state = lambda: None
     sensor = SolarfocusInstallerCodeSensor(coordinator, INSTALLER_CODE_SENSOR_TYPE)
 
-    await number.async_set_native_value(4711)
+    await number.async_set_native_value(47)
 
     # Nothing of the library was touched - no register was read, committed or
     # written on the way through
     assert not coordinator.api.method_calls
-    assert number.native_value == 4711
-    assert sensor.native_value == 4711 * 4
+    assert number.native_value == 47
+    assert sensor.native_value == 47 * 4
 
 
 async def test_the_number_survives_a_restart(
@@ -200,13 +201,13 @@ async def test_the_number_survives_a_restart(
         hass,
         (
             (
-                State(INSTALLER_INPUT, "4711"),
+                State(INSTALLER_INPUT, "47"),
                 {
-                    "native_max_value": 99999,
+                    "native_max_value": 99,
                     "native_min_value": 0,
                     "native_step": 1,
                     "native_unit_of_measurement": None,
-                    "native_value": 4711,
+                    "native_value": 47,
                 },
             ),
         ),
@@ -215,8 +216,32 @@ async def test_the_number_survives_a_restart(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.states.get(INSTALLER_INPUT).state == "4711"
-    assert hass.states.get(INSTALLER_CODE).state == str(4711 * 4)
+    assert hass.states.get(INSTALLER_INPUT).state == "47"
+    assert hass.states.get(INSTALLER_CODE).state == str(47 * 4)
+
+
+async def test_the_number_takes_the_two_digits_the_display_shows(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, entity_registry,
+) -> None:
+    """The installer menu shows two digits, so 99 is the highest there is."""
+    entry = build_config_entry()
+    entry.add_to_hass(hass)
+    _enable_on_the_controller(entity_registry, entry)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": INSTALLER_INPUT, "value": 99},
+        blocking=True,
+    )
+    assert float(hass.states.get(INSTALLER_INPUT).state) == 99
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            "number", "set_value", {"entity_id": INSTALLER_INPUT, "value": 100},
+            blocking=True,
+        )
 
 
 # --- the entities on the controller -----------------------------------------
@@ -291,11 +316,12 @@ async def test_the_registry_agrees_where_they_belong(
     }
 
     assert set(registered) == {SERVICE_CODE, INSTALLER_CODE, INSTALLER_INPUT}
-    assert all(
-        entity.device_id == controller.id
-        and entity.entity_category == er.EntityCategory.DIAGNOSTIC
-        for entity in registered.values()
-    )
+    assert all(entity.device_id == controller.id for entity in registered.values())
+    # The two that only report are diagnostic; the one that is typed into is
+    # configuration, which is the category Home Assistant has for a control.
+    assert registered[SERVICE_CODE].entity_category is er.EntityCategory.DIAGNOSTIC
+    assert registered[INSTALLER_CODE].entity_category is er.EntityCategory.DIAGNOSTIC
+    assert registered[INSTALLER_INPUT].entity_category is er.EntityCategory.CONFIG
     assert registered[SERVICE_CODE].disabled_by is None
     assert registered[INSTALLER_CODE].disabled_by is er.RegistryEntryDisabler.INTEGRATION
     assert registered[INSTALLER_INPUT].disabled_by is er.RegistryEntryDisabler.INTEGRATION
@@ -319,12 +345,12 @@ async def test_the_codes_change_at_midnight(
     await hass.services.async_call(
         "number",
         "set_value",
-        {"entity_id": INSTALLER_INPUT, "value": 4711},
+        {"entity_id": INSTALLER_INPUT, "value": 47},
         blocking=True,
     )
 
     assert hass.states.get(SERVICE_CODE).state == "127"
-    assert hass.states.get(INSTALLER_CODE).state == str(4711 * 4)
+    assert hass.states.get(INSTALLER_CODE).state == str(47 * 4)
 
     freezer.move_to("2026-08-20 00:00:01+02:00")
     async_fire_time_changed(hass)
@@ -332,4 +358,4 @@ async def test_the_codes_change_at_midnight(
 
     assert hass.states.get(SERVICE_CODE).state == "160"
     # Thursday, the fifth day of a week that starts on Sunday
-    assert hass.states.get(INSTALLER_CODE).state == str(4711 * 5)
+    assert hass.states.get(INSTALLER_CODE).state == str(47 * 5)

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -34,6 +34,7 @@ from custom_components.solarfocus.const import (
     BOILER_PREFIX,
     BUFFER_PREFIX,
     COMPONENT_DEVICES,
+    CONTROLLER_NAME,
     DOMAIN,
     FRESH_WATER_MODULE_PREFIX,
     HEAT_PUMP_PREFIX,
@@ -429,7 +430,9 @@ async def test_an_entity_name_is_the_words_of_its_key(hass: HomeAssistant) -> No
     wrong = []
     async for domain, description in _descriptions(hass):
         name = entity[domain][description.translation_key]["name"]
-        expected = description.item.replace("_", " ")
+        # What the entity id is built from, which is the words of the key -
+        # the entity of the controller has no register to take them from
+        expected = description.object_id_name
         if name.lower() != expected.lower():
             wrong.append((domain, description.translation_key, name, expected))
 
@@ -461,7 +464,9 @@ async def test_no_entity_name_repeats_its_component(
         for key, block in keys.items()
         if block["name"]
         .lower()
-        .startswith(component_of[key.split("_")[0]].lower() + " ")
+        # An unprefixed key is one of the controller's own, and the device it
+        # reads on is the controller.
+        .startswith(component_of.get(key.split("_")[0], CONTROLLER_NAME).lower() + " ")
     ]
 
     assert not repeated


### PR DESCRIPTION
The eco<sup>manager-touch</sup> asks for a code before it opens its service menus, and those codes are arithmetic on the date rather than anything the heating system answers. These are the first entities of this integration that read no register, and they sit on the controller device rather than on a component.

| Entity | Platform | State |
|---|---|---|
| `Service code` | `sensor` | Day of the month and month, each weighted with the day of the week |
| `Installer code input` | `number` | The number the installer menu shows on the display, typed in by hand |
| `Installer code` | `sensor` | That number times the day of the week; unknown until the number is entered |

The two installer entities are created **disabled** - entering the number is something an installer does once. `Service code` is enabled.

### Notes

- **Sunday.** The controller counts it as the first day of the week, Python as the last. That is the one day in seven a code comes out wrong if the shift is left out, so `service_menu.weekday` is that shift, in one place for both codes.
- **The number is not a register either**, so it lives on the coordinator - the one object per entry that both platforms are handed - and the entity that takes it restores what was typed before a restart, because the display is still showing the same number.
- **`SolarfocusControllerEntity`** holds what the three have in common: the device of the controller, no polling, and staying available while the heating cannot be read - which is exactly when a service menu is wanted.
- They change at **local midnight**, tracked as a wall clock time, rather than with the polling interval.

### Tests

`tests/test_service_menu.py` covers the arithmetic for both codes across the Sunday boundary, the number being shared between the two entities, `unknown` before anything is entered, that setting it touches no register, restore across a restart, both codes rolling over at midnight, and the registry agreeing where the three sit and which two start disabled.

Three existing tests assumed every entity belongs to a component and were adjusted for the controller having entities of its own.

1096 passed; `make check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)