### PR TITLE
Fix the EcoTop door contact polarity, with an opt-out for wiring differences

### DIFF
--- a/custom_components/solarfocus/__init__.py
+++ b/custom_components/solarfocus/__init__.py
@@ -29,6 +29,7 @@ from .const import (
     CONF_BUFFER,
     CONF_CIRCULATION,
     CONF_DIFFERENTIAL_MODULE,
+    CONF_DOOR_CONTACT_INVERTED,
     CONF_FRESH_WATER_MODULE,
     CONF_HEATING_CIRCUIT,
     CONF_HEATPUMP,
@@ -788,6 +789,23 @@ async def async_migrate_entry(
 
         hass.config_entries.async_update_entry(
             config_entry, options=new_options, version=11
+        )
+
+    if config_entry.version == 11:
+        # The door contact binary sensor read an EcoTop's register the wrong
+        # way round - see #91 - and that is fixed against the specification
+        # regardless of this option. But the door contact is wired through a
+        # 3-pin terminal that could be strapped normally-open or
+        # normally-closed depending on how the installer wired it, which is a
+        # per-installation hardware fact no register read can tell apart from
+        # here, so this stays as an escape hatch for whoever the fix gets
+        # backwards. Off - the specification's polarity - for every entry
+        # until its owner has a reason to say otherwise.
+        new_options = {**config_entry.options}
+        new_options.setdefault(CONF_DOOR_CONTACT_INVERTED, False)
+
+        hass.config_entries.async_update_entry(
+            config_entry, options=new_options, version=12
         )
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)

--- a/custom_components/solarfocus/binary_sensor.py
+++ b/custom_components/solarfocus/binary_sensor.py
@@ -1,6 +1,6 @@
 """Binary Sensor for Solarfocus integration."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import logging
 from typing import override
 
@@ -25,6 +25,7 @@ from .const import (
     CONF_BUFFER,
     CONF_CIRCULATION,
     CONF_DIFFERENTIAL_MODULE,
+    CONF_DOOR_CONTACT_INVERTED,
     CONF_FRESH_WATER_MODULE,
     CONF_HEATING_CIRCUIT,
     CONF_HEATPUMP,
@@ -103,7 +104,16 @@ async def async_setup_entry(
             entities.append(entity)
 
     if config_entry.options[CONF_BIOMASS_BOILER]:
+        # See #91: the door contact reads backwards on an installation wired
+        # the other way round at its 3-pin terminal, which nothing read over
+        # Modbus can tell apart from a correctly wired one. This is the escape
+        # hatch for that installation - every other one leaves it off and
+        # reads register 2405 the way the specification documents it.
+        door_contact_inverted = config_entry.options[CONF_DOOR_CONTACT_INVERTED]
         for description in BIOMASS_BOILER_BINARY_SENSOR_TYPES:
+            if description.key == "door_contact" and door_contact_inverted:
+                description = replace(description, on_state="0")
+
             _description = create_description(
                 BIOMASS_BOILER_COMPONENT,
                 BIOMASS_BOILER_COMPONENT_PREFIX,
@@ -239,17 +249,22 @@ HEATPUMP_BINARY_SENSOR_TYPES = [
     ),
 ]
 
-# Register 2405 is reported the other way round on a therminator than on an
-# EcoTop, which is why the door is described twice. Both descriptions carry the
-# same key, so they build the same `unique_id` and only one of the two may ever
-# survive the system filter: each names the systems it was measured on.
+# Register 2405 answers 1 open, 0 closed - the specification says so, and #91
+# confirmed it by measuring an EcoTop directly (register 2405 on QModMaster,
+# the controller's own display, and pysolarfocus all agreed) after it turned
+# out this integration had the EcoTop the other way round since #79/#80. A
+# Pellet Elegance (15 kW, v25.110) was read at the door for #217 and agrees.
 #
-# A Pellet Elegance (15 kW, v25.110) was read at the door for #217 and answers
-# 1 open, 0 closed - the therminator way round, so it joins that description.
-# The other Pellet Elegance in that thread reads 2 in both positions, on a
-# boiler whose owner reports the contact does not work; 2 is neither state
-# below, so it stays "closed" rather than flapping, which is the right way for
-# an unfitted contact to fail.
+# The other Pellet Elegance in the #217 thread read 2 in both door positions,
+# on a boiler whose owner reports the contact does not work; 2 is neither
+# state, so an unfitted contact reads "closed" rather than flapping, which is
+# the right way for it to fail.
+#
+# `CONF_DOOR_CONTACT_INVERTED` exists because the door contact is wired
+# through a 3-pin terminal - normally-open or normally-closed is an
+# installer's choice, not something a register read can tell apart - so a
+# boiler still reading backwards after this is a wiring fact about one
+# installation, not evidence the specification is wrong again.
 #
 # The Octoplus is still unmeasured and so still has no door contact. Guessing
 # between two polarities gives a sensor that is confidently wrong half the
@@ -260,14 +275,8 @@ BIOMASS_BOILER_BINARY_SENSOR_TYPES = [
         device_class=BinarySensorDeviceClass.DOOR,
         on_state="1",
         unsupported_systems=every_system_but(
-            Systems.THERMINATOR, Systems.PELLETELEGANCE
+            Systems.THERMINATOR, Systems.PELLETELEGANCE, Systems.ECOTOP
         ),
-    ),
-    SolarfocusBinarySensorEntityDescription(
-        key="door_contact",
-        device_class=BinarySensorDeviceClass.DOOR,
-        on_state="0",
-        unsupported_systems=every_system_but(Systems.ECOTOP),
     ),
 ]
 

--- a/custom_components/solarfocus/config_flow.py
+++ b/custom_components/solarfocus/config_flow.py
@@ -27,6 +27,7 @@ from .const import (
     CONF_BUFFER,
     CONF_CIRCULATION,
     CONF_DIFFERENTIAL_MODULE,
+    CONF_DOOR_CONTACT_INVERTED,
     CONF_FRESH_WATER_MODULE,
     CONF_HEATING_CIRCUIT,
     CONF_HEATPUMP,
@@ -254,7 +255,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Solarfocus."""
 
-    VERSION = 11
+    VERSION = 12
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     data: dict[str, Any]
@@ -346,6 +347,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_FRESH_WATER_MODULE: user_input[CONF_FRESH_WATER_MODULE],
                 CONF_CIRCULATION: user_input[CONF_CIRCULATION],
                 CONF_DIFFERENTIAL_MODULE: user_input[CONF_DIFFERENTIAL_MODULE],
+                # Not asked here - see #91. Off, the specification's polarity,
+                # until an owner has a reason from the door contact itself to
+                # change it under Configure.
+                CONF_DOOR_CONTACT_INVERTED: False,
             },
         )
 
