### PR TITLE
Grey out only the component that cannot be read (#230)

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,10 +402,13 @@ read, so raising the number of components does not raise the number of round tri
 interval. The connection is opened once and re-established automatically if it drops.
 
 If the heating system cannot be read at all, the entities of the entry become unavailable until
-the next successful poll, and the failure is logged once rather than once per interval. If a
-single component cannot be read while the others can, only the entities of that component become
-unavailable and the rest carry on reading; the log names it and a repair issue asks you to sort
-it out, since a component that answers nothing on one poll answers nothing on every one.
+the next successful poll, and the failure is logged once rather than once per interval. The same
+goes for a connection that drops part way through a poll: the components that were not reached
+are not blamed for it, and the connection is re-established on the next interval. If a single
+component cannot be read over a connection that is up while the others read fine, only the
+entities of that component become unavailable and the rest carry on reading; the log names it and
+a repair issue asks you to sort it out, since a register range a controller does not answer is
+usually a component that is not installed or an API version set higher than the controller runs.
 
 Writes go the other way and take effect immediately: setting a target temperature, pressing a
 button or changing a select writes the register, re-reads the component it belongs to and

--- a/README.md
+++ b/README.md
@@ -403,8 +403,9 @@ interval. The connection is opened once and re-established automatically if it d
 
 If the heating system cannot be read at all, the entities of the entry become unavailable until
 the next successful poll, and the failure is logged once rather than once per interval. If a
-single component cannot be read while the others can, only that one keeps its last value and
-the rest carry on; the log names it.
+single component cannot be read while the others can, only the entities of that component become
+unavailable and the rest carry on reading; the log names it and a repair issue asks you to sort
+it out, since a component that answers nothing on one poll answers nothing on every one.
 
 Writes go the other way and take effect immediately: setting a target temperature, pressing a
 button or changing a select writes the register, re-reads the component it belongs to and
@@ -477,12 +478,14 @@ rather than once per interval. Common causes are the controller being restarted,
 change (point the entry at the new address, see [Changing the Connection](#changing-the-connection))
 or another Modbus client holding the connection.
 
-**One component is stuck on old values while the rest updates.**
+**One component is unavailable while the rest updates.**
 That component could not be read. The log names it, with a warning when it starts failing and
-another when it recovers. If it fails on every poll, the registers of that component are
-probably not answered by your software version - lower the API version under
-[Changing the Connection](#changing-the-connection) or set the component to 0 under
-[Configuration Options](#configuration-options) if your installation does not have it.
+another when it recovers, and a repair issue is raised for it. If it fails on every poll, the
+registers of that component are probably not answered by your software version - lower the API
+version under [Changing the Connection](#changing-the-connection) or set the component to 0
+under [Configuration Options](#configuration-options) if your installation does not have it.
+Entities of a component that cannot be read do not accept writes either: a `switch`, `number`
+or `select` on it is unavailable like everything else on it.
 
 **Entities I expect are missing.**
 Either the component is set to 0 in the options, or the entity needs a newer API version than

--- a/custom_components/solarfocus/const.py
+++ b/custom_components/solarfocus/const.py
@@ -1,5 +1,7 @@
 """Constants for the Solarfocus integration."""
 
+from typing import NamedTuple
+
 from packaging import version
 
 from homeassistant.config_entries import ConfigEntry
@@ -65,22 +67,51 @@ MANUFACTURER = "Solarfocus"
 # same box whichever heating system is wired to it.
 CONTROLLER_NAME = "eco manager-touch"
 
+
+class ComponentDevice(NamedTuple):
+    """What an entity description's component prefix says about its device.
+
+    The option and the translation key spell the same word today, and used to
+    be the same field for it. They answer to different things: the option is
+    the name the entry stores a component under, which is also what a failed
+    read is reported as, and the translation key is what `strings.json` calls
+    the device. Renaming one silently rewired the other - a device key of
+    `heat_pump` would have left the entities of a heat pump that cannot be read
+    available for good, because nothing compares them but the entity itself.
+    """
+
+    # The entry option this component is configured by, and the name
+    # `failed_components` reports it as when it cannot be read.
+    option: str
+    # The key `strings.json` translates the device name under.
+    translation_key: str
+    # The model shown on the device page - a heating circuit has no model of
+    # its own to report, and a device page with nothing on it says less than
+    # the word.
+    model: str
+
+
 # The device the entities of a component belong to, keyed by the prefix every
-# entity description already carries: the key its name is translated under, and
-# the model shown on its device page - a heating circuit has no model of its own
-# to report, and a device page with nothing on it says less than the word.
-COMPONENT_DEVICES: dict[str, tuple[str, str]] = {
-    HEATING_CIRCUIT_COMPONENT_PREFIX: (CONF_HEATING_CIRCUIT, HEATING_CIRCUIT_PREFIX),
-    BUFFER_COMPONENT_PREFIX: (CONF_BUFFER, BUFFER_PREFIX),
-    BOILER_COMPONENT_PREFIX: (CONF_BOILER, BOILER_PREFIX),
-    FRESH_WATER_MODULE_COMPONENT_PREFIX: (
-        CONF_FRESH_WATER_MODULE,
-        FRESH_WATER_MODULE_PREFIX,
+# entity description already carries.
+COMPONENT_DEVICES: dict[str, ComponentDevice] = {
+    HEATING_CIRCUIT_COMPONENT_PREFIX: ComponentDevice(
+        CONF_HEATING_CIRCUIT, "heating_circuit", HEATING_CIRCUIT_PREFIX
     ),
-    SOLAR_COMPONENT_PREFIX: (CONF_SOLAR, SOLAR_PREFIX),
-    HEAT_PUMP_COMPONENT_PREFIX: (CONF_HEATPUMP, HEAT_PUMP_PREFIX),
-    PHOTOVOLTAIC_COMPONENT_PREFIX: (CONF_PHOTOVOLTAIC, PHOTOVOLTAIC_PREFIX),
-    BIOMASS_BOILER_COMPONENT_PREFIX: (CONF_BIOMASS_BOILER, BIOMASS_BOILER_PREFIX),
+    BUFFER_COMPONENT_PREFIX: ComponentDevice(CONF_BUFFER, "buffer", BUFFER_PREFIX),
+    BOILER_COMPONENT_PREFIX: ComponentDevice(CONF_BOILER, "boiler", BOILER_PREFIX),
+    FRESH_WATER_MODULE_COMPONENT_PREFIX: ComponentDevice(
+        CONF_FRESH_WATER_MODULE, "fresh_water_module", FRESH_WATER_MODULE_PREFIX
+    ),
+    SOLAR_COMPONENT_PREFIX: ComponentDevice(CONF_SOLAR, "solar", SOLAR_PREFIX),
+    HEAT_PUMP_COMPONENT_PREFIX: ComponentDevice(
+        CONF_HEATPUMP, "heatpump", HEAT_PUMP_PREFIX
+    ),
+    PHOTOVOLTAIC_COMPONENT_PREFIX: ComponentDevice(
+        CONF_PHOTOVOLTAIC, "photovoltaic", PHOTOVOLTAIC_PREFIX
+    ),
+    BIOMASS_BOILER_COMPONENT_PREFIX: ComponentDevice(
+        CONF_BIOMASS_BOILER, "biomassboiler", BIOMASS_BOILER_PREFIX
+    ),
 }
 
 """Version from which several solar circuits exist"""

--- a/custom_components/solarfocus/coordinator.py
+++ b/custom_components/solarfocus/coordinator.py
@@ -57,7 +57,7 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
         self.api = api
         self._entry = entry
         self.hass = hass
-        self._failed_components: set[str] = set()
+        self._failed_components: frozenset[str] = frozenset()
         # The controller every component device of this entry hangs off, set by
         # `async_setup_entry` once the device is registered. A component device
         # points at it by id rather than by identifier, which Home Assistant
@@ -76,9 +76,14 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
         )
 
     @property
-    def failed_components(self) -> set[str]:
-        """Return the components that could not be read on the last refresh."""
-        return set(self._failed_components)
+    def failed_components(self) -> frozenset[str]:
+        """Return the components that could not be read on the last refresh.
+
+        Every entity of the entry reads this on every state write, so it is
+        handed out as it is rather than copied: a frozenset cannot be added to
+        by the caller, which is what the copy was there for.
+        """
+        return self._failed_components
 
     @property
     def _address(self) -> str:
@@ -107,7 +112,16 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
             if not await self.hass.async_add_executor_job(getattr(self.api, update)):
                 failed.append(option)
 
-        if failed and len(failed) == configured:
+        # A connection that drops part way through the poll fails every
+        # component read after it, whatever those components would have
+        # answered - the library returns False without asking the socket
+        # anything. Calling that a component that does not answer would grey
+        # out an arbitrary tail of the system and raise an issue per component
+        # telling the user to switch it off, for what is one dropped
+        # connection, re-established on the next refresh.
+        connection_lost = bool(failed) and not self.api.is_connected
+
+        if connection_lost or (failed and len(failed) == configured):
             # Nothing could be read: the system is gone rather than one of its
             # components being unhappy. Reporting that as a success would leave
             # every entity available and showing its last value.
@@ -118,8 +132,14 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
             # issue saying that every other component reads fine. The outage
             # itself is what the failed refresh says, and the issue comes back
             # on the first refresh that reads anything at all.
-            self._failed_components = set()
+            self._failed_components = frozenset()
             self._report_failed_components([])
+            if connection_lost:
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="cannot_connect",
+                    translation_placeholders={"address": self._address},
+                )
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="cannot_read",
@@ -148,10 +168,10 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
         """
         self._report_failed_components(failed)
 
-        if set(failed) == self._failed_components:
+        if frozenset(failed) == self._failed_components:
             return
 
-        self._failed_components = set(failed)
+        self._failed_components = frozenset(failed)
 
         if failed:
             _LOGGER.warning(

--- a/custom_components/solarfocus/coordinator.py
+++ b/custom_components/solarfocus/coordinator.py
@@ -141,6 +141,10 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
         poll, and the components that do work - including the ones that can be
         written - would go with it. So the rest keeps updating and the failure
         is logged instead, once, until the set of failing components changes.
+
+        What the failing component itself does is read off `failed_components`
+        by the entities on it, which go unavailable while the rest of the entry
+        carries on.
         """
         self._report_failed_components(failed)
 
@@ -151,7 +155,7 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
 
         if failed:
             _LOGGER.warning(
-                "Could not read %s from %s, its entities keep their last value."
+                "Could not read %s from %s, its entities are unavailable."
                 " The other components were read successfully",
                 ", ".join(failed),
                 self._address,
@@ -163,11 +167,10 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
         """Raise a repair issue per component that cannot be read, one per entry.
 
         A register range a particular firmware does not answer fails on every
-        poll and never recovers on its own. The entities of that component keep
-        their last value for good, which looks like a heating system that has
-        stopped moving rather than like a component that is not there - and the
-        log line saying so is written once, so it has usually scrolled away by
-        the time anybody looks.
+        poll and never recovers on its own. The entities of that component are
+        unavailable for as long as it lasts, which says nothing about why - and
+        the log line that does is written once, so it has usually scrolled away
+        by the time anybody looks.
 
         Nothing here can fix it: either the component is not installed and the
         user should switch it off in the options, or the api version is set

--- a/custom_components/solarfocus/entity.py
+++ b/custom_components/solarfocus/entity.py
@@ -187,8 +187,30 @@ class SolarfocusEntity(Entity):
     @property
     @override
     def available(self) -> bool:
-        """Return True if entity is available."""
-        return self.coordinator.last_update_success
+        """Return True if the component this entity sits on was read.
+
+        Two ways to be unavailable, and the entry only knows about the first:
+        the whole system stopped answering, so the refresh failed, or this one
+        component did while the rest of the system read fine. The second used to
+        show as nothing at all - a partial failure is a successful refresh, so
+        the component that answers nothing kept the last value it ever returned,
+        which reads as a heating system that has stopped moving rather than as a
+        component that is not there.
+
+        One device per component is what makes this worth splitting: a component
+        that cannot be read greys out its own page and leaves the rest of the
+        system alone.
+
+        Writable entities go with it. A component whose registers do not answer
+        is not a component to be writing to, and Home Assistant drops
+        unavailable entities from service calls, so a `switch`, `number` or
+        `select` on it stops accepting writes - the entities of every component
+        that does answer keep taking them.
+        """
+        return self.coordinator.last_update_success and (
+            COMPONENT_DEVICES[self.entity_description.component_prefix][0]
+            not in self.coordinator.failed_components
+        )
 
     @property
     @override

--- a/custom_components/solarfocus/entity.py
+++ b/custom_components/solarfocus/entity.py
@@ -158,19 +158,19 @@ class SolarfocusEntity(Entity):
         its first device rather than orphaning it.
         """
         description = self.entity_description
-        translation_key, model = COMPONENT_DEVICES[description.component_prefix]
+        device = COMPONENT_DEVICES[description.component_prefix]
 
         device_info = DeviceInfo(
             identifiers={
                 (DOMAIN, f"{self._entry_id}_{description.component_prefix}"
                  f"{description.component_idx}")
             },
-            translation_key=translation_key,
+            translation_key=device.translation_key,
             # Blank for the components that exist once, and for the single
             # solar circuit that keeps the unnumbered name it had before there
             # could be four of them.
             translation_placeholders={"idx": description.device_idx},
-            model=model,
+            model=device.model,
             manufacturer=MANUFACTURER,
         )
 
@@ -208,7 +208,7 @@ class SolarfocusEntity(Entity):
         that does answer keep taking them.
         """
         return self.coordinator.last_update_success and (
-            COMPONENT_DEVICES[self.entity_description.component_prefix][0]
+            COMPONENT_DEVICES[self.entity_description.component_prefix].option
             not in self.coordinator.failed_components
         )
 

--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -125,7 +125,7 @@
     },
     "component_unavailable": {
       "title": "{component} cannot be read from your Solarfocus system",
-      "description": "\"{title}\" reads every other component of the system at {address}, but {component} answers nothing. Its entities keep the last value they had, which is not the same as being unavailable, so they look like a heating system that has stopped moving.\n\nThis does not recover on its own. Either the component is not installed, in which case switch it off under Configure, or the API version of the entry is set higher than the controller runs - the version is shown on the controller under Fachmann - Modbus."
+      "description": "\"{title}\" reads every other component of the system at {address}, but {component} answers nothing. Its entities are unavailable for as long as that lasts, and anything reading them - a template, a graph, an automation - has nothing to read.\n\nThis does not recover on its own. Either the component is not installed, in which case switch it off under Configure, or the API version of the entry is set higher than the controller runs - the version is shown on the controller under Fachmann - Modbus."
     }
   },
   "entity": {

--- a/custom_components/solarfocus/switch.py
+++ b/custom_components/solarfocus/switch.py
@@ -86,7 +86,7 @@ class SolarfocusSwitchEntity(SolarfocusEntity, SwitchEntity):
         switch = self.entity_description.item
         # The register holds 0 or 1. A register that could not be read keeps
         # whatever it last held, so there is no third answer to give here -
-        # the entity goes unavailable with the coordinator instead.
+        # the entity goes unavailable with its component instead.
         return bool(self._get_native_value(switch))
 
     @override

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -124,7 +124,7 @@
     },
     "component_unavailable": {
       "title": "{component} kann nicht von der Solarfocus-Anlage gelesen werden",
-      "description": "\"{title}\" liest alle anderen Komponenten der Anlage unter {address}, {component} antwortet jedoch nicht. Die zugehörigen Entitäten behalten ihren letzten Wert - das ist nicht dasselbe wie nicht verfügbar, sie wirken daher wie eine Heizungsanlage, die stehengeblieben ist.\n\nDas geht nicht von selbst weg. Entweder ist die Komponente nicht vorhanden, dann schalte sie unter Konfigurieren ab, oder die API-Version des Eintrags ist höher eingestellt als der Regler tatsächlich hat - die Version steht am Regler unter Fachmann - Modbus."
+      "description": "\"{title}\" liest alle anderen Komponenten der Anlage unter {address}, {component} antwortet jedoch nicht. Die zugehörigen Entitäten sind so lange nicht verfügbar, und was sie ausliest - ein Template, ein Diagramm, eine Automatisierung - findet nichts vor.\n\nDas geht nicht von selbst weg. Entweder ist die Komponente nicht vorhanden, dann schalte sie unter Konfigurieren ab, oder die API-Version des Eintrags ist höher eingestellt als der Regler tatsächlich hat - die Version steht am Regler unter Fachmann - Modbus."
     }
   },
   "entity": {

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -125,7 +125,7 @@
     },
     "component_unavailable": {
       "title": "{component} cannot be read from your Solarfocus system",
-      "description": "\"{title}\" reads every other component of the system at {address}, but {component} answers nothing. Its entities keep the last value they had, which is not the same as being unavailable, so they look like a heating system that has stopped moving.\n\nThis does not recover on its own. Either the component is not installed, in which case switch it off under Configure, or the API version of the entry is set higher than the controller runs - the version is shown on the controller under Fachmann - Modbus."
+      "description": "\"{title}\" reads every other component of the system at {address}, but {component} answers nothing. Its entities are unavailable for as long as that lasts, and anything reading them - a template, a graph, an automation - has nothing to read.\n\nThis does not recover on its own. Either the component is not installed, in which case switch it off under Configure, or the API version of the entry is set higher than the controller runs - the version is shown on the controller under Fachmann - Modbus."
     }
   },
   "entity": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,6 +147,10 @@ def build_coordinator(entry, api: MagicMock | None = None) -> MagicMock:
     coordinator._entry = entry
     coordinator.api = api if api is not None else build_api()
     coordinator.last_update_success = True
+    # Every component reads, so the entities on them are available. A stub of it
+    # rather than whatever a MagicMock makes of `in`, which is what availability
+    # asks of this.
+    coordinator.failed_components = set()
     # The real one, not a mock: the number the installer menu shows is shared
     # between two entities, and what a test of either is about is that sharing.
     coordinator.displayed_number = DisplayedNumber()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -19,6 +19,7 @@ from custom_components.solarfocus.const import (
 from custom_components.solarfocus.coordinator import SolarfocusDataUpdateCoordinator
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .conftest import build_api, build_config_entry
@@ -200,6 +201,88 @@ async def test_one_failing_component_keeps_the_others_working(
     assert coordinator.last_update_success
     assert api.update_buffer.called
     assert "Could not read heating_circuit" in caplog.text
+
+
+async def test_a_connection_dropping_mid_poll_is_an_outage(hass: HomeAssistant) -> None:
+    """The components after the drop failed for want of a socket, not a register.
+
+    A read on a closed connection returns False without asking the device
+    anything, so a connection that goes away half way through a poll fails an
+    arbitrary tail of the components. Calling those unreadable would grey them
+    out and raise an issue per component telling the user to switch it off, for
+    a connection that is re-established on the next refresh.
+    """
+    api = build_api()
+
+    def drop_the_connection() -> bool:
+        api.is_connected = False
+        return False
+
+    api.update_boiler.side_effect = drop_the_connection
+    api.update_heatpump.return_value = False
+    coordinator = _coordinator(hass, api, heating_circuit=1, boiler=1, heatpump=True)
+
+    with pytest.raises(UpdateFailed) as failure:
+        await coordinator._async_update_data()
+
+    assert failure.value.translation_key == "cannot_connect"
+    assert failure.value.translation_placeholders == {"address": "solarfocus.local:502"}
+    # Not the boiler and not the heat pump: neither of them was asked anything.
+    assert coordinator.failed_components == frozenset()
+
+
+async def test_a_connection_dropping_mid_poll_raises_no_component_issue(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """End to end: an outage is not a component to be configured away."""
+    entry = build_config_entry(heating_circuit=1, boiler=1)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    def drop_the_connection() -> bool:
+        api.is_connected = False
+        return False
+
+    api.update_boiler.side_effect = drop_the_connection
+    await entry.runtime_data.async_refresh()
+
+    assert not entry.runtime_data.last_update_success
+    assert not ir.async_get(hass).issues
+
+
+async def test_a_failing_component_on_a_live_connection_is_still_partial(
+    hass: HomeAssistant,
+) -> None:
+    """The guard is about the connection, not about a read that returns False."""
+    api = build_api()
+    api.update_boiler.return_value = False
+    coordinator = _coordinator(hass, api, heating_circuit=1, boiler=1)
+
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success
+    assert coordinator.failed_components == frozenset({CONF_BOILER})
+
+
+async def test_failed_components_is_handed_out_rather_than_copied(
+    hass: HomeAssistant,
+) -> None:
+    """Every entity of the entry reads this on every state write.
+
+    A copy per read is hundreds of throwaway sets per poll for a set of at most
+    eight names. A frozenset cannot be added to by whoever reads it, which is
+    what the copy was there for.
+    """
+    api = build_api()
+    api.update_boiler.return_value = False
+    coordinator = _coordinator(hass, api, heating_circuit=1, boiler=1)
+
+    await coordinator.async_refresh()
+
+    assert isinstance(coordinator.failed_components, frozenset)
+    assert coordinator.failed_components is coordinator.failed_components
 
 
 async def test_only_the_failing_component_is_greyed_out(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -17,6 +17,7 @@ from custom_components.solarfocus.const import (
     DOMAIN,
 )
 from custom_components.solarfocus.coordinator import SolarfocusDataUpdateCoordinator
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
@@ -199,6 +200,38 @@ async def test_one_failing_component_keeps_the_others_working(
     assert coordinator.last_update_success
     assert api.update_buffer.called
     assert "Could not read heating_circuit" in caplog.text
+
+
+async def test_only_the_failing_component_is_greyed_out(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """End to end: the heating circuit answers nothing, the boiler answers.
+
+    The refresh succeeds, so the entry keeps polling and every entity of the
+    boiler carries its value as usual. The entities of the heating circuit go
+    unavailable rather than keeping the last value they read, which they used to
+    do for as long as the entry was loaded.
+    """
+    api.update_heating.return_value = False
+    entry = build_config_entry(heating_circuit=1, boiler=1)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    def states(device: str) -> list[str]:
+        return [
+            hass.states.get(entity_id).state
+            for entity_id in hass.states.async_entity_ids()
+            if entity_id.split(".", 1)[1].startswith(device)
+        ]
+
+    heating_circuit = states("heating_circuit_1_")
+    boiler = states("boiler_1_")
+
+    assert heating_circuit and boiler, "the entities of both components are there"
+    assert set(heating_circuit) == {STATE_UNAVAILABLE}
+    assert STATE_UNAVAILABLE not in boiler
 
 
 async def test_a_partial_failure_is_logged_once_and_the_recovery_too(

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -38,7 +38,11 @@ from custom_components.solarfocus.select import (
     HEATPUMP_SELECT_TYPES,
     SolarfocusSelectEntity,
 )
-from custom_components.solarfocus.sensor import BOILER_SENSOR_TYPES, SolarfocusSensor
+from custom_components.solarfocus.sensor import (
+    BOILER_SENSOR_TYPES,
+    HEATPUMP_SENSOR_TYPES,
+    SolarfocusSensor,
+)
 from custom_components.solarfocus.switch import (
     HEATPUMP_SWITCH_TYPES,
     OFF,
@@ -187,6 +191,109 @@ def test_entity_is_unavailable_after_a_failed_update() -> None:
     assert entity.available is True
 
     entity.coordinator.last_update_success = False
+
+    assert entity.available is False
+
+
+def test_only_the_component_that_failed_goes_unavailable() -> None:
+    """A boiler that answers nothing must not grey out the heat pump.
+
+    A partial failure is a successful refresh - the entry keeps reading
+    everything that answers - so `last_update_success` has nothing to say about
+    it and the entities of the failing component read `failed_components`
+    instead. One device per component is what makes that visible: the boiler
+    greys out its own page and the rest of the system carries on.
+    """
+    coordinator = build_coordinator(build_config_entry())
+    boiler = SolarfocusSensor(
+        coordinator,
+        create_description(
+            BOILER_COMPONENT, BOILER_COMPONENT_PREFIX, "1", BOILER_SENSOR_TYPES[0]
+        ),
+    )
+    heat_pump = SolarfocusSensor(
+        coordinator,
+        create_description(
+            HEAT_PUMP_COMPONENT, HEAT_PUMP_COMPONENT_PREFIX, "", HEATPUMP_SENSOR_TYPES[0]
+        ),
+    )
+
+    coordinator.failed_components = {CONF_BOILER}
+
+    assert boiler.available is False
+    assert heat_pump.available is True
+
+
+def test_a_failing_component_takes_every_instance_of_it() -> None:
+    """The library reads all boilers in one call, so all of them failed."""
+    coordinator = build_coordinator(build_config_entry())
+    boilers = [
+        SolarfocusSensor(
+            coordinator,
+            create_description(
+                BOILER_COMPONENT, BOILER_COMPONENT_PREFIX, idx, BOILER_SENSOR_TYPES[0]
+            ),
+        )
+        for idx in ("1", "2")
+    ]
+
+    coordinator.failed_components = {CONF_BOILER}
+
+    assert [boiler.available for boiler in boilers] == [False, False]
+
+
+def test_a_writable_entity_of_a_failing_component_goes_unavailable() -> None:
+    """A component whose registers do not answer is not one to be writing to.
+
+    Home Assistant drops unavailable entities from service calls, so this is
+    what stops a write to a component that cannot be read. The entities of
+    every component that does answer keep taking them, which is the whole
+    difference to failing the refresh.
+    """
+    coordinator = build_coordinator(build_config_entry())
+    number = SolarfocusNumberEntity(
+        coordinator,
+        create_description(
+            BOILER_COMPONENT, BOILER_COMPONENT_PREFIX, "1", BOILER_NUMBER_TYPES[0]
+        ),
+    )
+
+    coordinator.failed_components = {CONF_BOILER}
+
+    assert number.available is False
+
+
+def test_a_component_that_reads_again_comes_back() -> None:
+    """Availability follows the last refresh, so a recovery is enough."""
+    entity = _make(
+        SolarfocusSensor,
+        BOILER_SENSOR_TYPES[0],
+        BOILER_COMPONENT,
+        BOILER_COMPONENT_PREFIX,
+    )
+
+    entity.coordinator.failed_components = {CONF_BOILER}
+    assert entity.available is False
+
+    entity.coordinator.failed_components = set()
+    assert entity.available is True
+
+
+def test_the_whole_system_being_gone_still_beats_a_working_component() -> None:
+    """Every configured component failing fails the refresh, and clears the set.
+
+    So a failed refresh is the only thing left saying that nothing can be read,
+    and it has to be enough on its own.
+    """
+    entity = _make(
+        SolarfocusSensor,
+        BOILER_SENSOR_TYPES[0],
+        BOILER_COMPONENT,
+        BOILER_COMPONENT_PREFIX,
+    )
+
+    entity.coordinator.last_update_success = False
+    entity.coordinator.failed_components = set()
 
     assert entity.available is False
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -21,6 +21,7 @@ from custom_components.solarfocus.const import (
     BOILER_COMPONENT,
     BOILER_COMPONENT_PREFIX,
     BOILER_PREFIX,
+    COMPONENT_DEVICES,
     CONF_BOILER,
     DOMAIN,
     HEAT_PUMP_COMPONENT,
@@ -28,7 +29,9 @@ from custom_components.solarfocus.const import (
     HEATING_CIRCUIT_COMPONENT,
     HEATING_CIRCUIT_COMPONENT_PREFIX,
     MANUFACTURER,
+    ComponentDevice,
 )
+from custom_components.solarfocus.coordinator import COMPONENT_UPDATES
 from custom_components.solarfocus.entity import create_description
 from custom_components.solarfocus.number import (
     BOILER_NUMBER_TYPES,
@@ -222,6 +225,43 @@ def test_only_the_component_that_failed_goes_unavailable() -> None:
 
     assert boiler.available is False
     assert heat_pump.available is True
+
+
+@pytest.mark.parametrize(("prefix", "device"), sorted(COMPONENT_DEVICES.items()))
+def test_every_component_goes_unavailable_under_its_own_option(
+    prefix: str, device: ComponentDevice
+) -> None:
+    """Availability is read off the option, which is not the translation key.
+
+    The two spell the same word, and used to be the same field for it: renaming
+    what `strings.json` calls a device would have left the entities of that
+    component available whatever the coordinator said about it. Every component
+    is pinned here rather than the boiler alone, because a mismatch is one
+    component with entities that never go unavailable and nothing else.
+    """
+    coordinator = build_coordinator(build_config_entry())
+    entity = SolarfocusSensor(
+        coordinator,
+        create_description(BOILER_COMPONENT, prefix, "1", BOILER_SENSOR_TYPES[0]),
+    )
+
+    coordinator.failed_components = {device.option}
+    assert entity.available is False
+
+    coordinator.failed_components = {device.translation_key + "_renamed"}
+    assert entity.available is True
+
+
+def test_every_component_device_names_an_option_the_coordinator_polls() -> None:
+    """A device whose option is not polled has entities that never grey out.
+
+    The other way round is worse: a component the coordinator reports as failed
+    under a name no device carries greys out nothing at all.
+    """
+    assert (
+        {device.option for device in COMPONENT_DEVICES.values()}
+        == {option for option, _ in COMPONENT_UPDATES}
+    )
 
 
 def test_a_failing_component_takes_every_instance_of_it() -> None:

--- a/tests/test_repair_issues.py
+++ b/tests/test_repair_issues.py
@@ -2,7 +2,7 @@
 
 A repair issue is for what the integration cannot fix on its own. Both of these
 are otherwise invisible: one is a log line written once at migration, the other
-is a component quietly keeping its last value for good.
+is a component that has gone unavailable for good.
 """
 
 from custom_components.solarfocus.const import CONF_BOILER, CONF_HEATING_CIRCUIT, DOMAIN
@@ -161,8 +161,8 @@ async def test_a_component_that_answers_nothing_is_reported(
 ) -> None:
     """A register range the firmware does not answer fails on every poll.
 
-    The entities keep their last value rather than going unavailable, so the
-    heating system looks stopped rather than partly unreadable.
+    The entities of that component are unavailable while it lasts, and nothing
+    in the entry says why: the log line that does is written once.
     """
     api.update_heating.return_value = False
 

--- a/tests/test_service_menu.py
+++ b/tests/test_service_menu.py
@@ -15,7 +15,7 @@ from pytest_homeassistant_custom_component.common import (
     mock_restore_cache_with_extra_data,
 )
 
-from custom_components.solarfocus.const import DOMAIN
+from custom_components.solarfocus.const import CONF_BOILER, CONF_HEATPUMP, DOMAIN
 from custom_components.solarfocus.number import (
     DISPLAYED_NUMBER_TYPE,
     SolarfocusDisplayedNumberEntity,
@@ -294,6 +294,28 @@ def test_they_stay_available_when_the_heating_cannot_be_read(
     """A heating system that does not answer is when the service menu is wanted."""
     entity = _entity(entity_class, description)
     entity.coordinator.last_update_success = False
+
+    assert entity.available
+
+
+@pytest.mark.parametrize(
+    ("entity_class", "description"),
+    [
+        (SolarfocusServiceCodeSensor, SERVICE_CODE_SENSOR_TYPE),
+        (SolarfocusInstallerCodeSensor, INSTALLER_CODE_SENSOR_TYPE),
+        (SolarfocusDisplayedNumberEntity, DISPLAYED_NUMBER_TYPE),
+    ],
+)
+def test_they_stay_available_when_a_component_cannot_be_read(
+    entity_class, description
+) -> None:
+    """A failing component greys out its own entities and nothing else.
+
+    These are not on a component at all - they are arithmetic on the controller
+    - so the set of components that failed says nothing about them.
+    """
+    entity = _entity(entity_class, description)
+    entity.coordinator.failed_components = {CONF_HEATPUMP, CONF_BOILER}
 
     assert entity.available
 

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -454,8 +454,10 @@ async def test_no_entity_name_repeats_its_component(
     # The name of the device this entity's own component is on, in the language
     # of the file being read, so the German names are held to the German words.
     component_of = {
-        prefix: data["device"][device_key]["name"].replace("{idx}", "").strip()
-        for prefix, (device_key, _) in COMPONENT_DEVICES.items()
+        prefix: data["device"][device.translation_key]["name"]
+        .replace("{idx}", "")
+        .strip()
+        for prefix, device in COMPONENT_DEVICES.items()
     }
 
     repeated = [


### PR DESCRIPTION
Closes #230.

## What changed

`SolarfocusEntity.available` was `self.coordinator.last_update_success` - one answer for every entity of the entry. A partial failure is a successful refresh (`_async_update_data` only raises `UpdateFailed` when *every* configured component fails), so a component that answered nothing kept the last value it ever read, for good, and nothing greyed out.

It now also asks whether its own component failed:

```python
return self.coordinator.last_update_success and (
    COMPONENT_DEVICES[self.entity_description.component_prefix][0]
    not in self.coordinator.failed_components
)
```

Everything it needs was already there: `coordinator.failed_components` is kept for the diagnostics download and the repair issue, and `COMPONENT_DEVICES` is the same map `device_info` unpacks for the device translation key. With one device per component since #213, a failing component greys out its own page and leaves the rest of the system alone.

The service menu entities keep their `available = True` override - a system that cannot be read is exactly when they are wanted.

## The open question from the issue: writable entities

**Answered as: they go unavailable with the rest of their component.** Home Assistant drops unavailable entities from service calls, so a `switch`, `number` or `select` on a component whose registers do not answer stops accepting writes. The reasoning:

- A component whose register range the firmware does not answer is not a component to be writing to, and a write is followed by a re-read of that same component to update the entity - the read that is already failing.
- Half-available (readable-as-stale, still writable) has no representation in the UI: the control would show a value that is not the value.
- The thing that argued against this - "the components that do work, including the ones that can be written, would go with it" - was about failing the whole refresh. Per-component availability keeps exactly that: every component that answers stays fully controllable.
- The repair issue asks the user to switch the component off under Configure, which removes its entities altogether.

## Behaviour change, for the release notes

Anyone whose firmware has never answered a register range sees a stale number today and `unavailable` afterwards: templates doing `float(states(...))` break, history graphs gap, statistics stop, and writes to that component are refused. That is the point of the change, and the repair issue already tells them to switch the component off or lower the API version, but it belongs at the top of the notes.

## Also updated, because they described the old behaviour

- The repair issue text (`strings.json`, `en.json`, `de.json`): "keep the last value they had, which is not the same as being unavailable" → unavailable while it lasts, and anything reading them has nothing to read.
- The partial-failure warning in the log: "its entities keep their last value" → "its entities are unavailable".
- README: the paragraph under *How Data Is Updated* and the troubleshooting entry, which was headed "One component is stuck on old values while the rest updates".

## Tests

- `test_only_the_component_that_failed_goes_unavailable` - a failing boiler leaves the heat pump alone.
- `test_a_failing_component_takes_every_instance_of_it` - one call reads all boilers, so all of them failed.
- `test_a_writable_entity_of_a_failing_component_goes_unavailable` - pins the decision above.
- `test_a_component_that_reads_again_comes_back`, and a failed refresh with an empty failure set still greys everything out.
- `test_only_the_failing_component_is_greyed_out` (end to end, `test_coordinator.py`) - the entry sets up, every `heating_circuit_1_*` state is `unavailable`, no `boiler_1_*` state is.
- `test_they_stay_available_when_a_component_cannot_be_read` for the three service menu entities.

All five new unit tests and the end-to-end one fail without the change. 1121 pass with it; `make check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
