### PR TITLE
Set the version to 6.0.0-rc4

### DIFF
--- a/custom_components/solarfocus/manifest.json
+++ b/custom_components/solarfocus/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/lavermanjj/home-assistant-solarfocus/issues",
   "requirements": ["pysolarfocus==5.2.4"],
   "ssdp": [],
-  "version": "6.0.0-rc3",
+  "version": "6.0.0-rc4",
   "zeroconf": []
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "solarfocus"
-version = "6.0.0rc3"
+version = "6.0.0rc4"
 description = "Custom component for integrating Solarfocus heating systems into Home Assistant."
 authors = [{ name = "Jeroen Laverman", email = "jjlaverman@web.de" }]
 requires-python = ">=3.14.2,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -2441,7 +2441,7 @@ wheels = [
 
 [[package]]
 name = "solarfocus"
-version = "6.0.0rc3"
+version = "6.0.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
The fourth pre-release of the 6.0.0 line: the manifest, `pyproject.toml` and the lock file.

On top of rc3 this carries #221 (strict typing), #222 (Pellet Elegance and Octoplus, and correcting the system of an entry) and #224 (the service menu codes on the controller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)