@@ -459,7 +464,9 @@ class SolarfocusOptionsFlowHandler(config_entries.OptionsFlow):
             )
 
         # Which of the two the system can have is not asked, so it is not in the
-        # form and has to be carried over rather than read back from it.
+        # form and has to be carried over rather than read back from it. A
+        # vampair has no door contact either, and does not ask about it, so
+        # that carries over the same way rather than dropping out of options.
         vampair = self.config_entry.data[CONF_SOLARFOCUS_SYSTEM] == Systems.VAMPAIR
 
         return self.async_create_entry(
@@ -469,6 +476,11 @@ class SolarfocusOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_HEATPUMP: user_input[CONF_HEATPUMP] if vampair else False,
                 CONF_BIOMASS_BOILER: (
                     False if vampair else user_input[CONF_BIOMASS_BOILER]
+                ),
+                CONF_DOOR_CONTACT_INVERTED: (
+                    self.config_entry.options[CONF_DOOR_CONTACT_INVERTED]
+                    if vampair
+                    else user_input[CONF_DOOR_CONTACT_INVERTED]
                 ),
             },
         )
@@ -509,6 +521,12 @@ class SolarfocusOptionsFlowHandler(config_entries.OptionsFlow):
         else:
             schema[
                 vol.Optional(CONF_BIOMASS_BOILER, default=current[CONF_BIOMASS_BOILER])
+            ] = bool
+            schema[
+                vol.Optional(
+                    CONF_DOOR_CONTACT_INVERTED,
+                    default=current[CONF_DOOR_CONTACT_INVERTED],
+                )
             ] = bool
 
         schema[

--- a/custom_components/solarfocus/const.py
+++ b/custom_components/solarfocus/const.py
@@ -28,6 +28,7 @@ CONF_SOLAR = "solar"
 CONF_FRESH_WATER_MODULE = "fresh_water_module"
 CONF_CIRCULATION = "circulation"
 CONF_DIFFERENTIAL_MODULE = "differential_module"
+CONF_DOOR_CONTACT_INVERTED = "door_contact_inverted"
 
 """Entity naming"""
 HEATING_CIRCUIT_PREFIX = "Heating circuit"

--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -15,7 +15,8 @@
           "solar": "Solar",
           "fresh_water_module": "Fresh water module",
           "circulation": "Circulation",
-          "differential_module": "Differential control module"
+          "differential_module": "Differential control module",
+          "door_contact_inverted": "Door contact reads inverted"
         },
         "data_description": {
           "scan_interval": "How often every configured component is read, in seconds. Five is the lowest accepted.",
@@ -28,7 +29,8 @@
           "solar": "How many solar circuits are installed. More than one needs API version 25.030 or newer.",
           "fresh_water_module": "How many fresh water modules are installed.",
           "circulation": "How many circulation groups are installed, one per boiler. Needs API version 25.030 or newer.",
-          "differential_module": "How many differential control modules are installed, each with two control loops. Needs API version 25.030 or newer."
+          "differential_module": "How many differential control modules are installed, each with two control loops. Needs API version 25.030 or newer.",
+          "door_contact_inverted": "Enable only if the door contact shows open while the boiler door is closed. The door contact is wired through a terminal that can be strapped either way round, so this is a fact about one installation, not about the model of boiler."
         }
       }
     },

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -15,7 +15,8 @@
           "solar": "Solar",
           "fresh_water_module": "Frischwassermodule",
           "circulation": "Zirkulation",
