### PR TITLE
Point the component issue at the device it is about

### DIFF
--- a/custom_components/solarfocus/__init__.py
+++ b/custom_components/solarfocus/__init__.py
@@ -125,6 +125,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -
     _async_inherit_the_hub_area(hass, entry, hub, known)
     _async_remove_gone_components(hass, entry)
 
+    # The devices a component issue names are registered by the entities on
+    # them, which the forward above is what builds - so an issue raised by the
+    # refresh further up has nothing but the option to call the component by.
+    # Now that the devices are there it is raised again over the top, with the
+    # names the device pages show and links to them.
+    coordinator.async_report_failed_components()
+
     # Registers update listener to update config entry when options are updated.
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 

--- a/custom_components/solarfocus/const.py
+++ b/custom_components/solarfocus/const.py
@@ -130,6 +130,18 @@ COMPONENT_DEVICES: dict[str, ComponentDevice] = {
     ),
 }
 
+# The entry option a component is configured by -> the prefix its devices are
+# identified by. `COMPONENT_DEVICES` is keyed the other way round, by what an
+# entity description carries; a failed read names the option, and the devices
+# of it are found by the prefix.
+COMPONENT_PREFIXES: dict[str, str] = {
+    device.option: prefix for prefix, device in COMPONENT_DEVICES.items()
+}
+
+# The components a heating system has at most one of, which is why their device
+# identifier carries no index where every other component's does.
+SINGLE_COMPONENTS = frozenset({CONF_HEATPUMP, CONF_PHOTOVOLTAIC, CONF_BIOMASS_BOILER})
+
 """Version from which several solar circuits exist"""
 MULTI_SOLAR_MIN_VERSION = "25.030"
 
@@ -203,6 +215,31 @@ def build_unique_id(host: str, port: int) -> str:
     return f"{host}:{port}"
 
 
+def component_device_identifiers(
+    entry: ConfigEntry, option: str
+) -> list[tuple[str, str]]:
+    """Return the identifier of every device of one component, in order.
+
+    One device per instance: four buffers are `Buffer 1` to `Buffer 4`, and the
+    identifier of a component that exists once is the bare prefix. How many
+    there are is what the entry builds rather than what the options hold, so a
+    component the selected api version does not have has no devices.
+
+    The identifier is what both the devices expected in the registry and the
+    devices a repair issue is about are looked up by, so they are built here
+    once rather than spelled out twice.
+    """
+    prefix = COMPONENT_PREFIXES[option]
+    count = (
+        solar_count(entry) if option == CONF_SOLAR else component_count(entry, option)
+    )
+
+    if option in SINGLE_COMPONENTS:
+        return [(DOMAIN, f"{entry.entry_id}_{prefix}")] if count else []
+
+    return [(DOMAIN, f"{entry.entry_id}_{prefix}{index + 1}") for index in range(count)]
+
+
 def expected_device_identifiers(entry: ConfigEntry) -> set[tuple[str, str]]:
     """Return the devices this entry should have, the controller included.
 
@@ -212,32 +249,8 @@ def expected_device_identifiers(entry: ConfigEntry) -> set[tuple[str, str]]:
     gone looks exactly like one of a component that is there - so the set is
     built from the configuration and everything outside it is stale.
     """
-    counted = {
-        HEATING_CIRCUIT_COMPONENT_PREFIX: entry.options[CONF_HEATING_CIRCUIT],
-        BUFFER_COMPONENT_PREFIX: entry.options[CONF_BUFFER],
-        BOILER_COMPONENT_PREFIX: entry.options[CONF_BOILER],
-        FRESH_WATER_MODULE_COMPONENT_PREFIX: entry.options[CONF_FRESH_WATER_MODULE],
-        # The counts the library was built with, not the ones the options hold
-        CIRCULATION_COMPONENT_PREFIX: component_count(entry, CONF_CIRCULATION),
-        DIFFERENTIAL_MODULE_COMPONENT_PREFIX: component_count(
-            entry, CONF_DIFFERENTIAL_MODULE
-        ),
-        SOLAR_COMPONENT_PREFIX: solar_count(entry),
-    }
-    once = {
-        HEAT_PUMP_COMPONENT_PREFIX: entry.options[CONF_HEATPUMP],
-        PHOTOVOLTAIC_COMPONENT_PREFIX: entry.options[CONF_PHOTOVOLTAIC],
-        BIOMASS_BOILER_COMPONENT_PREFIX: entry.options[CONF_BIOMASS_BOILER],
-    }
-
     identifiers = {(DOMAIN, entry.entry_id)}
