### PR TITLE
Offer every API version the library speaks (#218)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,10 @@ of the eco<sup>manager-touch</sup>, see the warning about the dew point under [C
 > **Important**
 > This integration has been tested with Solarfocus eco<sup>manager-touch</sup> version `25.030`.
 
-Supported versions: `21.140` - `26.020`. Features added in later versions are not yet supported.
+Supported versions: `20.110`, `21.140`, `22.090`, `23.010`, `23.020`, `23.040`, `23.080`,
+`25.020`, `25.030`, `25.100` and `26.020` - every version the register layout changed in.
+Features added after `26.020` are not yet supported. If the version on your display is not
+one of these, pick the highest one below it: `25.110` is configured as `25.100`.
 
 The eco<sup>manager-touch</sup> Modbus TCP specification can be found [here](https://www.solarfocus.com/de/partnerportal/pdf/open/UGFydG5lcmJlcmVpY2gtREUvUmVnZWx1bmdfZWNvbWFuYWdlci10b3VjaC9BbmxlaXR1bmdlbi9lY29tYW5hZ2VyLXRvdWNoX01vZGJ1cy1UQ1AtUmVnaXN0ZXJkYXRlbl9BbmxlaXR1bmcucGRm/117920/0/Lng_YSxpM245S30zMTc4W2Y8cVRRXWlJVWRQJDsv?serialNumber=21010).
 
@@ -256,7 +259,7 @@ which asks for the connection on its own and leaves your component layout untouc
 | Port | Modbus TCP port. |
 | Polling interval (s) | Seconds between two reads, the same setting as above. |
 | Solarfocus System | Correct a system picked wrongly at setup, e.g. a pellet<sup>elegance</sup> added as an EcoTop before it was offered. Entities are identified by the name of the entry and their own key, neither of which holds the system, so every entity the two systems share keeps its history. Entities only the new system has appear empty until the next poll. See below for what happens to the ones only the old system had. |
-| Solarfocus API Version | Raise this after a software update of the heating system to get the entities that version added. Setting it higher than the controller runs makes it answer the wrong registers, see [Troubleshooting](#troubleshooting). |
+| Solarfocus API Version | Raise this after a software update of the heating system to get the entities that version added. A version your display shows but the list does not offer is configured as the highest version below it, see [Software](#software). Setting it higher than the controller runs makes it answer the wrong registers, see [Troubleshooting](#troubleshooting). |
 
 Changing between the vampair and any of the biomass boilers also switches the heat source the
 entry reads, since no system has both. That removes the device of the old heat source and every
@@ -484,8 +487,9 @@ probably not answered by your software version - lower the API version under
 **Entities I expect are missing.**
 Either the component is set to 0 in the options, or the entity needs a newer API version than
 the one configured, or it does not exist for your system. Check the version selected under
-[Changing the Connection](#changing-the-connection) against the version shown on your display,
-and note that some entities are created disabled and have to be enabled on the device page.
+[Changing the Connection](#changing-the-connection) against the version shown on your display -
+if yours is not on the list, the highest version below it is the right choice - and note that
+some entities are created disabled and have to be enabled on the device page.
 
 **A device trigger or a device action in an automation stopped working.**
 The entities moved from the one device an entry used to have onto the device of their component,

--- a/custom_components/solarfocus/config_flow.py
+++ b/custom_components/solarfocus/config_flow.py
@@ -57,14 +57,15 @@ SOLARFOCUS_SYSTEMS = [
 ]
 
 # CONF_API_VERSION
+# Every version the library speaks is a version the user can pick, so the list
+# is taken from it rather than written out again here. Kept by hand it fell
+# behind - 25.100 was missing from it while controllers in the field were on
+# 25.110 - and a version that is not offered leaves the user choosing one that
+# is too low, which silently drops the registers added since. Newest first,
+# which is the declaration order of the enum reversed.
 SOLARFOCUS_API_VERSIONS = [
-    selector.SelectOptionDict(value="26.020", label="v26.020"),
-    selector.SelectOptionDict(value="25.030", label="v25.030"),
-    selector.SelectOptionDict(value="23.040", label="v23.040"),
-    selector.SelectOptionDict(value="23.020", label="v23.020"),
-    selector.SelectOptionDict(value="23.010", label="v23.010"),
-    selector.SelectOptionDict(value="22.090", label="v22.090"),
-    selector.SelectOptionDict(value="21.140", label="v21.140"),
+    selector.SelectOptionDict(value=api_version.value, label=f"v{api_version.value}")
+    for api_version in reversed(ApiVersions)
 ]
 
 _COMPONENT_COUNT_ZERO_EIGHT_SELECTOR = vol.All(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -94,6 +94,59 @@ async def test_form_shown_without_input(
     assert result["errors"] is None
 
 
+@pytest.mark.parametrize("step", ["user", "reconfigure"])
+async def test_every_api_version_of_the_library_is_offered(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, step: str
+) -> None:
+    """Regression test for #218: 25.100 was missing from the hand-kept list.
+
+    Every version `pysolarfocus` speaks is one a controller in the field can be
+    on, so leaving one out means the user picks a lower one and silently loses
+    the registers added since. Both forms that ask for the version read the
+    same list, newest first.
+    """
+    if step == "user":
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}
+        )
+    else:
+        entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
+        entry.add_to_hass(hass)
+        result = await _start_reconfigure(hass, entry)
+
+    versions = _offered_api_versions(result)
+
+    assert versions == [api_version.value for api_version in reversed(ApiVersions)]
+    assert ApiVersions.V_25_100.value in versions
+
+
+def _offered_api_versions(result) -> list[str]:
+    """Return the versions the version selector of a form offers, in order."""
+    schema = result["data_schema"].schema
+    selector_config = next(
+        value.config for key, value in schema.items() if key.schema == CONF_API_VERSION
+    )
+    return [option["value"] for option in selector_config["options"]]
+
+
+async def test_a_newly_offered_api_version_can_be_chosen(
+    hass: HomeAssistant, enable_custom_integrations, mock_api
+) -> None:
+    """The version the selector gained is the version the entry ends up on."""
+    result = await _start_user_step(
+        hass, {**USER_INPUT, CONF_API_VERSION: ApiVersions.V_25_100.value}
+    )
+
+    with patch("custom_components.solarfocus.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], VAMPAIR_COMPONENTS
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_API_VERSION] == ApiVersions.V_25_100.value
+
+
 async def test_full_flow_vampair(
     hass: HomeAssistant, enable_custom_integrations, mock_api
 ) -> None:


### PR DESCRIPTION
Fixes #218.

`SOLARFOCUS_API_VERSIONS` was written out by hand next to `ApiVersions` and had fallen behind it. Missing: **25.100**, 25.020, 23.080 and 20.110 — the last three gate real registers in `pysolarfocus` (biomass boiler, boiler), and 25.100 is the version [#215](https://github.com/LavermanJJ/home-assistant-solarfocus/issues/215) needed. Picking a version that is too low silently drops the registers added since.

## Changes

- `config_flow.py`: build the selector options from `ApiVersions`, newest first, so the list cannot drift from the library again. Both the user step and the reconfigure step read it, so an existing entry can move to 25.100 through **Reconfigure**.
- `tests/test_config_flow.py`: the options offered by both forms equal every `ApiVersions` value in order, and a full flow on 25.100 lands on 25.100.
- `README.md`: list the versions, and say that a display version not on the list is configured as the highest version below it (`25.110` → `25.100`).

## On 25.110

Out of scope here — it belongs in `pysolarfocus`, which has no `ApiVersions` entry for it. Nothing in the library gates on `V_25_100` today, so 25.100 and 25.030 currently read the same registers; a 25.110 controller configured as 25.100 gets everything the library knows about. If 25.110 turns out to add registers, that is a library change plus one more selector entry, which this now picks up for free.

## Checks

`make check` clean, 1112 tests pass, `config_flow.py` at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)