### PR TITLE
Give the boilers that read a return flow temperature its own entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ reading is always English.
 | `sensor` | Buffer | Top and bottom temperature, state, mode, external sensors X35 / X36 / X44 |
 | `sensor` | Boiler | Temperature, state, mode, single charge, circulation |
 | `sensor` | Heat pump | Outdoor, supply and return temperature, flow rate, compressor speed, electrical and thermal energy and power, COP and overall performance, state |
-| `sensor` | Biomass boiler | Temperature, status, message number, cleaning, ash container, outdoor temperature, operating mode, log wood, pellet usage, heat energy |
+| `sensor` | Biomass boiler | Temperature, return temperature, status, message number, cleaning, ash container, outdoor temperature, operating mode, log wood, pellet usage, heat energy |
 | `sensor` | Solar | Collector, supply, return and buffer temperatures, flow, current power, yields, state |
 | `sensor` | Photovoltaic | Power, house consumption, heat pump consumption, grid import and export |
 | `sensor` | Fresh water module | State, supply and target temperature, flow rate |

--- a/custom_components/solarfocus/icons.json
+++ b/custom_components/solarfocus/icons.json
@@ -143,6 +143,9 @@
       "bb_pellet_usage_total": {
         "default": "mdi:alpha-t-box"
       },