-    for prefix, count in counted.items():
-        identifiers |= {
-            (DOMAIN, f"{entry.entry_id}_{prefix}{index + 1}")
-            for index in range(int(count))
-        }
-    identifiers |= {
-        (DOMAIN, f"{entry.entry_id}_{prefix}") for prefix, on in once.items() if on
-    }
+    for option in COMPONENT_PREFIXES:
+        identifiers |= set(component_device_identifiers(entry, option))
 
     return identifiers

--- a/custom_components/solarfocus/coordinator.py
+++ b/custom_components/solarfocus/coordinator.py
@@ -13,6 +13,8 @@ from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    COMPONENT_DEVICES,
+    COMPONENT_PREFIXES,
     CONF_BIOMASS_BOILER,
     CONF_BOILER,
     CONF_BUFFER,
@@ -219,16 +221,21 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
                 continue
 
             devices = self._component_devices(option)
+            # What the device page calls this component's model, for when
+            # there is no device yet to ask - either it is not registered yet,
+            # which is what the report at the end of `async_setup_entry`
+            # catches up with, or the configured api version does not have it
+            # at all. Either way this is never the bare option: that is a
+            # config key, not a word, and leaks into every language's text.
+            fallback = COMPONENT_DEVICES[COMPONENT_PREFIXES[option]].model
             # What the device page calls this component, which is translated
             # and is whatever the user renamed it to, and the same names as
-            # links to those pages. The option is what is left if the devices
-            # are not registered yet, which is what the report at the end of
-            # `async_setup_entry` catches up with.
+            # links to those pages.
             names = [
-                device.name_by_user or device.name or option for device in devices
+                device.name_by_user or device.name or fallback for device in devices
             ]
             links = [
-                f"[{name}](/config/devices/device/{device.id})"
+                f"[{_escape_markdown_link_text(name)}](/config/devices/device/{device.id})"
                 for name, device in zip(names, devices, strict=True)
             ]
 
@@ -240,8 +247,8 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
                 severity=ir.IssueSeverity.WARNING,
                 translation_key="component_unavailable",
                 translation_placeholders={
-                    "component": ", ".join(names) or option,
-                    "devices": ", ".join(links) or option,
+                    "component": ", ".join(names) or fallback,
+                    "devices": ", ".join(links) or fallback,
                     "address": self._address,
                     "title": self._entry.title,
                 },