-          "differential_module": "Differenzregelmodul"
+          "differential_module": "Differenzregelmodul",
+          "door_contact_inverted": "Türkontakt invertiert lesen"
         },
         "data_description": {
           "scan_interval": "Wie oft jede konfigurierte Komponente gelesen wird, in Sekunden. Fünf ist der kleinste akzeptierte Wert.",
@@ -28,7 +29,8 @@
           "solar": "Wie viele Solarkreise vorhanden sind. Mehr als einer benötigt API-Version 25.030 oder neuer.",
           "fresh_water_module": "Wie viele Frischwassermodule vorhanden sind.",
           "circulation": "Wie viele Zirkulationsgruppen installiert sind, eine je Boiler. Ab API-Version 25.030.",
-          "differential_module": "Wie viele Differenzregelmodule installiert sind, jedes mit zwei Regelkreisen. Ab API-Version 25.030."
+          "differential_module": "Wie viele Differenzregelmodule installiert sind, jedes mit zwei Regelkreisen. Ab API-Version 25.030.",
+          "door_contact_inverted": "Nur aktivieren, wenn der Türkontakt bei geschlossener Kesseltür „offen“ anzeigt. Der Türkontakt hängt an einer Klemme, die sowohl öffnend als auch schließend verdrahtet sein kann - das ist eine Eigenschaft der jeweiligen Installation, nicht des Kesselmodells."
         }
       }
     },

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -15,7 +15,8 @@
           "solar": "Solar",
           "fresh_water_module": "Fresh water module",
           "circulation": "Circulation",