+      "bb_return_temperature": {
+        "default": "mdi:thermometer-chevron-down"
+      },
       "bb_status": {
         "default": "mdi:fire-circle",
         "state": {

--- a/custom_components/solarfocus/manifest.json
+++ b/custom_components/solarfocus/manifest.json
@@ -9,7 +9,7 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/lavermanjj/home-assistant-solarfocus/issues",
-  "requirements": ["pysolarfocus==5.2.4"],
+  "requirements": ["pysolarfocus==5.3.0"],
   "ssdp": [],
   "version": "6.0.0-rc5",
   "zeroconf": []

--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -694,9 +694,24 @@ BIOMASS_BOILER_SENSOR_TYPES = [
         state_class=SensorStateClass.MEASUREMENT,
         # Register 2410 is the buffer only on an octoplus. On every other
         # Sigmatek boiler bar the vampair it is the return flow temperature -
-        # a different measurement at the same address, which wants an entity
-        # of its own rather than this one under a name that would misread it.
+        # a different measurement at the same address, which has an entity of
+        # its own below rather than this one under a name that would misread it.
         unsupported_systems=every_system_but(Systems.OCTOPLUS),
+    ),
+    SolarfocusSensorEntityDescription(
+        key="return_temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        # The other half of register 2410, and the reason gating the buffer
+        # bottom to the octoplus was only half the fix: the boilers that were
+        # reporting a return flow temperature under the buffer's name get it
+        # back under its own. The document grants it to "alle anderen Sigmatek
+        # Kessel (ohne vampair)" bar the therminator, where 2410 is nicht
+        # belegt - which leaves the EcoTop and the Pellet Elegance.
+        unsupported_systems=every_system_but(
+            Systems.ECOTOP, Systems.PELLETELEGANCE
+        ),
     ),
     SolarfocusSensorEntityDescription(
         key="octoplus_buffer_temperature_top",

--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -431,6 +431,9 @@
       "bb_pellet_usage_total": {
         "name": "Pellet usage total"
       },
+      "bb_return_temperature": {
+        "name": "Return temperature"
+      },
       "bb_status": {
         "name": "Status",
         "state": {

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -450,6 +450,9 @@
       "bb_pellet_usage_total": {
         "name": "Pelletverbrauch gesamt"
       },
+      "bb_return_temperature": {
+        "name": "Rücklauftemperatur"
+      },
       "bb_status": {
         "name": "Statuszeile",
         "state": {

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -431,6 +431,9 @@
       "bb_pellet_usage_total": {
         "name": "Pellet usage total"
       },
+      "bb_return_temperature": {
+        "name": "Return temperature"
+      },
       "bb_status": {
         "name": "Status",
         "state": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.8.0,<2027",
-    "pysolarfocus>=5.2.4,<6",
+    "pysolarfocus>=5.3.0,<6",
     "packaging~=24.0",
     "pylint>=3.3.3",
     "pytest-homeassistant-custom-component>=0.13.355,<0.14",

--- a/tests/test_library_polling.py
+++ b/tests/test_library_polling.py
@@ -12,14 +12,25 @@ dropdown - `update_biomassboiler` named THERMINATOR and ECOTOP, so both new
 systems showed a boiler at 0.0 degrees and called it fine. These tests tie the
 dropdown to the library, so offering a system the library does not poll fails
 here instead of in somebody's dashboard.
+
+The same goes for the registers under a component. An entity reads its value by
+`getattr`-ing its key off the pysolarfocus component, so a description whose key
+the library does not carry for that system raises an `AttributeError` on the
+first read - which is why register 2410 could not simply be renamed here and
+needed the library to name it first (issue #223).
 """
 
-import pytest
+from packaging import version
 from pysolarfocus import ApiVersions, SolarfocusAPI, Systems
+import pytest
 
+from custom_components.solarfocus.binary_sensor import (
+    BIOMASS_BOILER_BINARY_SENSOR_TYPES,
+)
 from custom_components.solarfocus.config_flow import SOLARFOCUS_SYSTEMS
 from custom_components.solarfocus.const import CONF_BIOMASS_BOILER, CONF_HEATPUMP
 from custom_components.solarfocus.coordinator import COMPONENT_UPDATES
+from custom_components.solarfocus.sensor import BIOMASS_BOILER_SENSOR_TYPES
 
 # The systems a user can actually pick, read off the dropdown itself so that
 # adding one to the form brings it under these tests with it.
@@ -95,3 +106,96 @@ def test_the_heat_source_a_system_does_not_have_is_skipped(
         f"{system.name} has no {HEAT_SOURCE_COMPONENTS[absent]}, but pysolarfocus "
         f"reads one for it."
     )
+
+
+# Every description of the biomass boiler, whichever platform reports it.
+BIOMASS_BOILER_DESCRIPTIONS = [
+    *BIOMASS_BOILER_SENSOR_TYPES,
+    *BIOMASS_BOILER_BINARY_SENSOR_TYPES,
+]
+
+
+def _reaches(system: Systems, description) -> bool:
+    """Return whether a description survives the system and version filter."""
+    return system not in (
+        description.unsupported_systems or []
+    ) and version.parse(description.min_required_version) <= version.parse(
+        LATEST_API_VERSION.value
+    )
+
+
+@pytest.mark.parametrize("system", OFFERED_SYSTEMS, ids=lambda s: s.name)
+def test_every_biomass_boiler_entity_has_a_register_behind_it(
+    system: Systems,
+) -> None:
+    """A description the library has no attribute for cannot be read at all.
+
+    `_get_native_value` does `getattr(component, key).scaled_value`, so the
+    entity is built, added, and raises on the first refresh. Nothing else in
+    this suite notices: the platform tests build their components from mocks,
+    which answer to any name.
+    """
+    if _heat_source_of(system) != CONF_BIOMASS_BOILER:
+        pytest.skip(f"{system.name} has no biomass boiler")
+
+    boiler = SolarfocusAPI(
+        ip="127.0.0.1", system=system, api_version=LATEST_API_VERSION
+    ).biomassboiler
+
+    missing = [
+        description.key
+        for description in BIOMASS_BOILER_DESCRIPTIONS
+        if _reaches(system, description) and not hasattr(boiler, description.key)
+    ]
+
+    assert not missing, (
+        f"{system.name} would build {sorted(missing)} on its biomass boiler, "
+        f"but pysolarfocus carries no such register for that system."
+    )
+
+
+# The two names register 2410 is read under, and the systems the register
+# document grants each to. The octoplus reads the bottom of its buffer there,
+# the EcoTop and the Pellet Elegance read the return flow of the boiler, and on
+# a therminator the address is nicht belegt.
+REGISTER_2410 = {
+    "octoplus_buffer_temperature_bottom": [Systems.OCTOPLUS],
+    "return_temperature": [Systems.ECOTOP, Systems.PELLETELEGANCE],
+}
+
+
+@pytest.mark.parametrize("system", OFFERED_SYSTEMS, ids=lambda s: s.name)
+def test_register_2410_is_reported_under_one_name_per_system(
+    system: Systems,
+) -> None:
+    """Regression test for #223.
+
+    Two measurements share address 2410, so exactly one of the two names may
+    reach a system - and it has to be the one the library reads there. Reading
+    it as the buffer bottom everywhere gave an EcoTop and a Pellet Elegance
+    their return flow temperature under a name that says "buffer"; gating that
+    to the octoplus without adding this one took the reading away instead of
+    correcting it.
+    """
+    described = {
+        description.key: description
+        for description in BIOMASS_BOILER_SENSOR_TYPES
+        if description.key in REGISTER_2410
+    }
+    assert sorted(described) == sorted(REGISTER_2410), (
+        f"the biomass boiler describes {sorted(described)} for register 2410, "
+        f"and both of {sorted(REGISTER_2410)} have to be there."
+    )
+
+    reached = [key for key in REGISTER_2410 if _reaches(system, described[key])]
+    expected = [
+        key for key, systems in REGISTER_2410.items() if system in systems
+    ]
+
+    assert reached == expected
+
+    if _heat_source_of(system) == CONF_BIOMASS_BOILER:
+        boiler = SolarfocusAPI(
+            ip="127.0.0.1", system=system, api_version=LATEST_API_VERSION
+        ).biomassboiler
+        assert [key for key in REGISTER_2410 if hasattr(boiler, key)] == expected

--- a/uv.lock
+++ b/uv.lock
@@ -2016,15 +2016,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/08/64/a99f27d3b4347486c
 
 [[package]]
 name = "pysolarfocus"
-version = "5.2.4"
+version = "5.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "pymodbus" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/00/9d6341ce69c153286f5d8c0b79be510bcca762facefc01a69099770ce7de/pysolarfocus-5.2.4.tar.gz", hash = "sha256:7e3c0f7da607917cea1dc0095eccd77e8d3ee93ca08d63286f81206552b9ce9b", size = 743217, upload-time = "2026-08-19T17:07:45.874Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/b9/a9e046eb721ea90be3e1938143fa52162134ecb4c09f3ffed85e805ae933/pysolarfocus-5.3.0.tar.gz", hash = "sha256:979f56d37d7f3ddcc37ad75c03bcc4626b2a9c57767356ad78f3c6bd40e1166b", size = 744343, upload-time = "2026-08-20T09:38:25.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/fc/32437ef5e2e75a9a62f7d98ee08132a0d458ade9b122bc6ee3c8a6ed3e0e/pysolarfocus-5.2.4-py3-none-any.whl", hash = "sha256:6060a097098135e322562d57f6d66257459833dcc5986a0f274a6c994052e648", size = 31952, upload-time = "2026-08-19T17:07:44.934Z" },
+    { url = "https://files.pythonhosted.org/packages/67/be/d53e744fbd2dc60823c94e22e5a926688bd082cdcda33b60829ec1e03278/pysolarfocus-5.3.0-py3-none-any.whl", hash = "sha256:43d5be978a6d66bd48335011bd50c9c9d22d58ebad8a022722d73def7f6e4c68", size = 32351, upload-time = "2026-08-20T09:38:23.961Z" },
 ]
 
 [[package]]
@@ -2465,7 +2465,7 @@ requires-dist = [
     { name = "packaging", specifier = "~=24.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pylint", specifier = ">=3.3.3" },
-    { name = "pysolarfocus", specifier = ">=5.2.4,<6" },
+    { name = "pysolarfocus", specifier = ">=5.3.0,<6" },
     { name = "pytest-homeassistant-custom-component", specifier = ">=0.13.355,<0.14" },
     { name = "pytest-socket", specifier = ">=0.8.0,<0.9" },
 ]


### PR DESCRIPTION
Closes #223. **Blocked on pysolarfocus 5.3.0** — LavermanJJ/pysolarfocus#60, pinned here. CI fails on `uv sync --locked` until that is tagged and on PyPI; `uv lock` here is the last commit this branch needs.

Register 2410 is two measurements at one address. #222 did the correct half — it gated `bb_octoplus_buffer_temperature_bottom` to the octoplus, so an EcoTop and a Pellet Elegance stopped reporting a **return flow temperature** under a name that says "buffer". What it did not do is give them the reading back under the right name, which left them with no reading at all rather than the right one.

## The entity

`bb_return_temperature`, gated with `every_system_but(Systems.ECOTOP, Systems.PELLETELEGANCE)` — what the three clauses of the document leave once the vampair is excluded outright, the octoplus has its buffer bottom at that address, and the therminator has it *nicht belegt*.

Named `return_temperature` rather than `return_flow_temperature`, matching the heat pump's `hp_return_temperature`: 2301 is the same measurement on the other heat source, and there is no reason for the two to read differently in a dashboard. German `Rücklauftemperatur`, icon `mdi:thermometer-chevron-down`, both taken from the heat pump's.

## Why it needed the library

An entity reads its value by `getattr`-ing the description `key` off the pysolarfocus component — `item=description.key` in `create_description`. There was no attribute on `BiomassBoiler` under any name that says return flow, so the entity could not exist until the library carried one. LavermanJJ/pysolarfocus#60 adds it, per system:

| System | Attribute at 2410 | Entity |
| --- | --- | --- |
| Octoplus | `octoplus_buffer_temperature_bottom` | `bb_octoplus_buffer_temperature_bottom` |
| EcoTop | `return_temperature` | `bb_return_temperature` |
| Pellet Elegance | `return_temperature` | `bb_return_temperature` |
| Therminator | none | none |
| vampair | none | none |

## Tests

`tests/test_library_polling.py` is where this belongs — it is the file that checks the integration against what the library actually does, rather than against a mock.

- **`test_every_biomass_boiler_entity_has_a_register_behind_it`** — every biomass boiler description that survives the system and version filter has to name an attribute on the component the library builds for that system. This is the general guard for the class of bug #223 is: a description with no register behind it builds an entity, adds it, and raises `AttributeError` on the first refresh. Nothing else in the suite notices, because the platform tests build their components from mocks, which answer to any name. Fails against 5.2.4 for `ECOTOP` and `PELLETELEGANCE`.
- **`test_register_2410_is_reported_under_one_name_per_system`** — exactly one of the two names may reach a system, and it has to be the one the library reads there. Fails on `main` for all five systems, and fails again with only the library half of the change.

**1124 pass** against LavermanJJ/pysolarfocus#60. ruff, pylint and mypy clean.

## Still unconfirmed

Nobody has read 2410 on an **EcoTop** or an **octoplus**. The EcoTop reading should look like the two Pellet Elegance ones (22.6 °C and 27.6 °C on idle boilers); the octoplus should look like a buffer bottom rather than a return flow. The read-only script in #217 covers it. Both are consistent with the document either way, so this is confirmation rather than a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)