@@ -277,6 +284,16 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
         it again over the top is what puts the device names and their links in.
         """
         self._report_failed_components(sorted(self._failed_components))
+
+
+def _escape_markdown_link_text(text: str) -> str:
+    """Escape a device name for use as the text span of a markdown link.
+
+    The name is whatever the user renamed the device to, so it can contain a
+    `]` that would otherwise close the link's text span early and leave the
+    rest of it as literal, unlinked text in the repair dialog.
+    """
+    return text.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
 
 
 def component_issue_id(entry_id: str, option: str) -> str:

--- a/custom_components/solarfocus/coordinator.py
+++ b/custom_components/solarfocus/coordinator.py
@@ -9,7 +9,7 @@ from pysolarfocus import SolarfocusAPI
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -25,6 +25,7 @@ from .const import (
     CONF_SOLAR,
     DOMAIN,
     component_count,
+    component_device_identifiers,
 )
 from .service_menu import DisplayedNumber
 
@@ -217,6 +218,20 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
                 ir.async_delete_issue(self.hass, DOMAIN, issue_id)
                 continue
 
+            devices = self._component_devices(option)
+            # What the device page calls this component, which is translated
+            # and is whatever the user renamed it to, and the same names as
+            # links to those pages. The option is what is left if the devices
+            # are not registered yet, which is what the report at the end of
+            # `async_setup_entry` catches up with.
+            names = [
+                device.name_by_user or device.name or option for device in devices
+            ]
+            links = [
+                f"[{name}](/config/devices/device/{device.id})"
+                for name, device in zip(names, devices, strict=True)
+            ]
+
             ir.async_create_issue(
                 self.hass,
                 DOMAIN,
@@ -225,11 +240,43 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
                 severity=ir.IssueSeverity.WARNING,
                 translation_key="component_unavailable",
                 translation_placeholders={
-                    "component": option,
+                    "component": ", ".join(names) or option,
+                    "devices": ", ".join(links) or option,
                     "address": self._address,
                     "title": self._entry.title,
                 },
             )
+
+    def _component_devices(self, option: str) -> list[dr.DeviceEntry]:
+        """Return the registered devices of one component, in order.
+
+        One device per instance of the component, and every one of them is
+        behind the single issue the component raises: the library reads all
+        four buffers in one call, so a buffer that answers nothing is every
+        buffer as far as anything here can tell.
+
+        A device is registered by the entities on it, which are built after the
+        refresh `async_setup_entry` awaits - so on the first refresh of a new
+        entry there are none yet, and the issue names what it can.
+        """
+        registry = dr.async_get(self.hass)
+        devices = (
+            registry.async_get_device({identifier})
+            for identifier in component_device_identifiers(self._entry, option)
+        )
+
+        return [device for device in devices if device is not None]
+
+    @callback
+    def async_report_failed_components(self) -> None:
+        """Raise the issues of the components that are failing again.
+
+        For `async_setup_entry` to call once the platforms are set up: an issue
+        raised by the refresh before that names its devices by the option they
+        are configured under, because nothing has registered them yet. Raising
+        it again over the top is what puts the device names and their links in.
+        """
+        self._report_failed_components(sorted(self._failed_components))
 
 
 def component_issue_id(entry_id: str, option: str) -> str:

--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -133,7 +133,7 @@
     },
     "component_unavailable": {
       "title": "{component} cannot be read from your Solarfocus system",
-      "description": "\"{title}\" reads every other component of the system at {address}, but {component} answers nothing. Its entities are unavailable for as long as that lasts, and anything reading them - a template, a graph, an automation - has nothing to read.\n\nThis does not recover on its own. Either the component is not installed, in which case switch it off under Configure, or the API version of the entry is set higher than the controller runs - the version is shown on the controller under Fachmann - Modbus."
+      "description": "\"{title}\" reads every other component of the system at {address}, but nothing comes back from {devices}. The entities there are unavailable for as long as that lasts, and anything reading them - a template, a graph, an automation - has nothing to read.\n\nThis does not recover on its own. Either the component is not installed, in which case switch it off under Configure, or the API version of the entry is set higher than the controller runs - the version is shown on the controller under Fachmann - Modbus."
     }
   },
   "entity": {

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -131,8 +131,8 @@
       "description": "\"{title}\" und ein weiterer Eintrag zeigen beide auf {address}. Das stammt aus der Zeit, bevor diese Integration eine Anlage anhand ihrer Adresse identifiziert hat. Beide funktionieren weiterhin, fragen aber einen Regler über eine Modbus-Verbindung ab, und jede Entität existiert doppelt.\n\nEntferne den der beiden, den deine Dashboards und Automatisierungen nicht verwenden. Diese Entscheidung kann hier niemand abnehmen, und wird der falsche entfernt, werden die verbliebenen Entitäten umbenannt. Der Eintrag, den du behältst, übernimmt die Adresse beim nächsten Laden, und diese Meldung verschwindet damit."
     },
     "component_unavailable": {
-      "title": "{component} kann nicht von der Solarfocus-Anlage gelesen werden",
-      "description": "\"{title}\" liest alle anderen Komponenten der Anlage unter {address}, {component} antwortet jedoch nicht. Die zugehörigen Entitäten sind so lange nicht verfügbar, und was sie ausliest - ein Template, ein Diagramm, eine Automatisierung - findet nichts vor.\n\nDas geht nicht von selbst weg. Entweder ist die Komponente nicht vorhanden, dann schalte sie unter Konfigurieren ab, oder die API-Version des Eintrags ist höher eingestellt als der Regler tatsächlich hat - die Version steht am Regler unter Fachmann - Modbus."
+      "title": "Die Solarfocus-Anlage liefert keine Daten von {component}",
+      "description": "\"{title}\" liest alle anderen Komponenten der Anlage unter {address}, von {devices} kommt jedoch nichts zurück. Die Entitäten dort sind so lange nicht verfügbar, und was sie ausliest - ein Template, ein Diagramm, eine Automatisierung - findet nichts vor.\n\nDas geht nicht von selbst weg. Entweder ist die Komponente nicht vorhanden, dann schalte sie unter Konfigurieren ab, oder die API-Version des Eintrags ist höher eingestellt als der Regler tatsächlich hat - die Version steht am Regler unter Fachmann - Modbus."
     }
   },
   "entity": {

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -133,7 +133,7 @@
     },
     "component_unavailable": {
       "title": "{component} cannot be read from your Solarfocus system",
-      "description": "\"{title}\" reads every other component of the system at {address}, but {component} answers nothing. Its entities are unavailable for as long as that lasts, and anything reading them - a template, a graph, an automation - has nothing to read.\n\nThis does not recover on its own. Either the component is not installed, in which case switch it off under Configure, or the API version of the entry is set higher than the controller runs - the version is shown on the controller under Fachmann - Modbus."
+      "description": "\"{title}\" reads every other component of the system at {address}, but nothing comes back from {devices}. The entities there are unavailable for as long as that lasts, and anything reading them - a template, a graph, an automation - has nothing to read.\n\nThis does not recover on its own. Either the component is not installed, in which case switch it off under Configure, or the API version of the entry is set higher than the controller runs - the version is shown on the controller under Fachmann - Modbus."
     }
   },
   "entity": {

--- a/tests/test_repair_issues.py
+++ b/tests/test_repair_issues.py
@@ -5,9 +5,15 @@ are otherwise invisible: one is a log line written once at migration, the other
 is a component that has gone unavailable for good.
 """
 