-          "differential_module": "Differential control module"
+          "differential_module": "Differential control module",
+          "door_contact_inverted": "Door contact reads inverted"
         },
         "data_description": {
           "scan_interval": "How often every configured component is read, in seconds. Five is the lowest accepted.",
@@ -28,7 +29,8 @@
           "solar": "How many solar circuits are installed. More than one needs API version 25.030 or newer.",
           "fresh_water_module": "How many fresh water modules are installed.",
           "circulation": "How many circulation groups are installed, one per boiler. Needs API version 25.030 or newer.",
-          "differential_module": "How many differential control modules are installed, each with two control loops. Needs API version 25.030 or newer."
+          "differential_module": "How many differential control modules are installed, each with two control loops. Needs API version 25.030 or newer.",
+          "door_contact_inverted": "Enable only if the door contact shows open while the boiler door is closed. The door contact is wired through a terminal that can be strapped either way round, so this is a fact about one installation, not about the model of boiler."
         }
       }
     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from custom_components.solarfocus.const import (
     CONF_BUFFER,
     CONF_CIRCULATION,
     CONF_DIFFERENTIAL_MODULE,
+    CONF_DOOR_CONTACT_INVERTED,
     CONF_FRESH_WATER_MODULE,
     CONF_HEATING_CIRCUIT,
     CONF_HEATPUMP,
@@ -32,7 +33,7 @@ from homeassistant.const import (
 )
 
 # The config entry version the integration currently migrates to.
-CURRENT_VERSION = 11
+CURRENT_VERSION = 12
 
 
 def build_data(system: Systems = Systems.VAMPAIR) -> dict:
@@ -60,6 +61,7 @@ def build_options(**overrides) -> dict:
         CONF_HEATPUMP: False,
         CONF_BIOMASS_BOILER: False,
         CONF_PHOTOVOLTAIC: False,
+        CONF_DOOR_CONTACT_INVERTED: False,
     }
     options.update(overrides)
     return options

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -21,6 +21,7 @@ from custom_components.solarfocus.const import (
     CONF_BUFFER,
     CONF_CIRCULATION,
     CONF_DIFFERENTIAL_MODULE,
+    CONF_DOOR_CONTACT_INVERTED,
     CONF_FRESH_WATER_MODULE,
     CONF_HEATING_CIRCUIT,
     CONF_HEATPUMP,
@@ -194,6 +195,9 @@ async def test_full_flow_vampair(
         CONF_HEATPUMP: True,
         # A heat pump system never has a biomass boiler
         CONF_BIOMASS_BOILER: False,
+        # Not asked in the wizard - see #91. A vampair never has a door
+        # contact either, so this is only ever changed under Configure.
+        CONF_DOOR_CONTACT_INVERTED: False,
     }
     assert len(setup_entry.mock_calls) == 1
 
@@ -232,6 +236,7 @@ async def test_full_flow_biomass_systems(
     assert result["options"][CONF_FRESH_WATER_MODULE] == 1
     assert result["options"][CONF_CIRCULATION] == 2
     assert result["options"][CONF_DIFFERENTIAL_MODULE] == 1
+    assert result["options"][CONF_DOOR_CONTACT_INVERTED] is False
 
 
 async def test_form_cannot_connect(

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -245,11 +245,15 @@ def test_single_system_biomass_registers_reach_only_that_system(
 
 # What register 2405 was measured to hold, and on which boiler. A door contact
 # is worth pinning down: get the polarity backwards and the entity still works,
-# it just says the opposite of the truth, which is how #91 and #101 have stayed
-# open for two years.
+# it just says the opposite of the truth, which is how #91 and #101 stayed open
+# for two years - this integration had the EcoTop backwards from #79/#80 until
+# #91 measured a real one directly: register 2405 on QModMaster, the
+# controller's own display, and pysolarfocus all agreed on 0 closed / 1 open,
+# the same as the specification and every other system below.
 MEASURED_DOOR_POLARITIES = [
     (Systems.THERMINATOR, "1"),
-    (Systems.ECOTOP, "0"),
+    # 25.100, measured directly for #91 after #79/#80 had this backwards.
+    (Systems.ECOTOP, "1"),
     # 15 kW on v25.110, read at the door for #217: 1 open, 0 closed.
     (Systems.PELLETELEGANCE, "1"),
 ]
@@ -259,7 +263,13 @@ MEASURED_DOOR_POLARITIES = [
 def test_the_door_contact_reads_the_way_it_was_measured(
     system: Systems, on_state: str
 ) -> None:
-    """Exactly one door description reaches a system, with the measured polarity."""
+    """Exactly one door description reaches a system, with the measured polarity.
+
+    `CONF_DOOR_CONTACT_INVERTED` is a per-installation escape hatch layered on
+    top of this in `binary_sensor.async_setup_entry`, for a door contact wired
+    the other way round at its terminal - it does not change what the
+    description itself says here.
+    """
     reaching = [
         d
         for d in binary_sensor.BIOMASS_BOILER_BINARY_SENSOR_TYPES

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -18,6 +18,7 @@ from custom_components.solarfocus.const import (
     CONF_BUFFER,
     CONF_CIRCULATION,
     CONF_DIFFERENTIAL_MODULE,
+    CONF_DOOR_CONTACT_INVERTED,
     CONF_FRESH_WATER_MODULE,
     CONF_HEATING_CIRCUIT,
     CONF_HEATPUMP,
@@ -319,6 +320,43 @@ async def test_migration_keeps_the_module_counts_an_entry_already_has(
 
     assert entry.options[CONF_CIRCULATION] == 2
     assert entry.options[CONF_DIFFERENTIAL_MODULE] == 1
+
+
+async def test_migration_from_version_11_adds_the_door_contact_option(
+    hass: HomeAssistant,
+) -> None:
+    """Version 11 predates the door contact polarity option from #91.
+
+    `binary_sensor.async_setup_entry` reads it by key, so an entry that has
+    never been asked fails to load rather than reading the specification's
+    polarity by default.
+    """
+    entry = build_config_entry()
+    options = {
+        setting: value
+        for setting, value in entry.options.items()
+        if setting != CONF_DOOR_CONTACT_INVERTED
+    }
+    entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(entry, options=options, version=11)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == CURRENT_VERSION
+    assert entry.options[CONF_DOOR_CONTACT_INVERTED] is False
+
+
+async def test_migration_keeps_the_door_contact_option_an_entry_already_has(
+    hass: HomeAssistant,
+) -> None:
+    """An owner who already opted into the inverted reading keeps it."""
+    entry = build_config_entry(door_contact_inverted=True)
+    entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(entry, version=11)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.options[CONF_DOOR_CONTACT_INVERTED] is True
 
 
 async def test_migration_from_version_3_moves_options(hass: HomeAssistant) -> None:

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -340,6 +340,39 @@ async def test_binary_sensors_cover_all_configured_components(
         assert any(key.startswith(prefix) for key in keys), prefix
 
 
+def _door_contact(entities) -> object:
+    return next(e for e in entities if e.entity_description.key == "bb_door_contact")
+
+
+async def test_the_door_contact_reads_the_specifications_polarity_by_default(
+    hass: HomeAssistant,
+) -> None:
+    """Off by default - see #91.
+
+    An entry built before this option existed is migrated straight to the
+    specification's polarity, not to the inverted reading the old EcoTop
+    description had.
+    """
+    entry = build_config_entry(Systems.ECOTOP, biomassboiler=True)
+
+    entities = await _setup(hass, binary_sensor, entry)
+
+    assert _door_contact(entities).entity_description.on_state == "1"
+
+
+async def test_the_door_contact_option_inverts_it_for_one_installation(
+    hass: HomeAssistant,
+) -> None:
+    """The escape hatch from #91, for a door contact wired the other way round."""
+    entry = build_config_entry(
+        Systems.ECOTOP, biomassboiler=True, door_contact_inverted=True
+    )
+
+    entities = await _setup(hass, binary_sensor, entry)
+
+    assert _door_contact(entities).entity_description.on_state == "0"
+
+
 async def test_entities_read_the_coordinator(hass: HomeAssistant) -> None:
     """Created entities are wired to the coordinator of their entry."""
     entry = build_config_entry(boiler=1)


### PR DESCRIPTION
## Summary

Fixes #91 (and the related #101): the door contact binary sensor read backwards on an EcoTop.

- Register 2405 answers 1 open, 0 closed - confirmed by @lein1013 measuring a real EcoTop directly in #91/#132 (register 2405 on QModMaster, the controller's own display, and `pysolarfocus` all agreed). This integration has had the EcoTop the other way round since #79/#80. The two system-specific `door_contact` descriptions (EcoTop vs. Therminator/Pellet Elegance) now agree and are merged into one.
- Added `CONF_DOOR_CONTACT_INVERTED`, an options-flow checkbox (off by default), as the escape hatch @lein1013 suggested in #132. The door contact is wired through a 3-pin terminal that can be strapped normally-open or normally-closed depending on the installer, which is a per-installation hardware fact no Modbus read can distinguish - so rather than gate the fix on a firmware version nobody could pin down, this ships the specification-correct default for everyone and lets an owner whose contact still reads backwards flip it under **Configure**.
- Config entry version bumped 11 → 12, with a migration step that defaults existing entries to the un-inverted (spec-correct) reading.

## Test plan
- [x] `uv run pytest` - 1216 passed, 1 skipped
- [x] `make check` (pylint, ruff, mypy) - clean
- [x] Updated `MEASURED_DOOR_POLARITIES` in `tests/test_entity_descriptions.py`, which had encoded the old (backwards) EcoTop polarity as "measured"
- [x] New migration tests for the version 11 → 12 step
- [x] New tests in `tests/test_platform_setup.py` covering both the default and the inverted option end-to-end through `binary_sensor.async_setup_entry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)