-from custom_components.solarfocus.const import CONF_BOILER, CONF_HEATING_CIRCUIT, DOMAIN
+from custom_components.solarfocus.const import (
+    CONF_BOILER,
+    CONF_BUFFER,
+    CONF_FRESH_WATER_MODULE,
+    CONF_HEATING_CIRCUIT,
+    DOMAIN,
+)
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 
 from .conftest import build_config_entry
 
@@ -173,10 +179,143 @@ async def test_a_component_that_answers_nothing_is_reported(
     )
 
     assert issue is not None
-    assert issue.translation_placeholders["component"] == CONF_HEATING_CIRCUIT
+    assert issue.translation_placeholders["component"] == "Heating circuit 1"
     assert issue.translation_placeholders["address"] == "solarfocus.local:502"
     # The component that reads fine has nothing raised against it
     assert _issue(hass, f"component_unavailable_{entry.entry_id}_{CONF_BOILER}") is None
+
+
+async def test_the_issue_names_the_component_the_way_the_device_page_does(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """The option is what the coordinator calls a component, not what a user does.
+
+    `fresh_water_module` is what the entry stores it under; `Fresh water module`
+    is what the device page has said since there is a device per component. An
+    issue naming the option asks the user to recognise their heating system in
+    a configuration key.
+
+    Every instance is named, because every instance is behind the issue: the
+    library reads both fresh water modules in one call, so one that answers
+    nothing is both of them as far as anything here can tell.
+    """
+    api.update_fresh_water_modules.return_value = False
+
+    entry = await _setup(hass, heating_circuit=1, fresh_water_module=2)
+
+    issue = _issue(
+        hass, f"component_unavailable_{entry.entry_id}_{CONF_FRESH_WATER_MODULE}"
+    )
+
+    assert issue is not None
+    assert issue.translation_placeholders["component"] == (
+        "Fresh water module 1, Fresh water module 2"
+    )
+
+
+async def test_the_issue_names_the_component_in_the_language_of_the_system(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """The device name is translated, so the issue that borrows it is too.
+
+    Which is the other half of what the option leaks: `heating_circuit` is an
+    English configuration key in the middle of a German sentence, and the
+    device page next to it says `Heizkreis 1`.
+    """
+    await hass.config.async_update(language="de")
+
+    api.update_heating.return_value = False
+
+    entry = await _setup(hass, heating_circuit=1, boiler=1)
+
+    issue = _issue(
+        hass, f"component_unavailable_{entry.entry_id}_{CONF_HEATING_CIRCUIT}"
+    )
+
+    assert issue is not None
+    assert issue.translation_placeholders["component"] == "Heizkreis 1"
+
+
+async def test_the_issue_calls_the_component_what_the_user_renamed_it_to(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """A renamed device is the name the user knows that component by.
+
+    Nothing else they read says `Boiler 1` any more, so an issue that does is
+    about a component they cannot place.
+    """
+    api.update_boiler.return_value = False
+
+    entry = await _setup(hass, heating_circuit=1, boiler=1)
+    registry = dr.async_get(hass)
+    device = registry.async_get_device({(DOMAIN, f"{entry.entry_id}_bo1")})
+
+    assert device is not None
+    registry.async_update_device(device.id, name_by_user="Dusche")
+    await entry.runtime_data.async_refresh()
+
+    issue = _issue(hass, f"component_unavailable_{entry.entry_id}_{CONF_BOILER}")
+
+    assert issue is not None
+    assert issue.translation_placeholders["component"] == "Dusche"
+
+
+async def test_the_issue_links_the_device_pages_of_the_component(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """The issue is about a device and there is no device field to say so.
+
+    A repair issue takes placeholders and nothing that binds it to a device, so
+    the link is markdown in the description - one per instance, because the
+    issue covers all of them. What it has to point at is a device that is in
+    the registry: a link to a page that does not exist is worse than no link.
+    """
+    api.update_buffer.return_value = False
+
+    entry = await _setup(hass, heating_circuit=1, buffer=2)
+    registry = dr.async_get(hass)
+
+    issue = _issue(hass, f"component_unavailable_{entry.entry_id}_{CONF_BUFFER}")
+
+    assert issue is not None
+
+    devices = [
+        registry.async_get_device({(DOMAIN, f"{entry.entry_id}_bu{index}")})
+        for index in (1, 2)
+    ]
+
+    assert all(device is not None for device in devices)
+    assert issue.translation_placeholders["devices"] == ", ".join(
+        f"[Buffer {index}](/config/devices/device/{device.id})"
+        for index, device in enumerate(devices, start=1)
+    )
+
+
+async def test_an_issue_raised_before_the_devices_exist_is_named_once_they_do(
+    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+) -> None:
+    """The first refresh of a new entry is the one that has no devices to name.
+
+    Setting the entry up reads every component once, and that is what raises
+    the issue - before the platforms are forwarded, so before the entities
+    that register the devices exist. Without a second look the user would be
+    left with the option name and no link until the next poll.
+    """
+    api.update_heating.return_value = False
+
+    entry = await _setup(hass, heating_circuit=1, boiler=1)
+
+    issue = _issue(
+        hass, f"component_unavailable_{entry.entry_id}_{CONF_HEATING_CIRCUIT}"
+    )
+    device = dr.async_get(hass).async_get_device({(DOMAIN, f"{entry.entry_id}_hc1")})
+
+    assert issue is not None
+    assert device is not None
+    # No refresh has run since the one setting the entry up
+    assert issue.translation_placeholders["devices"] == (
+        f"[Heating circuit 1](/config/devices/device/{device.id})"
+    )
 
 
 async def test_a_component_coming_back_clears_only_its_own_issue(


### PR DESCRIPTION
Closes #231, the second of the two `consider` items #208 left after #213.

A component that stops answering raised an issue naming the raw option:

> **biomassboiler cannot be read from your Solarfocus system**
> "Solarfocus" reads every other component of the system at 192.168.1.2:502, but biomassboiler answers nothing. […]

`fresh_water_module` and `heating_circuit` leaked configuration keys into German text, and there was nothing in the issue to get from it to the thing it is about.

## The name

Since #213 there is a device per component, so the name is there to borrow. The issue now calls a component what its device page calls it — translated, and whatever the user renamed it to:

> **Heating circuit 1 cannot be read from your Solarfocus system**
> "Solarfocus" reads every other component of the system at 192.168.1.2:502, but nothing comes back from [Heating circuit 1](/config/devices/device/…). The entities there are unavailable […]

## The link

A repair issue has no device field — `ir.async_create_issue` takes placeholders, `learn_more_url` and `is_fixable`/`data`, and nothing that binds an issue to a device. So the link is a `/config/devices/device/<id>` placeholder rendered as markdown in the description, rather than a fix flow that would only end at the same page.

## The wrinkle

One issue covers every instance of a component, because the library reads all four buffers in one call and a failure is not attributable to buffer 2. All of them are named and all of them are linked: `Buffer 1, Buffer 2` in the title, both device pages in the description.

That is also why the German title changed — `{component} kann nicht von der Solarfocus-Anlage gelesen werden` reads `Pufferspeicher 1, Pufferspeicher 2 kann` as soon as the placeholder holds more than one name. `Die Solarfocus-Anlage liefert keine Daten von {component}` stays correct for one instance or four, and the description phrases both languages the same way.

## Ordering

The refresh that raises the issue is the one `async_setup_entry` awaits, and the devices are registered by the entities, which are built after it. So setup reports again once the platforms are forwarded. The option name survives only as what an issue falls back to when no device is there to name — which is now a moment rather than a poll interval.

## Also

`expected_device_identifiers` is built from the new `component_device_identifiers` instead of repeating the counted/once split: the identifiers a repair issue looks a component up by have to be the identifiers the entities register, so they are spelled out once.

## Tests

`1212 passed`, `ruff`, `mypy` and `pylint` clean on `custom_components/`.

New coverage in `tests/test_repair_issues.py`: the placeholder resolves to the translated device name, in German too (`Heizkreis 1`); a user-renamed device is called what the user named it; the links point at devices that exist in the registry, one per instance; and an issue raised before the devices exist is named once they do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)