### PR TITLE
Migrate to aiosolarfocus, and reach Platinum

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Copy your changes manually (see [README.md -> Installation](README.md)) to your 
 - [hacs.json](https://github.com/LavermanJJ/home-assistant-solarfocus/blob/main/hacs.json): name, version definition for the hacs integration (see [HACS Integrations](https://hacs.xyz/docs/publish/integration/)), modify if you plan to install the integration from your fork, don't use this branch to make a pull request to the original repository.
 
 - [custom_components/solafocus/manifest.json](https://github.com/LavermanJJ/home-assistant-solarfocus/blob/main/custom_components/solarfocus/manifest.json): if you go deeper into the development you might need to update the used aiosolarfocus python package. To test you can modifiy the requirements to used your own version: e.g.,
-  `"requirements": ["git+https://github.com/LavermanJJ/aiosolarfocus.git@main#aiosolarfocus==0.2.0"],`
+  `"requirements": ["git+https://github.com/LavermanJJ/aiosolarfocus.git@main#aiosolarfocus==0.2.1"],`
 
 - [strings.json](https://github.com/LavermanJJ/home-assistant-solarfocus/blob/main/custom_components/solarfocus/strings.json): relevant for enums and translation (see the related translations folder). Keep consistent. Some guides:
     - First letter is capital

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,8 +50,8 @@ Copy your changes manually (see [README.md -> Installation](README.md)) to your 
 
 - [hacs.json](https://github.com/LavermanJJ/home-assistant-solarfocus/blob/main/hacs.json): name, version definition for the hacs integration (see [HACS Integrations](https://hacs.xyz/docs/publish/integration/)), modify if you plan to install the integration from your fork, don't use this branch to make a pull request to the original repository.
 
-- [custom_components/solafocus/manifest.json](https://github.com/LavermanJJ/home-assistant-solarfocus/blob/main/custom_components/solarfocus/manifest.json): if you go deeper into the development you might need to update the used pysolarfocus python package. To test you can modifiy the requirements to used your own version: e.g.,
-  `"requirements": ["git+https://github.com/lein1013/pysolarfocus.git@develop#pysolarfocus==3.4.2", "pymodbus==3.1.2"],`
+- [custom_components/solafocus/manifest.json](https://github.com/LavermanJJ/home-assistant-solarfocus/blob/main/custom_components/solarfocus/manifest.json): if you go deeper into the development you might need to update the used aiosolarfocus python package. To test you can modifiy the requirements to used your own version: e.g.,
+  `"requirements": ["git+https://github.com/LavermanJJ/aiosolarfocus.git@main#aiosolarfocus==0.2.0"],`
 
 - [strings.json](https://github.com/LavermanJJ/home-assistant-solarfocus/blob/main/custom_components/solarfocus/strings.json): relevant for enums and translation (see the related translations folder). Keep consistent. Some guides:
     - First letter is capital

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This Home Assistant custom component is a community driven effort to integrate S
 > **Warning**
 > Use with caution, in case of doubt check with Solarfocus or your installer if a feature / functionality (e.g. cooling) is supported by your installation to avoid damages to your heating system or the building.
 
-The project uses the Python library [pysolarfocus](https://github.com/LavermanJJ/pysolarfocus) for retrieving values via Modbus TCP from the heating system.
+The project uses the Python library [aiosolarfocus](https://github.com/LavermanJJ/aiosolarfocus) for retrieving values via Modbus TCP from the heating system. It is the async successor of [pysolarfocus](https://github.com/LavermanJJ/pysolarfocus), which the integration used up to version 6.
 
 ## Home Assistant Device Types
 
@@ -528,7 +528,7 @@ logger:
   default: info
   logs:
     custom_components.solarfocus: debug
-    pysolarfocus: debug
+    aiosolarfocus: debug
 ```
 
 The debug log contains the registers being read and written, which is what an issue report

--- a/custom_components/solarfocus/__init__.py
+++ b/custom_components/solarfocus/__init__.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from collections import Counter
 import logging
 
-from pysolarfocus import ApiVersions, SolarfocusAPI, Systems
+from aiosolarfocus import (
+    ApiVersion,
+    SolarfocusClient,
+    SolarfocusConfig,
+    SolarfocusConfigError,
+    Systems,
+)
 
 from homeassistant.const import (
     CONF_API_VERSION,
@@ -16,7 +22,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
@@ -69,20 +75,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -
     _async_sync_unique_id(hass, entry)
     _async_report_duplicate_entry(hass, entry)
 
-    api = SolarfocusAPI(
-        ip=entry.data[CONF_HOST],
-        port=entry.data[CONF_PORT],
-        heating_circuit_count=entry.options[CONF_HEATING_CIRCUIT],
-        buffer_count=entry.options[CONF_BUFFER],
-        boiler_count=entry.options[CONF_BOILER],
-        fresh_water_module_count=entry.options[CONF_FRESH_WATER_MODULE],
-        circulation_count=component_count(entry, CONF_CIRCULATION),
-        differential_module_count=component_count(entry, CONF_DIFFERENTIAL_MODULE),
-        solar_count=solar_count(entry),
-        system=Systems(entry.data[CONF_SOLARFOCUS_SYSTEM]),
-        api_version=ApiVersions(entry.data[CONF_API_VERSION]),
-    )
-    coordinator = SolarfocusDataUpdateCoordinator(hass, entry, api)
+    try:
+        config = SolarfocusConfig(
+            host=entry.data[CONF_HOST],
+            port=entry.data[CONF_PORT],
+            system=Systems(entry.data[CONF_SOLARFOCUS_SYSTEM]),
+            # `parse` rather than the constructor: the entry holds the version
+            # as the controller prints it, and a controller newer than this
+            # library knows clamps to the newest it does rather than raising.
+            api_version=ApiVersion.parse(entry.data[CONF_API_VERSION]),
+            heating_circuits=entry.options[CONF_HEATING_CIRCUIT],
+            buffers=entry.options[CONF_BUFFER],
+            boilers=entry.options[CONF_BOILER],
+            fresh_water_modules=entry.options[CONF_FRESH_WATER_MODULE],
+            circulations=component_count(entry, CONF_CIRCULATION),
+            differential_modules=component_count(entry, CONF_DIFFERENTIAL_MODULE),
+            solar=solar_count(entry),
+            heat_pump=entry.options[CONF_HEATPUMP],
+            biomass_boiler=entry.options[CONF_BIOMASS_BOILER],
+            photovoltaic=entry.options[CONF_PHOTOVOLTAIC],
+        )
+    except SolarfocusConfigError as error:
+        # A combination no controller can have - a heat pump on an Ecotop, more
+        # solar circuits than the firmware addresses. The options are what say
+        # so, and only the user can correct them, so this is not something to
+        # retry.
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_configuration",
+            translation_placeholders={"reason": str(error)},
+        ) from error
+
+    client = SolarfocusClient(config)
+    coordinator = SolarfocusDataUpdateCoordinator(hass, entry, client)
 
     await coordinator.async_refresh()
 
@@ -95,7 +120,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -
         # a controller that answered the connection and then none of the
         # registers. Whether the library is still connected is what says which.
         address = f"{entry.data[CONF_HOST]}:{entry.data[CONF_PORT]}"
-        if not api.is_connected:
+        if not client.connected:
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
                 translation_key="cannot_connect",
@@ -108,7 +133,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -
             translation_placeholders={"address": address},
         ) from coordinator.last_exception
 
-    hub = _async_hub_device(hass, entry, api)
+    hub = _async_hub_device(hass, entry, client)
     coordinator.hub_device_id = hub.id
     entry.runtime_data = coordinator
 
@@ -333,7 +358,7 @@ def _async_remove_gone_components(
 
 @callback
 def _async_hub_device(
-    hass: HomeAssistant, entry: SolarfocusConfigEntry, api: SolarfocusAPI
+    hass: HomeAssistant, entry: SolarfocusConfigEntry, client: SolarfocusClient
 ) -> dr.DeviceEntry:
     """Register the controller every component of this entry hangs off.
 
@@ -355,8 +380,8 @@ def _async_hub_device(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, entry.entry_id)},
         name=CONTROLLER_NAME,
-        model=api.system.value,
-        sw_version=api.api_version.value,
+        model=client.config.system.value,
+        sw_version=client.config.api_version.label,
         manufacturer=MANUFACTURER,
     )
 
@@ -589,11 +614,23 @@ async def async_update_options(
 async def async_unload_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -> bool:
     """Unload a config entry.
 
-    The coordinator lives on the entry, so the platforms are all there is to
-    unload. The repair issues are not on the entry and outlive it, including
-    the removal of the entry they name, so they are deleted here.
+    The coordinator lives on the entry, so the platforms are the only thing
+    there is to unload - but the client owns a socket to the controller, and an
+    entry that is unloaded has no business holding one open. The repair issues
+    are not on the entry and outlive it, including the removal of the entry
+    they name, so they are deleted here.
     """
     unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    # After the platforms, not before: an entity that refuses to unload keeps
+    # reading, and closing the socket underneath it would be the entry breaking
+    # itself on the way out of a failed unload.
+    #
+    # An entry whose setup never finished has no coordinator to ask, and
+    # Home Assistant unloads one of those too - `runtime_data` is set at the
+    # end of `async_setup_entry`, after the first refresh has to have worked.
+    if unloaded and (coordinator := getattr(entry, "runtime_data", None)):
+        await coordinator.client.disconnect()
 
     ir.async_delete_issue(hass, DOMAIN, _duplicate_issue_id(entry))
     async_delete_component_issues(hass, entry)

--- a/custom_components/solarfocus/binary_sensor.py
+++ b/custom_components/solarfocus/binary_sensor.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, replace
 import logging
 from typing import override
 
-from pysolarfocus import Systems
+from aiosolarfocus import Systems
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -48,7 +48,7 @@ from .entity import (
     SolarfocusEntityDescription,
     create_description,
     every_system_but,
-    filterVersionAndSystem,
+    supported_entities,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -172,7 +172,7 @@ async def async_setup_entry(
             entity = SolarfocusBinarySensorEntity(coordinator, _description)
             entities.append(entity)
 
-    async_add_entities(filterVersionAndSystem(config_entry, entities))
+    async_add_entities(supported_entities(config_entry, entities))
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -202,12 +202,20 @@ class SolarfocusBinarySensorEntity(SolarfocusEntity, BinarySensorEntity):
 
     @property
     @override
-    def is_on(self) -> bool:
-        """Return the state of the binary sensor."""
-        binary_sensor = self.entity_description.item
-        value = self._get_native_value(binary_sensor)
-        on_state = self.entity_description.on_state
-        return int(value) == int(on_state)
+    def is_on(self) -> bool | None:
+        """Return the state of the binary sensor, or None if it has none.
+
+        `None` is a real reading now: the register is not on this firmware or
+        system, it has not been read yet, or the controller had nothing to put
+        in a flag and sent 0xFFFF, which used to decode through `bool()` and
+        report every flag as set. Reporting it as `off` would be a claim about
+        a door or a pump that nothing has answered for.
+        """
+        value = self._get_native_value(self.entity_description.item)
+        if value is None:
+            return None
+
+        return int(value) == int(self.entity_description.on_state)
 
 
 HEATING_CIRCUIT_BINARY_SENSOR_TYPES = [
@@ -251,7 +259,7 @@ HEATPUMP_BINARY_SENSOR_TYPES = [
 
 # Register 2405 answers 1 open, 0 closed - the specification says so, and #91
 # confirmed it by measuring an EcoTop directly (register 2405 on QModMaster,
-# the controller's own display, and pysolarfocus all agreed) after it turned
+# the controller's own display, and the library all agreed) after it turned
 # out this integration had the EcoTop the other way round since #79/#80. A
 # Pellet Elegance (15 kW, v25.110) was read at the door for #217 and agrees.
 #
@@ -266,15 +274,19 @@ HEATPUMP_BINARY_SENSOR_TYPES = [
 # boiler still reading backwards after this is a wiring fact about one
 # installation, not evidence the specification is wrong again.
 #
-# The Octoplus is still unmeasured and so still has no door contact. Guessing
-# between two polarities gives a sensor that is confidently wrong half the
-# time, which is worse than not having one.
+# The Octoplus is still unmeasured and so still has no door contact. The
+# library maps register 2405 on every biomass boiler, and it is right to: the
+# register is there and it answers. What has not been established is which way
+# round it answers on an Octoplus, and guessing between two polarities gives a
+# sensor that is confidently wrong half the time, which is worse than not
+# having one. That is what `unverified_systems` says, and it is the only
+# reading in the integration that says it.
 BIOMASS_BOILER_BINARY_SENSOR_TYPES = [
     SolarfocusBinarySensorEntityDescription(
         key="door_contact",
         device_class=BinarySensorDeviceClass.DOOR,
         on_state="1",
-        unsupported_systems=every_system_but(
+        unverified_systems=every_system_but(
             Systems.THERMINATOR, Systems.PELLETELEGANCE, Systems.ECOTOP
         ),
     ),
@@ -297,7 +309,6 @@ FRESH_WATER_MODULE_BINARY_SENSOR_TYPES = [
         key="valve",
         device_class=BinarySensorDeviceClass.OPENING,
         on_state="1",
-        min_required_version="23.040",
     ),
 ]
 
@@ -306,7 +317,6 @@ CIRCULATION_BINARY_SENSOR_TYPES = [
         key="pump",
         device_class=BinarySensorDeviceClass.RUNNING,
         on_state="1",
-        min_required_version="25.030",
     ),
 ]
 
@@ -317,12 +327,10 @@ DIFFERENTIAL_MODULE_BINARY_SENSOR_TYPES = [
         key="relay_control_loop_o1",
         device_class=BinarySensorDeviceClass.RUNNING,
         on_state="1",
-        min_required_version="25.030",
     ),
     SolarfocusBinarySensorEntityDescription(
         key="relay_control_loop_o2",
         device_class=BinarySensorDeviceClass.RUNNING,
         on_state="1",
-        min_required_version="25.030",
     ),
 ]

--- a/custom_components/solarfocus/button.py
+++ b/custom_components/solarfocus/button.py
@@ -14,7 +14,7 @@ from .entity import (
     SolarfocusEntity,
     SolarfocusEntityDescription,
     create_description,
-    filterVersionAndSystem,
+    supported_entities,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -52,7 +52,7 @@ async def async_setup_entry(
             entity = SolarfocusButtonEntity(coordinator, _description)
             entities.append(entity)
 
-    async_add_entities(filterVersionAndSystem(config_entry, entities))
+    async_add_entities(supported_entities(config_entry, entities))
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -81,7 +81,7 @@ class SolarfocusButtonEntity(SolarfocusEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Update the current value."""
         button = self.entity_description.item
-        return self._set_native_value(button, PRESSED)
+        await self._async_set_native_value(button, PRESSED)
 
 
 BOILER_BUTTON_TYPES = [

--- a/custom_components/solarfocus/climate.py
+++ b/custom_components/solarfocus/climate.py
@@ -4,7 +4,12 @@ from dataclasses import dataclass
 import logging
 from typing import Any, cast, override
 
-from pysolarfocus import ApiVersions
+from aiosolarfocus import (
+    HeatingCircuitCooling,
+    HeatingCircuitHeatingMode,
+    HeatingCircuitMode,
+)
+from aiosolarfocus.components.heating_circuit import HeatingCircuit
 
 from homeassistant.components.climate import ClimateEntity, ClimateEntityDescription
 from homeassistant.components.climate.const import (
@@ -77,10 +82,6 @@ OPERATING_MODE_OFF = 3
 # Register 32608 "Heizkreismodus"
 HEATING_MODE_HEATING_AND_COOLING = 2
 
-# Register 32608 only exists from this api version on. Without it the circuit
-# cannot be switched to "Heizen + Kühlen", so cooling is not offered below it.
-MIN_COOLING_API_VERSION = ApiVersions.V_22_090.value
-
 # Heating circuit states that mean the circuit is actively cooling.
 COOLING_STATES = [23, 24]
 
@@ -137,6 +138,10 @@ class SolarfocusClimateExtraStoredData(ExtraStoredData):
 
 class SolarfocusClimateEntity(SolarfocusEntity, RestoreEntity, ClimateEntity):
     """Representation of a Solarfocus number entity."""
+
+    # `thermostat` and `domestic_hot_water` are labels rather than register
+    # names: this entity reads and writes several registers of its component.
+    reads_no_single_register = True
 
     entity_description: SolarfocusClimateEntityDescription
 
@@ -197,10 +202,15 @@ class SolarfocusClimateEntity(SolarfocusEntity, RestoreEntity, ClimateEntity):
 
     @property
     def cooling_supported(self) -> bool:
-        """Return whether the circuit can be switched to "Heizen + Kühlen"."""
-        return cast(
-            bool, self.coordinator.api.api_version.greater_or_equal(MIN_COOLING_API_VERSION)
-        )
+        """Return whether the circuit can be switched to "Heizen + Kühlen".
+
+        Asked of the register that answers it rather than of a version number:
+        `heating_mode` is register 32608, which arrived in 22.090, and the
+        library resolves what this firmware and this system actually have. A
+        version comparison here was the integration keeping a second copy of
+        that fact.
+        """
+        return self.component.supports("heating_mode")
 
     @property
     @override
@@ -337,7 +347,7 @@ class SolarfocusClimateEntity(SolarfocusEntity, RestoreEntity, ClimateEntity):
         _LOGGER.info("Set HVAC Mode: %s", hvac_mode)
 
         if hvac_mode == HVACMode.OFF:
-            self._write_heating_circuit(
+            await self._write_heating_circuit(
                 target_supply_temperature=0,
                 cooling=COOLING_OFF,
                 operating_mode=OPERATING_MODE_OFF,
@@ -348,7 +358,7 @@ class SolarfocusClimateEntity(SolarfocusEntity, RestoreEntity, ClimateEntity):
             self._log_dew_point_warning()
 
         self._active_mode = hvac_mode
-        self._write_heating_circuit(
+        await self._write_heating_circuit(
             target_supply_temperature=self._remembered_target_temperature(hvac_mode),
             cooling=COOLING_ON if hvac_mode == HVACMode.COOL else COOLING_OFF,
             operating_mode=self._operating_mode(),
@@ -365,21 +375,34 @@ class SolarfocusClimateEntity(SolarfocusEntity, RestoreEntity, ClimateEntity):
             return OPERATING_MODE_CONTINUOUS
         return int(mode)
 
-    def _write_heating_circuit(
+    async def _write_heating_circuit(
         self, target_supply_temperature: float, cooling: int, operating_mode: int
     ) -> None:
         """Write the registers section 6.2 requires to be written together.
 
         Writing only some of them can leave the controller in an undefined state.
+        They go out under one hold of the transport lock now, in the order this
+        entity has always written them, so no poll of the coordinator lands
+        between two of them. It used to be four separate blocking writes, each
+        followed by re-reading the whole component.
+
         Register 32608 does not exist below api version 22.090; a circuit that old
         cannot cool anyway, so heating and off are written without it.
         """
-        self._set_native_value("target_supply_temperature", target_supply_temperature)
-        self._set_native_value("cooling", cooling)
-        self._set_native_value("mode", operating_mode)
+        component = cast(HeatingCircuit, self.component)
 
-        if self.cooling_supported:
-            self._set_native_value("heating_mode", HEATING_MODE_HEATING_AND_COOLING)
+        await component.set_operating_state(
+            target_supply_temperature=target_supply_temperature,
+            cooling=HeatingCircuitCooling(cooling),
+            mode=HeatingCircuitMode(operating_mode),
+            heating_mode=(
+                HeatingCircuitHeatingMode(HEATING_MODE_HEATING_AND_COOLING)
+                if self.cooling_supported
+                else None
+            ),
+        )
+
+        self.async_write_ha_state()
 
     def _log_dew_point_warning(self) -> None:
         """Warn that the controller stops watching the dew point, once."""
@@ -400,7 +423,15 @@ class SolarfocusClimateEntity(SolarfocusEntity, RestoreEntity, ClimateEntity):
         """Set new target preset mode."""
         mode = PRESET_TO_SOLARFOCUS_MODE.get(preset_mode)
         _LOGGER.info("Set Preset Mode: %s (mapped mode: %s)", preset_mode, mode)
-        self._set_native_value("mode", mode)
+
+        if mode is None:
+            # Home Assistant only offers the presets this entity declares, so
+            # this is a service call naming one that does not exist. It used to
+            # write the `None` to the register.
+            _LOGGER.warning("Unknown preset mode %s, nothing written", preset_mode)
+            return
+
+        await self._async_set_native_value("mode", HeatingCircuitMode(mode))
 
     @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
@@ -420,7 +451,7 @@ class SolarfocusClimateEntity(SolarfocusEntity, RestoreEntity, ClimateEntity):
 
         self._active_mode = hvac_mode
         self._target_temperatures[hvac_mode] = float(temperature)
-        self._set_native_value("target_supply_temperature", temperature)
+        await self._async_set_native_value("target_supply_temperature", temperature)
 
     @override
     async def async_turn_on(self) -> None:

--- a/custom_components/solarfocus/config_flow.py
+++ b/custom_components/solarfocus/config_flow.py
@@ -5,7 +5,13 @@ from collections.abc import Mapping
 import logging
 from typing import Any, override
 
-from pysolarfocus import ApiVersions, SolarfocusAPI, Systems
+from aiosolarfocus import (
+    ApiVersion,
+    SolarfocusClient,
+    SolarfocusConfig,
+    SolarfocusConnectionError,
+    Systems,
+)
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -67,8 +73,13 @@ SOLARFOCUS_SYSTEMS = [
 # is too low, which silently drops the registers added since. Newest first,
 # which is the declaration order of the enum reversed.
 SOLARFOCUS_API_VERSIONS = [
-    selector.SelectOptionDict(value=api_version.value, label=f"v{api_version.value}")
-    for api_version in reversed(ApiVersions)
+    selector.SelectOptionDict(
+        value=api_version.label, label=f"v{api_version.label}"
+    )
+    # `label`, not `value`: an `ApiVersion` is ordered by construction, so its
+    # value is the printed version with the dot taken out - 25030, not the
+    # "25.030" an entry has always stored and a controller shows on its screen.
+    for api_version in reversed(ApiVersion)
 ]
 
 _COMPONENT_COUNT_ZERO_EIGHT_SELECTOR = vol.All(
@@ -218,32 +229,30 @@ STEP_COMP_THERMINATOR_SELECTION_SCHEMA = vol.Schema(
 )
 
 
-class Solarfocus:
-    """Solarfocus Configflow."""
-
-    def __init__(self, hass: HomeAssistant, data: dict[str, Any]) -> None:
-        """Initialize."""
-        self.host = data[CONF_HOST]
-        self.port = data[CONF_PORT]
-        self.hass = hass
-
-        self.api = SolarfocusAPI(
-            ip=data[CONF_HOST],
-            port=data[CONF_PORT],
-            system=Systems(data[CONF_SOLARFOCUS_SYSTEM]),
-            api_version=ApiVersions(data[CONF_API_VERSION]),
-        )
-
-
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect.
 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
-    """
-    client = Solarfocus(hass, data=data)
 
-    if not await hass.async_add_executor_job(client.api.connect):
-        raise CannotConnect
+    Only the connection is checked here, so the component counts are left at
+    whatever the configuration defaults to - what this asks is whether there is
+    an eco manager-touch at that address, and the component step comes later.
+
+    The client is closed on the way out whatever happens: this used to build one
+    and drop it on the floor with its socket still open.
+    """
+    config = SolarfocusConfig(
+        host=data[CONF_HOST],
+        port=data[CONF_PORT],
+        system=Systems(data[CONF_SOLARFOCUS_SYSTEM]),
+        api_version=ApiVersion.parse(data[CONF_API_VERSION]),
+    )
+
+    try:
+        async with SolarfocusClient(config):
+            pass
+    except SolarfocusConnectionError as error:
+        raise CannotConnect from error
 
     if data[CONF_SCAN_INTERVAL] < MINIMUM_SCAN_INTERVAL:
         raise InvalidScanInterval

--- a/custom_components/solarfocus/const.py
+++ b/custom_components/solarfocus/const.py
@@ -44,11 +44,11 @@ BUFFER_COMPONENT = "buffers"
 BUFFER_COMPONENT_PREFIX = "bu"
 
 HEAT_PUMP_PREFIX = "Heat pump"
-HEAT_PUMP_COMPONENT = "heatpump"
+HEAT_PUMP_COMPONENT = "heat_pump"
 HEAT_PUMP_COMPONENT_PREFIX = "hp"
 
 BIOMASS_BOILER_PREFIX = "Biomass boiler"
-BIOMASS_BOILER_COMPONENT = "biomassboiler"
+BIOMASS_BOILER_COMPONENT = "biomass_boiler"
 BIOMASS_BOILER_COMPONENT_PREFIX = "bb"
 
 PHOTOVOLTAIC_PREFIX = "Photovoltaic"
@@ -143,7 +143,39 @@ COMPONENT_PREFIXES: dict[str, str] = {
 # identifier carries no index where every other component's does.
 SINGLE_COMPONENTS = frozenset({CONF_HEATPUMP, CONF_PHOTOVOLTAIC, CONF_BIOMASS_BOILER})
 
-"""Version from which several solar circuits exist"""
+# How many of each component an entry can ever have been configured with, which
+# is what the options form offers. It is not what this entry has: a repair issue
+# has to be answered for every instance a *previous* configuration could have
+# raised one for, or lowering a count would leave the issue of the instance that
+# is gone standing forever with nothing left to clear it.
+COMPONENT_MAX_COUNT: dict[str, int] = {
+    CONF_HEATING_CIRCUIT: 8,
+    CONF_BUFFER: 4,
+    CONF_BOILER: 4,
+    CONF_FRESH_WATER_MODULE: 4,
+    CONF_CIRCULATION: 4,
+    CONF_DIFFERENTIAL_MODULE: 4,
+    CONF_SOLAR: 4,
+    CONF_HEATPUMP: 1,
+    CONF_PHOTOVOLTAIC: 1,
+    CONF_BIOMASS_BOILER: 1,
+}
+
+
+def component_instances(option: str) -> list[tuple[str, str]]:
+    """Return every instance of one component an entry could have configured.
+
+    The pair an entity carries and a failed read is reported as: the option and
+    the index as a string, blank for the components that exist once.
+    """
+    if option in SINGLE_COMPONENTS:
+        return [(option, "")]
+
+    return [
+        (option, str(index + 1)) for index in range(COMPONENT_MAX_COUNT[option])
+    ]
+
+# Version from which several solar circuits exist.
 MULTI_SOLAR_MIN_VERSION = "25.030"
 
 
@@ -151,7 +183,7 @@ def solar_count(entry: ConfigEntry) -> int:
     """Return how many solar circuits to build for this entry.
 
     Solar was a boolean before it became a count, and several circuits only
-    exist from api version 25.030 on - pysolarfocus rejects a higher count
+    exist from api version 25.030 on - the library rejects a higher count
     below that and the whole entry fails to load. The options let the count be
     raised regardless of the selected version, so it is capped here.
 
@@ -170,7 +202,7 @@ def solar_count(entry: ConfigEntry) -> int:
 
 
 # The api version a component's registers arrived in, for those that are not in
-# every version the integration offers. Below it pysolarfocus builds no such
+# every version the integration offers. Below it the library builds no such
 # component at all - the attribute the entities would read is not there - and
 # its update call returns success without asking the controller anything.
 COMPONENT_MIN_VERSION: dict[str, str] = {

--- a/custom_components/solarfocus/coordinator.py
+++ b/custom_components/solarfocus/coordinator.py
@@ -1,10 +1,16 @@
 """Coordinator for Solarfocus integration."""
 
+from collections.abc import Iterable, Mapping
 from datetime import timedelta
 import logging
 from typing import override
 
-from pysolarfocus import SolarfocusAPI
+from aiosolarfocus import (
+    ComponentId,
+    ComponentKey,
+    SolarfocusClient,
+    SolarfocusConnectionError,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL
@@ -26,26 +32,45 @@ from .const import (
     CONF_PHOTOVOLTAIC,
     CONF_SOLAR,
     DOMAIN,
-    component_count,
-    component_device_identifiers,
+    SINGLE_COMPONENTS,
+    component_instances,
 )
 from .service_menu import DisplayedNumber
 
 _LOGGER = logging.getLogger(__name__)
 
-# Config option -> the library call that reads the registers of that component.
-COMPONENT_UPDATES: tuple[tuple[str, str], ...] = (
-    (CONF_HEATING_CIRCUIT, "update_heating"),
-    (CONF_BUFFER, "update_buffer"),
-    (CONF_BOILER, "update_boiler"),
-    (CONF_HEATPUMP, "update_heatpump"),
-    (CONF_PHOTOVOLTAIC, "update_photovoltaic"),
-    (CONF_BIOMASS_BOILER, "update_biomassboiler"),
-    (CONF_SOLAR, "update_solar"),
-    (CONF_FRESH_WATER_MODULE, "update_fresh_water_modules"),
-    (CONF_CIRCULATION, "update_circulation"),
-    (CONF_DIFFERENTIAL_MODULE, "update_differential_modules"),
-)
+# The entry option a component is configured under -> what the library calls
+# that component. The option keys are what an entry has stored since long
+# before this library, so they stay as they are and are translated here.
+COMPONENT_IDS: Mapping[str, ComponentId] = {
+    CONF_HEATING_CIRCUIT: ComponentId.HEATING_CIRCUITS,
+    CONF_BUFFER: ComponentId.BUFFERS,
+    CONF_BOILER: ComponentId.BOILERS,
+    CONF_HEATPUMP: ComponentId.HEAT_PUMP,
+    CONF_PHOTOVOLTAIC: ComponentId.PHOTOVOLTAIC,
+    CONF_BIOMASS_BOILER: ComponentId.BIOMASS_BOILER,
+    CONF_SOLAR: ComponentId.SOLAR,
+    CONF_FRESH_WATER_MODULE: ComponentId.FRESH_WATER_MODULES,
+    CONF_CIRCULATION: ComponentId.CIRCULATIONS,
+    CONF_DIFFERENTIAL_MODULE: ComponentId.DIFFERENTIAL_MODULES,
+}
+
+# The other way round, for reading a failure back off an `UpdateResult`.
+COMPONENT_OPTIONS: Mapping[ComponentId, str] = {
+    component_id: option for option, component_id in COMPONENT_IDS.items()
+}
+
+
+def failed_instance(key: ComponentKey) -> tuple[str, str]:
+    """Return the option and index an entity of this component instance carries.
+
+    The library names a component instance by its id and a 1-based number; an
+    entity description carries the entry option and `component_idx`, which is
+    blank for the components a controller only has one of. Availability is
+    matched on the pair, so this is where the two namings meet.
+    """
+    option = COMPONENT_OPTIONS[key.id]
+    return (option, "" if option in SINGLE_COMPONENTS else str(key.number))
 
 
 # Nothing is handed to the entities through the coordinator: an entity reads
@@ -58,14 +83,14 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
         self,
         hass: HomeAssistant,
         entry: "SolarfocusConfigEntry",
-        api: SolarfocusAPI,
+        client: SolarfocusClient,
     ) -> None:
         """Init the Solarfocus data object."""
 
-        self.api = api
+        self.client = client
         self._entry = entry
         self.hass = hass
-        self._failed_components: frozenset[str] = frozenset()
+        self._failed_components: frozenset[tuple[str, str]] = frozenset()
         # The controller every component device of this entry hangs off, set by
         # `async_setup_entry` once the device is registered. A component device
         # points at it by id rather than by identifier, which Home Assistant
@@ -84,8 +109,12 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
         )
 
     @property
-    def failed_components(self) -> frozenset[str]:
-        """Return the components that could not be read on the last refresh.
+    def failed_components(self) -> frozenset[tuple[str, str]]:
+        """Return the component instances that could not be read last refresh.
+
+        A pair of the entry option and the index, because the library reports a
+        failure per instance: one buffer that answers nothing is one buffer, and
+        the other three carry on. See `failed_instance`.
 
         Every entity of the entry reads this on every state write, so it is
         handed out as it is rather than copied: a frozenset cannot be added to
@@ -102,71 +131,46 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
     async def _async_update_data(self) -> None:
         """Update data via library."""
 
-        if not self.api.is_connected and not await self.hass.async_add_executor_job(
-            self.api.connect
-        ):
+        try:
+            result = await self.client.update()
+        except SolarfocusConnectionError as error:
+            # The one failure that says nothing about any component: there is
+            # no socket, so no component was asked anything. Whatever was
+            # failing on its own before is forgotten rather than left behind to
+            # be reported as still true - named in the diagnostics download, and
+            # raised as an issue saying that every other component reads fine.
+            # The outage itself is what the failed refresh says, and the issue
+            # comes back on the first refresh that reads anything at all.
+            self._failed_components = frozenset()
+            self._report_failed_components([])
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="cannot_connect",
                 translation_placeholders={"address": self._address},
-            )
+            ) from error
 
-        configured = 0
-        failed = []
-        for option, update in COMPONENT_UPDATES:
-            # What the entry reads, not what the options ask for: a component
-            # the selected api version does not have is read by a library call
-            # that returns success without asking the controller anything, so
-            # counting it as configured would mean a system that answers
-            # nothing at all no longer has every component fail.
-            if not component_count(self._entry, option):
-                continue
-            configured += 1
-            if not await self.hass.async_add_executor_job(getattr(self.api, update)):
-                failed.append(option)
+        failed = sorted(failed_instance(key) for key in result.failed)
 
-        # A connection that drops part way through the poll fails every
-        # component read after it, whatever those components would have
-        # answered - the library returns False without asking the socket
-        # anything. Calling that a component that does not answer would grey
-        # out an arbitrary tail of the system and raise an issue per component
-        # telling the user to switch it off, for what is one dropped
-        # connection, re-established on the next refresh.
-        connection_lost = bool(failed) and not self.api.is_connected
-
-        if connection_lost or (failed and len(failed) == configured):
+        if failed and len(failed) == len(self.client.components):
             # Nothing could be read: the system is gone rather than one of its
             # components being unhappy. Reporting that as a success would leave
             # every entity available and showing its last value.
-            #
-            # No component is failing on its own any more, so whatever was doing
-            # that is forgotten here rather than left behind to be reported as
-            # still true: named in the diagnostics download, and raised as an
-            # issue saying that every other component reads fine. The outage
-            # itself is what the failed refresh says, and the issue comes back
-            # on the first refresh that reads anything at all.
             self._failed_components = frozenset()
             self._report_failed_components([])
-            if connection_lost:
-                raise UpdateFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="cannot_connect",
-                    translation_placeholders={"address": self._address},
-                )
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="cannot_read",
                 translation_placeholders={
                     "address": self._address,
-                    "components": ", ".join(failed),
+                    "components": ", ".join(_names(failed)),
                 },
             )
 
         self._report_partial_failure(failed)
 
-        _LOGGER.debug("Data updated successfully")
+        _LOGGER.debug("Data updated successfully: %s", result)
 
-    def _report_partial_failure(self, failed: list[str]) -> None:
+    def _report_partial_failure(self, failed: list[tuple[str, str]]) -> None:
         """Log components that could not be read while others could.
 
         Taking the whole entry down for this would be worse than it sounds: a
@@ -190,14 +194,14 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
             _LOGGER.warning(
                 "Could not read %s from %s, its entities are unavailable."
                 " The other components were read successfully",
-                ", ".join(failed),
+                ", ".join(_names(failed)),
                 self._address,
             )
         else:
             _LOGGER.info("Reading all components of %s works again", self._address)
 
-    def _report_failed_components(self, failed: list[str]) -> None:
-        """Raise a repair issue per component that cannot be read, one per entry.
+    def _report_failed_components(self, failed: list[tuple[str, str]]) -> None:
+        """Raise a repair issue per component instance that cannot be read.
 
         A register range a particular firmware does not answer fails on every
         poll and never recovers on its own. The entities of that component are
@@ -209,70 +213,71 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
         user should switch it off in the options, or the api version is set
         higher than the controller runs.
 
-        Every component is answered for, not only the ones that changed or are
+        One issue per *instance* rather than per component: the library plans
+        its reads across the whole system and attributes a refused range to the
+        components whose registers were in it, so one buffer that answers
+        nothing is one buffer, and the other three carry on with their entities
+        available and their pages alive.
+
+        Every instance is answered for, not only the ones that changed or are
         configured: switching a component off is what the issue asks the user to
         do, and that reloads the entry into a coordinator that knows nothing
         about the issues the one before it raised.
         """
-        for option, _ in COMPONENT_UPDATES:
-            issue_id = component_issue_id(self._entry.entry_id, option)
-            if option not in failed:
-                ir.async_delete_issue(self.hass, DOMAIN, issue_id)
-                continue
+        for option in COMPONENT_IDS:
+            for instance in component_instances(option):
+                issue_id = component_issue_id(self._entry.entry_id, *instance)
+                if instance not in failed:
+                    ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+                    continue
 
-            devices = self._component_devices(option)
-            # What the device page calls this component's model, for when
-            # there is no device yet to ask - either it is not registered yet,
-            # which is what the report at the end of `async_setup_entry`
-            # catches up with, or the configured api version does not have it
-            # at all. Either way this is never the bare option: that is a
-            # config key, not a word, and leaks into every language's text.
-            fallback = COMPONENT_DEVICES[COMPONENT_PREFIXES[option]].model
-            # What the device page calls this component, which is translated
-            # and is whatever the user renamed it to, and the same names as
-            # links to those pages.
-            names = [
-                device.name_by_user or device.name or fallback for device in devices
-            ]
-            links = [
-                f"[{_escape_markdown_link_text(name)}](/config/devices/device/{device.id})"
-                for name, device in zip(names, devices, strict=True)
-            ]
+                device = self._component_device(*instance)
+                # What the device page calls this component's model, for when
+                # there is no device yet to ask - either it is not registered
+                # yet, which is what the report at the end of
+                # `async_setup_entry` catches up with, or the configured api
+                # version does not have it at all. Either way this is never the
+                # bare option: that is a config key, not a word, and leaks into
+                # every language's text.
+                fallback = _fallback_name(*instance)
+                # What the device page calls this component, which is translated
+                # and is whatever the user renamed it to, and the same name as a
+                # link to that page.
+                if device is None:
+                    name, link = fallback, fallback
+                else:
+                    name = device.name_by_user or device.name or fallback
+                    link = (
+                        f"[{_escape_markdown_link_text(name)}]"
+                        f"(/config/devices/device/{device.id})"
+                    )
 
-            ir.async_create_issue(
-                self.hass,
-                DOMAIN,
-                issue_id,
-                is_fixable=False,
-                severity=ir.IssueSeverity.WARNING,
-                translation_key="component_unavailable",
-                translation_placeholders={
-                    "component": ", ".join(names) or fallback,
-                    "devices": ", ".join(links) or fallback,
-                    "address": self._address,
-                    "title": self._entry.title,
-                },
-            )
+                ir.async_create_issue(
+                    self.hass,
+                    DOMAIN,
+                    issue_id,
+                    is_fixable=False,
+                    severity=ir.IssueSeverity.WARNING,
+                    translation_key="component_unavailable",
+                    translation_placeholders={
+                        "component": name,
+                        "devices": link,
+                        "address": self._address,
+                        "title": self._entry.title,
+                    },
+                )
 
-    def _component_devices(self, option: str) -> list[dr.DeviceEntry]:
-        """Return the registered devices of one component, in order.
-
-        One device per instance of the component, and every one of them is
-        behind the single issue the component raises: the library reads all
-        four buffers in one call, so a buffer that answers nothing is every
-        buffer as far as anything here can tell.
+    def _component_device(self, option: str, idx: str) -> dr.DeviceEntry | None:
+        """Return the registered device of one component instance.
 
         A device is registered by the entities on it, which are built after the
         refresh `async_setup_entry` awaits - so on the first refresh of a new
-        entry there are none yet, and the issue names what it can.
+        entry there is none yet, and the issue names what it can.
         """
-        registry = dr.async_get(self.hass)
-        devices = (
-            registry.async_get_device({identifier})
-            for identifier in component_device_identifiers(self._entry, option)
-        )
+        prefix = COMPONENT_PREFIXES[option]
+        identifier = (DOMAIN, f"{self._entry.entry_id}_{prefix}{idx}")
 
-        return [device for device in devices if device is not None]
+        return dr.async_get(self.hass).async_get_device({identifier})
 
     @callback
     def async_report_failed_components(self) -> None:
@@ -286,6 +291,22 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
         self._report_failed_components(sorted(self._failed_components))
 
 
+def _fallback_name(option: str, idx: str) -> str:
+    """Return what to call a component instance with no device to ask.
+
+    The model the device page shows, with the index the device name would carry
+    - `Buffer 2` rather than the bare `buffer`, which is a config key rather
+    than a word and would leak English into every language's text.
+    """
+    model = COMPONENT_DEVICES[COMPONENT_PREFIXES[option]].model
+    return f"{model} {idx}" if idx else model
+
+
+def _names(failed: Iterable[tuple[str, str]]) -> list[str]:
+    """Return what to call each failing instance in a log line or a message."""
+    return [_fallback_name(*instance) for instance in failed]
+
+
 def _escape_markdown_link_text(text: str) -> str:
     """Escape a device name for use as the text span of a markdown link.
 
@@ -296,13 +317,13 @@ def _escape_markdown_link_text(text: str) -> str:
     return text.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
 
 
-def component_issue_id(entry_id: str, option: str) -> str:
-    """Return the issue id of one component of one entry.
+def component_issue_id(entry_id: str, option: str, idx: str) -> str:
+    """Return the issue id of one component instance of one entry.
 
-    Per component rather than one for all of them, so that a component coming
-    back clears its own issue and leaves the others standing.
+    Per instance rather than one for all of them, so that a buffer coming back
+    clears its own issue and leaves the others standing.
     """
-    return f"component_unavailable_{entry_id}_{option}"
+    return f"component_unavailable_{entry_id}_{option}{idx}"
 
 
 @callback
@@ -315,8 +336,11 @@ def async_delete_component_issues(
     is not there to be configured, so an issue naming it has nothing left to
     say. Neither is noticed by the issue registry on its own.
     """
-    for option, _ in COMPONENT_UPDATES:
-        ir.async_delete_issue(hass, DOMAIN, component_issue_id(entry.entry_id, option))
+    for option in COMPONENT_IDS:
+        for instance in component_instances(option):
+            ir.async_delete_issue(
+                hass, DOMAIN, component_issue_id(entry.entry_id, *instance)
+            )
 
 
 # The coordinator of an entry lives on the entry itself, this spells that out

--- a/custom_components/solarfocus/diagnostics.py
+++ b/custom_components/solarfocus/diagnostics.py
@@ -11,71 +11,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from pysolarfocus.components.base.part import Part
-
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
-from .const import (
-    BIOMASS_BOILER_COMPONENT,
-    BOILER_COMPONENT,
-    BUFFER_COMPONENT,
-    CIRCULATION_COMPONENT,
-    DIFFERENTIAL_MODULE_COMPONENT,
-    FRESH_WATER_MODULE_COMPONENT,
-    HEAT_PUMP_COMPONENT,
-    HEATING_CIRCUIT_COMPONENT,
-    PHOTOVOLTAIC_COMPONENT,
-    SOLAR_COMPONENT,
-)
 from .coordinator import SolarfocusConfigEntry
-
-# The components pysolarfocus builds, in the order the coordinator reads them.
-COMPONENTS: tuple[str, ...] = (
-    HEATING_CIRCUIT_COMPONENT,
-    BUFFER_COMPONENT,
-    BOILER_COMPONENT,
-    HEAT_PUMP_COMPONENT,
-    PHOTOVOLTAIC_COMPONENT,
-    BIOMASS_BOILER_COMPONENT,
-    SOLAR_COMPONENT,
-    FRESH_WATER_MODULE_COMPONENT,
-    CIRCULATION_COMPONENT,
-    DIFFERENTIAL_MODULE_COMPONENT,
-)
 
 # The address of the controller is on the user's own network and says little on
 # its own, but a diagnostics download is something people paste into an issue.
 TO_REDACT = {CONF_HOST}
-
-
-def _registers(component: Any) -> dict[str, Any]:
-    """Return every register of one component, the way the entities read it.
-
-    `Part` is what pysolarfocus gives a component for each of its registers, and
-    for the two values it calculates rather than reads, so this is exactly the
-    set of values an entity of that component can show.
-    """
-    return {
-        name: part.scaled_value
-        for name, part in vars(component).items()
-        if isinstance(part, Part)
-    }
-
-
-def _component_registers(component: Any) -> Any:
-    """Return the registers of a component, or of each of them if it is a list.
-
-    A heating circuit, buffer, boiler, solar circuit, fresh water module,
-    circulation group and differential module can exist several times over; the
-    heat pump, photovoltaic and biomass boiler are either there once or not at
-    all.
-    """
-    if isinstance(component, list):
-        return [_registers(one) for one in component]
-
-    return None if component is None else _registers(component)
 
 
 async def async_get_config_entry_diagnostics(
@@ -92,12 +36,19 @@ async def async_get_config_entry_diagnostics(
         },
         "coordinator": {
             "last_update_success": coordinator.last_update_success,
-            # Empty unless a component fails on its own while the others read
-            # fine, which is what an unsupported register range looks like.
-            "failed_components": sorted(coordinator.failed_components),
+            # Empty unless a component instance fails on its own while the
+            # others read fine, which is what an unsupported register range
+            # looks like. Rendered as the library names the instance, so a
+            # report here and a `python -m aiosolarfocus dump` line up.
+            "failed_components": [
+                f"{option}.{idx}" if idx else option
+                for option, idx in sorted(coordinator.failed_components)
+            ],
         },
-        "components": {
-            name: _component_registers(getattr(coordinator.api, name, None))
-            for name in COMPONENTS
-        },
+        # Keyed "heating_circuits.1", and richer than what this used to reach
+        # into the library for: the address each value came from, the raw words
+        # before scaling, and the unit. A sentinel reading has a raw value and
+        # no decoded one, which is how a reader tells "no sensor fitted" from
+        # "never read".
+        "components": coordinator.client.snapshot(),
     }

--- a/custom_components/solarfocus/entity.py
+++ b/custom_components/solarfocus/entity.py
@@ -6,10 +6,9 @@ from dataclasses import dataclass, replace
 import logging
 from typing import Any, override
 
-from packaging import version
-from pysolarfocus import Systems
+from aiosolarfocus import ComponentId, Systems
+from aiosolarfocus.components.base import Component
 
-from homeassistant.const import CONF_API_VERSION
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
@@ -40,8 +39,13 @@ class SolarfocusEntityDescription(EntityDescription):
     object_id_name: str = ""
     # The index as a device name shows it, " 1" or blank - see `create_description`
     device_idx: str = ""
-    min_required_version: str = "21.140"
-    unsupported_systems: list[Systems] | None = None
+    # The systems whose reading of this register nobody has checked. Not a
+    # claim about the register map - the library owns that, and knows exactly
+    # what a firmware and a system have. This is the narrower thing it cannot
+    # know: that the register is there and answers, and that what it means on
+    # that system has never been measured. See the biomass boiler's door
+    # contact, the only one.
+    unverified_systems: list[Systems] | None = None
 
 
 def create_description[_DescriptionT: SolarfocusEntityDescription](
@@ -76,7 +80,11 @@ def create_description[_DescriptionT: SolarfocusEntityDescription](
     # in every language.
     return replace(
         description,
-        item=description.key,
+        # The key with no override, which is all but three of them. An entity
+        # whose register the library renamed keeps the key its entity id, its
+        # history and its translation are built from, and names the register
+        # separately - see the heat pump's seasonal performance figures.
+        item=description.item or description.key,
         component=component,
         component_prefix=prefix,
         component_idx=idx,
@@ -90,34 +98,46 @@ def create_description[_DescriptionT: SolarfocusEntityDescription](
 def every_system_but(*supported: Systems) -> list[Systems]:
     """Return every system except the ones given.
 
-    Some registers are documented for a single system - the register document
-    writes them "Kesselbetriebsart therminator" or "Speichertemperatur Oben
-    octoplus". Naming the system that has the register says that far more
-    plainly than listing the four that do not, and it keeps a system added to
-    the enum later out of a register the document never granted it.
+    Naming the systems a reading has been checked on says far more plainly than
+    listing the ones it has not, and it keeps a system added to the enum later
+    out of a reading nobody has measured on it.
     """
     return [system for system in Systems if system not in supported]
 
 
-def filterVersionAndSystem[_EntityT: SolarfocusEntity](
+def supported_entities[_EntityT: SolarfocusEntity](
     config_entry: SolarfocusConfigEntry, entities: list[_EntityT]
 ) -> Generator[_EntityT]:
-    """Filter entities not compatible to version or system."""
-    api_version = version.parse(config_entry.data[CONF_API_VERSION])
+    """Drop the entities this controller has nothing behind.
 
-    filtered_entities = filter(
-        lambda entity: version.parse(entity.entity_description.min_required_version)
-        <= api_version,
-        entities,
-    )
+    The library resolves the register map against the firmware and the system,
+    so `supports` is the whole answer to what this controller has: it replaces a
+    `min_required_version` and an `unsupported_systems` list carried on every
+    description, which were a second copy of the register document and drifted
+    from it - a Therminator on 21.140 was offered a `log_wood` sensor for a
+    register that firmware does not map, and an Ecotop a buffer `x35_temperature`
+    the document gives to the Therminator alone.
 
-    current_system = config_entry.data[CONF_SOLARFOCUS_SYSTEM]
+    A derived value counts as supported when the registers it is worked out from
+    are, which is why this asks the component rather than the register map.
 
-    for entity in filtered_entities:
-        unsupported_systems = entity.entity_description.unsupported_systems
-        if unsupported_systems is None:
+    Two kinds of entity are passed through rather than asked about: the ones
+    that read no single register - the climate entity, the water heater - and
+    the ones that read no register at all, on the controller rather than on a
+    component. `component` is blank on the latter, and there is nothing to ask.
+    """
+    system = config_entry.data[CONF_SOLARFOCUS_SYSTEM]
+
+    for entity in entities:
+        description = entity.entity_description
+
+        unverified = description.unverified_systems
+        if unverified is not None and system in unverified:
+            continue
+
+        if not description.component or entity.reads_no_single_register:
             yield entity
-        elif current_system not in unsupported_systems:
+        elif entity.component.supports(description.item):
             yield entity
 
 
@@ -126,6 +146,13 @@ class SolarfocusEntity(Entity):
 
     _attr_should_poll = True
     has_entity_name = True
+
+    #: Whether this entity's `item` names one register of its component. The
+    #: climate entity and the water heater read and write several under a key
+    #: that is a label rather than a register name, so what they need is the
+    #: component, not a register on it - and there is nothing for
+    #: `supported_entities` to ask about.
+    reads_no_single_register = False
 
     entity_description: SolarfocusEntityDescription
 
@@ -207,9 +234,15 @@ class SolarfocusEntity(Entity):
         `select` on it stops accepting writes - the entities of every component
         that does answer keep taking them.
         """
-        return self.coordinator.last_update_success and (
-            COMPONENT_DEVICES[self.entity_description.component_prefix].option
-            not in self.coordinator.failed_components
+        description = self.entity_description
+        instance = (
+            COMPONENT_DEVICES[description.component_prefix].option,
+            description.component_idx,
+        )
+
+        return (
+            self.coordinator.last_update_success
+            and instance not in self.coordinator.failed_components
         )
 
     @property
@@ -274,63 +307,59 @@ class SolarfocusEntity(Entity):
         """Update entity."""
         await self.coordinator.async_request_refresh()
 
-    def _set_native_value(self, item: str, value: Any) -> None:
-        """Write a value to one register of the component this entity is on."""
-        # The library builds its components at runtime, so what a component and
-        # its registers are is only known to it - `Any` is the honest type here.
-        component: Any
-        idx = -1
+    @property
+    def component(self) -> Component:
+        """Return the component instance this entity reads and writes.
 
-        if self.entity_description.component_idx:
-            idx = int(self.entity_description.component_idx) - 1
-            component = getattr(
-                self.coordinator.api, self.entity_description.component
-            )[idx]
-        else:
-            component = getattr(self.coordinator.api, self.entity_description.component)
+        `of` answers with a list whatever the component is, including the ones
+        a controller only has one of, so which of the two an entity is on stops
+        being something this has to know: an index the description does not
+        carry is the first and only one.
+        """
+        description = self.entity_description
+        index = int(description.component_idx or 1) - 1
+
+        return self.coordinator.client.of(ComponentId(description.component))[index]
+
+    async def _async_set_native_value(self, item: str, value: Any) -> None:
+        """Write a value to one register of the component this entity is on.
+
+        Class access on a register gives its specification, instance access
+        gives the reading - so this is the register named by the description,
+        handed back to the component it was declared on.
+
+        Everything that used to be here has moved into the library: the two's
+        complement of a negative value, and the re-read of the whole component
+        afterwards. A write that the controller took updates the component's
+        own cache, so the new value is readable straight away.
+        """
+        component = self.component
         _LOGGER.debug(
-            "_set_native_value - idx: %s, component: %s, entity: %s",
-            idx,
+            "_async_set_native_value - component: %s, entity: %s, value: %s",
             self.entity_description.component,
             item,
+            value,
         )
-        entity = getattr(component, item)
-        entity.set_unscaled_value(value)
 
-        raw_value = entity.value
-        if isinstance(raw_value, (int, float)) and raw_value < 0:
-            # Modbus transmits registers as unsigned words, negative values have
-            # to be written as two's complement (16 bit per register). The signed
-            # value is restored afterwards, reading the register turns it back
-            # into a signed one.
-            entity.value = raw_value + (1 << (16 * entity.count))
-            entity.commit()
-            entity.value = raw_value
-        else:
-            entity.commit()
-
-        component.update()
+        await component.write(getattr(type(component), item), value)
 
         self.async_write_ha_state()
 
     def _get_native_value(self, item: str) -> Any:
-        """Read the value of one register of the component this entity is on."""
-        component: Any
-        idx = -1
+        """Read the value of one register of the component this entity is on.
 
-        if self.entity_description.component_idx:
-            idx = int(self.entity_description.component_idx) - 1
-            component = getattr(
-                self.coordinator.api, self.entity_description.component
-            )[idx]
-        else:
-            component = getattr(self.coordinator.api, self.entity_description.component)
+        Not a coroutine: the reading is already decoded and in hand, and only
+        the calls that talk to the controller are awaited.
 
-        native_value = getattr(component, item).scaled_value
+        `None` is a real answer - the register is not on this firmware or
+        system, it has not been read yet or its last read failed, or the channel
+        is reporting an open sensor rather than a measurement. Every caller here
+        wants the same thing for all three.
+        """
+        native_value = getattr(self.component, item)
 
         _LOGGER.debug(
-            "_get_native_value - idx: %s, component: %s, entity: %s, value: %s",
-            idx,
+            "_get_native_value - component: %s, entity: %s, value: %s",
             self.entity_description.component,
             item,
             native_value,

--- a/custom_components/solarfocus/manifest.json
+++ b/custom_components/solarfocus/manifest.json
@@ -9,7 +9,7 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/lavermanjj/home-assistant-solarfocus/issues",
-  "requirements": ["aiosolarfocus==0.2.0"],
+  "requirements": ["aiosolarfocus==0.2.1"],
   "ssdp": [],
   "version": "7.0.0-rc1",
   "zeroconf": []

--- a/custom_components/solarfocus/manifest.json
+++ b/custom_components/solarfocus/manifest.json
@@ -9,8 +9,8 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/lavermanjj/home-assistant-solarfocus/issues",
-  "requirements": ["pysolarfocus==5.3.0"],
+  "requirements": ["aiosolarfocus==0.2.0"],
   "ssdp": [],
-  "version": "6.0.0",
+  "version": "7.0.0-rc1",
   "zeroconf": []
 }

--- a/custom_components/solarfocus/number.py
+++ b/custom_components/solarfocus/number.py
@@ -33,7 +33,7 @@ from .entity import (
     SolarfocusEntity,
     SolarfocusEntityDescription,
     create_description,
-    filterVersionAndSystem,
+    supported_entities,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -99,7 +99,7 @@ async def async_setup_entry(
         SolarfocusDisplayedNumberEntity(coordinator, DISPLAYED_NUMBER_TYPE)
     )
 
-    async_add_entities(filterVersionAndSystem(config_entry, entities))
+    async_add_entities(supported_entities(config_entry, entities))
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -128,7 +128,7 @@ class SolarfocusNumberEntity(SolarfocusEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         number = self.entity_description.item
-        return self._set_native_value(number, value)
+        await self._async_set_native_value(number, value)
 
     @property
     @override
@@ -291,6 +291,5 @@ PHOTOVOLTAIC_NUMBER_TYPES = [
         native_max_value=32767,
         native_step=1,
         mode=NumberMode.BOX,
-        min_required_version="26.020",
     ),
 ]

--- a/custom_components/solarfocus/quality_scale.yaml
+++ b/custom_components/solarfocus/quality_scale.yaml
@@ -89,24 +89,9 @@ rules:
   stale-devices: done
 
   # Platinum
-  async-dependency:
-    status: todo
-    comment: |
-      pysolarfocus is synchronous, so every read and write goes through
-      `async_add_executor_job`. This is a change in the library rather than
-      here.
+  async-dependency: done
   inject-websession:
     status: exempt
     comment: |
       Modbus TCP, there is no HTTP session to inject.
-  strict-typing:
-    status: todo
-    comment: |
-      Half done. The integration itself passes the strict mypy configuration
-      core applies to an integration in its `.strict-typing`, kept in `mypy.ini`
-      here and run by `make check-mypy` in CI, with no per-module exceptions.
-
-      What is left is pysolarfocus: the rule wants the dependency to be PEP 561
-      compliant, and it ships no `py.typed`. Nearly all of it is annotated
-      already, so this is a marker file and a release rather than a rewrite -
-      and a change in that library rather than here.
+  strict-typing: done

--- a/custom_components/solarfocus/select.py
+++ b/custom_components/solarfocus/select.py
@@ -27,7 +27,7 @@ from .entity import (
     SolarfocusEntity,
     SolarfocusEntityDescription,
     create_description,
-    filterVersionAndSystem,
+    supported_entities,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -84,7 +84,7 @@ async def async_setup_entry(
             entity = SolarfocusSelectEntity(coordinator, _description)
             entities.append(entity)
 
-    async_add_entities(filterVersionAndSystem(config_entry, entities))
+    async_add_entities(supported_entities(config_entry, entities))
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -117,17 +117,29 @@ class SolarfocusSelectEntity(SolarfocusEntity, SelectEntity):
 
     @override
     async def async_select_option(self, option: str) -> None:
-        """Update the current selected option."""
+        """Update the current selected option.
+
+        The options are the strings of the numbers the controller works in, so
+        the number is what goes to the register: the library encodes an int or
+        a member of the register's own enumeration, and refuses a string.
+        """
         self._attr_current_option = option
         select = self.entity_description.item
-        return self._set_native_value(select, option)
+        await self._async_set_native_value(select, int(option))
 
     @property
     @override
-    def current_option(self) -> str:
-        """Return current option."""
-        select = self.entity_description.item
-        return str(self._get_native_value(select))
+    def current_option(self) -> str | None:
+        """Return current option, or None while the register has no reading.
+
+        A closed set of values decodes to a member of the library's enumeration,
+        which is an `IntEnum` and so prints as its number - which is what the
+        options are. `int()` first regardless, so a register that decodes to
+        something else does not report an option that is not on the list.
+        """
+        value = self._get_native_value(self.entity_description.item)
+
+        return None if value is None else str(int(value))
 
 
 HEATPUMP_SELECT_TYPES = [
@@ -175,7 +187,6 @@ HEATING_CIRCUIT_SELECT_TYPES = [
             "1",
             "2",
         ],
-        min_required_version="22.090",
     ),
 ]
 

--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -6,8 +6,6 @@ from datetime import datetime
 import logging
 from typing import cast, override
 
-from pysolarfocus import Systems
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -71,8 +69,7 @@ from .entity import (
     SolarfocusEntity,
     SolarfocusEntityDescription,
     create_description,
-    every_system_but,
-    filterVersionAndSystem,
+    supported_entities,
 )
 from .service_menu import installer_code, service_code
 
@@ -186,7 +183,8 @@ async def async_setup_entry(
 
         for i in range(count):
             for description in SOLAR_SENSOR_TYPES:
-                # Always use index since solar is now always a list in pysolarfocus
+                # Always use index: solar is one of the components a controller
+                # can have several of, so the library addresses it by number
                 # But for single instance, don't show the number in the entity name
                 idx = str(i + 1)
                 _description = create_description(
@@ -253,7 +251,7 @@ async def async_setup_entry(
         SolarfocusInstallerCodeSensor(coordinator, INSTALLER_CODE_SENSOR_TYPE)
     )
 
-    async_add_entities(filterVersionAndSystem(config_entry, entities))
+    async_add_entities(supported_entities(config_entry, entities))
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -451,38 +449,27 @@ BUFFER_SENSOR_TYPES = [
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        unsupported_systems=[
-            Systems.VAMPAIR,
-            Systems.PELLETELEGANCE,
-            Systems.OCTOPLUS,
-        ],
     ),
     SolarfocusSensorEntityDescription(
         key="external_top_temperature_x44",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        min_required_version="22.090",
         entity_registry_enabled_default=False,
-        unsupported_systems=[Systems.THERMINATOR, Systems.ECOTOP],
     ),
     SolarfocusSensorEntityDescription(
         key="external_middle_temperature_x36",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        min_required_version="22.090",
         entity_registry_enabled_default=False,
-        unsupported_systems=[Systems.THERMINATOR, Systems.ECOTOP],
     ),
     SolarfocusSensorEntityDescription(
         key="external_bottom_temperature_x35",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        min_required_version="22.090",
         entity_registry_enabled_default=False,
-        unsupported_systems=[Systems.THERMINATOR, Systems.ECOTOP],
     ),
 ]
 
@@ -628,18 +615,26 @@ HEATPUMP_SENSOR_TYPES = [
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
     ),
+    # The three the library renamed. A "performance overall" that is a seasonal
+    # figure reads better as one, but the key is what the entity id, the
+    # history behind it and the translation of its name are built from, so the
+    # key stays and the register is named beside it. `item` is the only place
+    # in the integration where the two differ.
     SolarfocusSensorEntityDescription(
         key="performance_overall",
+        item="seasonal_performance",
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
     ),
     SolarfocusSensorEntityDescription(
         key="performance_overall_heating",
+        item="seasonal_performance_heating",
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
     ),
     SolarfocusSensorEntityDescription(
         key="performance_overall_drinking_water",
+        item="seasonal_performance_drinking_water",
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
     ),
@@ -716,7 +711,6 @@ BIOMASS_BOILER_SENSOR_TYPES = [
         key="boiler_operating_mode",
         device_class=SensorDeviceClass.ENUM,
         options=enum_options(range(0, 6)),
-        unsupported_systems=every_system_but(Systems.THERMINATOR),
     ),
     SolarfocusSensorEntityDescription(
         key="octoplus_buffer_temperature_bottom",
@@ -727,7 +721,6 @@ BIOMASS_BOILER_SENSOR_TYPES = [
         # Sigmatek boiler bar the vampair it is the return flow temperature -
         # a different measurement at the same address, which has an entity of
         # its own below rather than this one under a name that would misread it.
-        unsupported_systems=every_system_but(Systems.OCTOPLUS),
     ),
     SolarfocusSensorEntityDescription(
         key="return_temperature",
@@ -740,43 +733,35 @@ BIOMASS_BOILER_SENSOR_TYPES = [
         # back under its own. The document grants it to "alle anderen Sigmatek
         # Kessel (ohne vampair)" bar the therminator, where 2410 is nicht
         # belegt - which leaves the EcoTop and the Pellet Elegance.
-        unsupported_systems=every_system_but(
-            Systems.ECOTOP, Systems.PELLETELEGANCE
-        ),
     ),
     SolarfocusSensorEntityDescription(
         key="octoplus_buffer_temperature_top",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        unsupported_systems=every_system_but(Systems.OCTOPLUS),
     ),
     SolarfocusSensorEntityDescription(
         key="log_wood",
         device_class=SensorDeviceClass.ENUM,
         options=enum_options(range(0, 2)),
-        unsupported_systems=every_system_but(Systems.THERMINATOR),
     ),
     SolarfocusSensorEntityDescription(
         key="pellet_usage_last_fill",
         native_unit_of_measurement=UnitOfMass.KILOGRAMS,
         device_class=SensorDeviceClass.WEIGHT,
         state_class=SensorStateClass.MEASUREMENT,
-        min_required_version="23.010",
     ),
     SolarfocusSensorEntityDescription(
         key="pellet_usage_total",
         native_unit_of_measurement=UnitOfMass.KILOGRAMS,
         device_class=SensorDeviceClass.WEIGHT,
         state_class=SensorStateClass.MEASUREMENT,
-        min_required_version="23.010",
     ),
     SolarfocusSensorEntityDescription(
         key="heat_energy_total",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        min_required_version="23.010",
     ),
 ]
 
@@ -858,27 +843,23 @@ FRESH_WATER_MODULE_SENSOR_TYPES = [
         key="state",
         device_class=SensorDeviceClass.ENUM,
         options=enum_options(range(0, 5)),
-        min_required_version="23.020",
     ),
     SolarfocusSensorEntityDescription(
         key="supply_temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        min_required_version="23.040",
     ),
     SolarfocusSensorEntityDescription(
         key="flow_rate",
         native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
         state_class=SensorStateClass.MEASUREMENT,
-        min_required_version="23.040",
     ),
     SolarfocusSensorEntityDescription(
         key="target_temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        min_required_version="23.040",
     ),
 ]
 
@@ -890,7 +871,6 @@ CIRCULATION_SENSOR_TYPES = [
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        min_required_version="25.030",
     ),
 ]
 
@@ -903,27 +883,23 @@ DIFFERENTIAL_MODULE_SENSOR_TYPES = [
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        min_required_version="25.030",
     ),
     SolarfocusSensorEntityDescription(
         key="temperature_2_control_loop_1",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        min_required_version="25.030",
     ),
     SolarfocusSensorEntityDescription(
         key="temperature_1_control_loop_2",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        min_required_version="25.030",
     ),
     SolarfocusSensorEntityDescription(
         key="temperature_2_control_loop_2",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        min_required_version="25.030",
     ),
 ]

--- a/custom_components/solarfocus/strings.json
+++ b/custom_components/solarfocus/strings.json
@@ -126,6 +126,9 @@
     },
     "cannot_set_up": {
       "message": "Cannot read from the Solarfocus system at {address}. It accepted the connection but did not answer the registers."
+    },
+    "invalid_configuration": {
+      "message": "The configured components do not match the Solarfocus system: {reason}. Correct them in the options of the integration."
     }
   },
   "issues": {

--- a/custom_components/solarfocus/switch.py
+++ b/custom_components/solarfocus/switch.py
@@ -18,7 +18,7 @@ from .entity import (
     SolarfocusEntity,
     SolarfocusEntityDescription,
     create_description,
-    filterVersionAndSystem,
+    supported_entities,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ async def async_setup_entry(
             entity = SolarfocusSwitchEntity(coordinator, _description)
             entities.append(entity)
 
-    async_add_entities(filterVersionAndSystem(config_entry, entities))
+    async_add_entities(supported_entities(config_entry, entities))
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -93,13 +93,13 @@ class SolarfocusSwitchEntity(SolarfocusEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         switch = self.entity_description.item
-        return self._set_native_value(switch, ON)
+        await self._async_set_native_value(switch, ON)
 
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         switch = self.entity_description.item
-        return self._set_native_value(switch, OFF)
+        await self._async_set_native_value(switch, OFF)
 
 
 HEATPUMP_SWITCH_TYPES = [

--- a/custom_components/solarfocus/translations/de.json
+++ b/custom_components/solarfocus/translations/de.json
@@ -125,6 +125,9 @@
     },
     "cannot_set_up": {
       "message": "Von der Solarfocus-Anlage unter {address} kann nicht gelesen werden. Sie nimmt die Verbindung an, antwortet aber nicht auf die Register."
+    },
+    "invalid_configuration": {
+      "message": "Die konfigurierten Komponenten passen nicht zur Solarfocus-Anlage: {reason}. Korrigiere sie in den Optionen der Integration."
     }
   },
   "issues": {

--- a/custom_components/solarfocus/translations/en.json
+++ b/custom_components/solarfocus/translations/en.json
@@ -126,6 +126,9 @@
     },
     "cannot_set_up": {
       "message": "Cannot read from the Solarfocus system at {address}. It accepted the connection but did not answer the registers."
+    },
+    "invalid_configuration": {
+      "message": "The configured components do not match the Solarfocus system: {reason}. Correct them in the options of the integration."
     }
   },
   "issues": {

--- a/custom_components/solarfocus/water_heater.py
+++ b/custom_components/solarfocus/water_heater.py
@@ -92,6 +92,10 @@ class SolarfocusWaterHeaterEntityDescription(
 class SolarfocusWaterHeaterEntity(SolarfocusEntity, WaterHeaterEntity):
     """Representation of a Solarfocus number entity."""
 
+    # `thermostat` and `domestic_hot_water` are labels rather than register
+    # names: this entity reads and writes several registers of its component.
+    reads_no_single_register = True
+
     entity_description: SolarfocusWaterHeaterEntityDescription
 
     _attr_has_entity_name = True
@@ -164,14 +168,14 @@ class SolarfocusWaterHeaterEntity(SolarfocusEntity, WaterHeaterEntity):
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
-            self._set_native_value("target_temperature", temp)
+            await self._async_set_native_value("target_temperature", temp)
             _LOGGER.debug("Set Temperature: %s", temp)
 
     @override
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new target temperature."""
         mapped_mode = HA_MODE_TO_SOLARFOCUS.get(operation_mode)
-        self._set_native_value("holding_mode", mapped_mode)
+        await self._async_set_native_value("holding_mode", mapped_mode)
         _LOGGER.debug(
             "Set Operation Mode: %s (mapped to: %s)", operation_mode, mapped_mode
         )
@@ -179,13 +183,13 @@ class SolarfocusWaterHeaterEntity(SolarfocusEntity, WaterHeaterEntity):
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn water heater on."""
-        self._set_native_value("holding_mode", SOLARFOCUS_MODE_ALWAYS_ON)
+        await self._async_set_native_value("holding_mode", SOLARFOCUS_MODE_ALWAYS_ON)
         _LOGGER.debug("async_turn_on")
 
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn water heater off."""
-        self._set_native_value("holding_mode", SOLARFOCUS_MODE_ALWAYS_OFF)
+        await self._async_set_native_value("holding_mode", SOLARFOCUS_MODE_ALWAYS_OFF)
         _LOGGER.debug("async_turn_off")
 
 

--- a/docs/home-assistant-core-changes.md
+++ b/docs/home-assistant-core-changes.md
@@ -272,11 +272,11 @@ Checked against the codebase and confirmed no impact:
 [2026-07-05 — Modernizing Modbus](https://developers.home-assistant.io/blog/2026/07/05/modernizing-modbus)
 introduces a `modbus_connection` integration and a backend-neutral `modbus-connection` PyPI library,
 so several integrations can share one bus. That is directly on-topic for this integration, which
-talks Modbus TCP to the Solarfocus controller through `pysolarfocus`.
+talks Modbus TCP to the Solarfocus controller through `aiosolarfocus`.
 
 **Do nothing yet.** The post explicitly says: *"If you are working on a device integration, hold off
 on wiring it up to the `modbus_connection` integration described below — we will share the updated
-approach here soon."* Worth tracking for a future `pysolarfocus` refactor, since a shared connection
+approach here soon."* Worth tracking for a future `aiosolarfocus` change, since a shared connection
 would fix the case where a user runs both this integration and the core `modbus` integration against
 the same controller.
 

--- a/docs/modbus-registers.md
+++ b/docs/modbus-registers.md
@@ -23,8 +23,8 @@ Redoing it means pulling the text out of the PDF, splitting each row at its type
 column (`int16`, `uint16`, `int32`, `uint32`) into name and remark, rejoining
 the words the layout breaks across lines, and keeping only the first instance of
 each repeated component block. The `Gelesen als` column is joined on the address:
-the base address of a `pysolarfocus` component plus the relative address of its
-`DataValue` is the `Adr.` of the table. The arrows in the document are Wingdings
+the base address of an `aiosolarfocus` component plus the relative address of
+its `Register` is the `Adr.` of the table. The arrows in the document are Wingdings
 and come out in the private use area, where they render as tofu; they are written
 as `→` here.
 
@@ -35,7 +35,7 @@ as `→` here.
   heating circuit 3 supply temperature is `1100 + 2 × 50 = 1200`.
 - **Bezeichnung** is the German name from the `Bezeichnung` column, which is
   what the entity names in `translations/de.json` are taken from.
-- **Gelesen als** is the `pysolarfocus` attribute the integration reads the
+- **Gelesen als** is the `aiosolarfocus` value the integration reads the
   register through, prefixed with the component the entity keys use — `hc` for
   the heating circuit, `bo` boiler, `bu` buffer, `hp` heat pump, `bb` biomass
   boiler, `pv` photovoltaic, `so` solar, `fm` fresh water module, `ci`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "solarfocus"
-version = "6.0.0"
+version = "7.0.0-rc1"
 description = "Custom component for integrating Solarfocus heating systems into Home Assistant."
 authors = [{ name = "Jeroen Laverman", email = "jjlaverman@web.de" }]
 requires-python = ">=3.14.2,<3.15"
@@ -12,7 +12,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.8.0,<2027",
-    "pysolarfocus>=5.3.0,<6",
+    "aiosolarfocus>=0.2.0,<1",
     "packaging~=24.0",
     "pylint>=3.3.3",
     "pytest-homeassistant-custom-component>=0.13.355,<0.14",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -545,6 +545,11 @@ ignore = [
 
 ]
 
+[tool.ruff.per-file-ignores]
+# The report *is* the point of this one: it runs against a real controller, by
+# hand, with `-s`, and prints what that controller answered.
+"tests/test_live_controller.py" = ["T201"]
+
 [tool.ruff.flake8-import-conventions.extend-aliases]
 voluptuous = "vol"
 "homeassistant.helpers.area_registry" = "ar"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.8.0,<2027",
-    "aiosolarfocus>=0.2.0,<1",
+    "aiosolarfocus>=0.2.1,<1",
     "packaging~=24.0",
     "pylint>=3.3.3",
     "pytest-homeassistant-custom-component>=0.13.355,<0.14",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,20 @@
 """Fixtures for the Solarfocus tests."""
 
+from collections.abc import Iterator
+from typing import Any
 from unittest.mock import MagicMock, patch
 
-from pysolarfocus import ApiVersions, Systems
+from aiosolarfocus import (
+    ApiVersion,
+    ComponentId,
+    RegisterKind,
+    SolarfocusClient,
+    SolarfocusConfig,
+    SolarfocusConnectionError,
+    Systems,
+)
+from aiosolarfocus.codec import words_to_raw
+from aiosolarfocus.testing import FakeController
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -22,6 +34,8 @@ from custom_components.solarfocus.const import (
     DEFAULT_NAME,
     DOMAIN,
     build_unique_id,
+    component_count,
+    solar_count,
 )
 from custom_components.solarfocus.service_menu import DisplayedNumber
 from homeassistant.const import (
@@ -43,7 +57,9 @@ def build_data(system: Systems = Systems.VAMPAIR) -> dict:
         CONF_SOLARFOCUS_SYSTEM: system,
         CONF_HOST: "solarfocus.local",
         CONF_PORT: 502,
-        CONF_API_VERSION: ApiVersions.V_23_020.value,
+        # `label`, not `value`: an entry stores the version as the controller
+        # prints it, and an `ApiVersion` is numbered for ordering.
+        CONF_API_VERSION: ApiVersion.V_23_020.label,
     }
 
 
@@ -96,6 +112,117 @@ def build_config_entry(
     )
 
 
+def every_component(system: Systems = Systems.VAMPAIR, **overrides) -> dict:
+    """Return options asking for everything this system can have at once.
+
+    The heat source is the one part of the layout the system decides rather
+    than the user, and the library refuses the combination the config flow has
+    never offered - a Vampair has the heat pump, everything else has the
+    biomass boiler - so which of the two is asked for follows the system.
+    """
+    options = {
+        CONF_HEATING_CIRCUIT: 1,
+        CONF_BUFFER: 1,
+        CONF_BOILER: 1,
+        CONF_FRESH_WATER_MODULE: 1,
+        CONF_CIRCULATION: 1,
+        CONF_DIFFERENTIAL_MODULE: 1,
+        CONF_SOLAR: 1,
+        CONF_PHOTOVOLTAIC: True,
+        CONF_HEATPUMP: system is Systems.VAMPAIR,
+        CONF_BIOMASS_BOILER: system is not Systems.VAMPAIR,
+    }
+    options.update(overrides)
+
+    return options
+
+
+class OfflineController(FakeController):
+    """A controller that is not there at all, on every attempt.
+
+    `FakeController.fail_with` raises once and clears, which is a socket that
+    drops and comes back. This is the other outage: nothing at the address.
+    """
+
+    async def connect(self) -> None:
+        """Refuse the connection, as an address with nothing on it does."""
+        raise SolarfocusConnectionError("no route to host", context="connecting")
+
+
+def build_config(entry: MockConfigEntry) -> SolarfocusConfig:
+    """Return the library configuration this entry describes.
+
+    The same translation `async_setup_entry` makes, so a test that drives the
+    client directly is driving the one the integration would have built.
+    """
+    return SolarfocusConfig(
+        host=entry.data[CONF_HOST],
+        port=entry.data[CONF_PORT],
+        system=Systems(entry.data[CONF_SOLARFOCUS_SYSTEM]),
+        api_version=ApiVersion.parse(entry.data[CONF_API_VERSION]),
+        heating_circuits=entry.options[CONF_HEATING_CIRCUIT],
+        buffers=entry.options[CONF_BUFFER],
+        boilers=entry.options[CONF_BOILER],
+        fresh_water_modules=entry.options[CONF_FRESH_WATER_MODULE],
+        circulations=component_count(entry, CONF_CIRCULATION),
+        differential_modules=component_count(entry, CONF_DIFFERENTIAL_MODULE),
+        solar=solar_count(entry),
+        heat_pump=entry.options[CONF_HEATPUMP],
+        biomass_boiler=entry.options[CONF_BIOMASS_BOILER],
+        photovoltaic=entry.options[CONF_PHOTOVOLTAIC],
+    )
+
+
+def build_client(
+    entry: MockConfigEntry | None = None,
+    *,
+    controller: FakeController | None = None,
+    **config_overrides: Any,
+) -> SolarfocusClient:
+    """Return a real client, reading a controller that is not real.
+
+    The library ships `FakeController` for exactly this: it refuses an address
+    the firmware does not map, hands out a 32-bit register only whole, and
+    compacts a read that spans a gap - the three behaviours that have caused
+    every register bug this integration has had. A mock of the client would
+    agree with whatever the test expected instead.
+    """
+    if entry is None:
+        entry = build_config_entry(
+            heating_circuit=1, buffer=1, boiler=1, heatpump=True
+        )
+
+    config = build_config(entry)
+    if config_overrides:
+        config = replace_config(config, **config_overrides)
+
+    return SolarfocusClient(
+        config, transport=controller or FakeController.for_config(config)
+    )
+
+
+def replace_config(config: SolarfocusConfig, **overrides: Any) -> SolarfocusConfig:
+    """Return the configuration with some fields changed.
+
+    `SolarfocusConfig` is frozen, and validates in `__post_init__`, so this is
+    a new one rather than an edit.
+    """
+    fields = {
+        name: getattr(config, name)
+        for name in SolarfocusConfig.__dataclass_fields__
+    }
+
+    return SolarfocusConfig(**{**fields, **overrides})
+
+
+def controller_of(client: SolarfocusClient) -> FakeController:
+    """Return the fake controller a client built by `build_client` reads."""
+    controller = client._transport  # noqa: SLF001
+    assert isinstance(controller, FakeController)
+
+    return controller
+
+
 @pytest.fixture(name="config_entry")
 def config_entry_fixture() -> MockConfigEntry:
     """Return a vampair config entry with one of every multi-instance component."""
@@ -107,59 +234,260 @@ def config_entry_fixture() -> MockConfigEntry:
     )
 
 
-def build_api(system: Systems = Systems.VAMPAIR) -> MagicMock:
-    """Return a mocked SolarfocusAPI that connects and updates successfully."""
-    api = MagicMock()
-    api.system = system
-    api.api_version = ApiVersions.V_23_020
-    api.connect.return_value = True
-    api.is_connected = True
-    for update in (
-        "update_heating",
-        "update_buffer",
-        "update_boiler",
-        "update_heatpump",
-        "update_photovoltaic",
-        "update_biomassboiler",
-        "update_solar",
-        "update_fresh_water_modules",
-        "update_circulation",
-        "update_differential_modules",
-    ):
-        getattr(api, update).return_value = True
-    return api
+@pytest.fixture(name="client")
+def client_fixture(config_entry: MockConfigEntry) -> SolarfocusClient:
+    """Return the client the entry of the `config_entry` fixture describes."""
+    return build_client(config_entry)
 
 
-@pytest.fixture(name="api")
-def api_fixture() -> MagicMock:
-    """Return a mocked SolarfocusAPI."""
-    return build_api()
+class ClientFactory:
+    """Stands in for the `SolarfocusClient` constructor during a test.
+
+    It builds a real client every time, over a controller that is not real, so
+    the client under test is always the one the entry actually describes - a
+    fixture built ahead of time would be the client of whatever entry the
+    fixture happened to use, and half these tests set up their own.
+
+    `offline()` before the entry is set up is an address with nothing on it;
+    `controller` afterwards is what the client just read, for a test that wants
+    to put a value somewhere or take a register away.
+    """
+
+    def __init__(self) -> None:
+        """Start with no clients built and a controller that answers."""
+        self.instances: list[SolarfocusClient] = []
+        self.controller_type: type[FakeController] = FakeController
+        self._silenced: list[tuple[ComponentId | str, int]] = []
+        self._readings: list[tuple[ComponentId | str, str, float, int]] = []
+
+    def __call__(self, config: SolarfocusConfig, **kwargs: Any) -> SolarfocusClient:
+        """Build the client the integration asked for."""
+        client = SolarfocusClient(
+            config, transport=self.controller_type.for_config(config)
+        )
+        self.instances.append(client)
+
+        for component, register, value, index in self._readings:
+            set_reading(client, component, register, value, index=index)
+        for component, index in self._silenced:
+            silence(client, component, index=index)
+
+        return client
+
+    def offline(self) -> None:
+        """Have every client built after this find nothing at the address."""
+        self.controller_type = OfflineController
+
+    def online(self) -> None:
+        """Have every client built after this reach the controller again."""
+        self.controller_type = FakeController
+
+    def reads(
+        self,
+        component: ComponentId | str,
+        register: str,
+        value: float,
+        *,
+        index: int = 1,
+    ) -> None:
+        """Have one register already hold a value when the entry loads.
+
+        The entry builds its own client, so a test that wants a reading in
+        place before the first refresh cannot reach it beforehand - the
+        instruction is kept and applied to every client built afterwards.
+        """
+        self._readings.append((component, register, value, index))
+        for client in self.instances:
+            set_reading(client, component, register, value, index=index)
+
+    def silence(self, component: ComponentId | str, *, index: int = 1) -> None:
+        """Have one component answer nothing, before or after the entry loads.
+
+        Before is the common case - a test wants the entry to set up with the
+        component already failing - and the client does not exist yet then, so
+        the instruction is kept and applied to every client built afterwards.
+        """
+        self._silenced.append((component, index))
+        for client in self.instances:
+            silence(client, component, index=index)
+
+    @property
+    def instance(self) -> SolarfocusClient:
+        """The client built last, which is the one the entry is using."""
+        return self.instances[-1]
+
+    @property
+    def controller(self) -> FakeController:
+        """The controller that client is reading."""
+        return controller_of(self.instance)
 
 
-@pytest.fixture(name="mock_api")
-def mock_api_fixture(api: MagicMock):
-    """Patch SolarfocusAPI everywhere the integration constructs one."""
+@pytest.fixture(name="mock_client")
+def mock_client_fixture() -> Iterator[ClientFactory]:
+    """Patch SolarfocusClient everywhere the integration constructs one.
+
+    Both patch targets are import-site names, so this holds only as long as
+    both modules go on importing the class by name.
+    """
+    factory = ClientFactory()
+
     with (
         patch(
-            "custom_components.solarfocus.SolarfocusAPI", return_value=api
+            "custom_components.solarfocus.SolarfocusClient", side_effect=factory
         ) as constructor,
-        patch("custom_components.solarfocus.config_flow.SolarfocusAPI", return_value=api),
+        patch(
+            "custom_components.solarfocus.config_flow.SolarfocusClient",
+            side_effect=factory,
+        ),
     ):
-        constructor.instance = api
-        yield constructor
+        factory.constructor = constructor  # type: ignore[attr-defined]
+        yield factory
 
 
-def build_coordinator(entry, api: MagicMock | None = None) -> MagicMock:
+def build_coordinator(entry, client: SolarfocusClient | None = None) -> MagicMock:
     """Return a coordinator stub that entities can read from."""
     coordinator = MagicMock()
     coordinator._entry = entry
-    coordinator.api = api if api is not None else build_api()
+    coordinator.client = client if client is not None else build_client(entry)
     coordinator.last_update_success = True
     # Every component reads, so the entities on them are available. A stub of it
     # rather than whatever a MagicMock makes of `in`, which is what availability
     # asks of this.
-    coordinator.failed_components = set()
+    coordinator.failed_components = frozenset()
     # The real one, not a mock: the number the installer menu shows is shared
     # between two entities, and what a test of either is about is that sharing.
     coordinator.displayed_number = DisplayedNumber()
     return coordinator
+
+
+def set_value(
+    client: SolarfocusClient,
+    component: ComponentId | str,
+    register: str,
+    raw: int,
+    *,
+    index: int = 1,
+) -> None:
+    """Put a raw word where one register of one component is read from.
+
+    Named by the register rather than by an address, because an address is a
+    fact about a firmware and a system and the layout already knows it.
+
+    The word goes to the controller and into the component's own readings, so
+    it is both what the next poll would find and what the entity reads now -
+    the component holds the last reading, and a test that only put a word on
+    the wire would be reading whatever the component last decoded, which is
+    nothing.
+    """
+    instance = client.of(ComponentId(component))[index - 1]
+    resolved = instance.layout.by_name[register]
+    controller = controller_of(client)
+
+    width = len(resolved.addresses)
+    words = {}
+    for offset, address in enumerate(resolved.addresses):
+        word = (raw >> (16 * (width - 1 - offset))) & 0xFFFF
+        controller.set(resolved.kind, address, word)
+        words[(resolved.kind, address)] = word
+
+    instance.decode_readings(words)
+
+
+def set_reading(
+    client: SolarfocusClient,
+    component: ComponentId | str,
+    register: str,
+    value: float,
+    *,
+    index: int = 1,
+) -> None:
+    """Have one register read as a value, in the unit the entity reports.
+
+    The scale is the register's own, so a test says "the boiler is at 55
+    degrees" rather than "word 550 sits at address 501" - and the word that
+    ends up at the address is the one a real controller would have sent.
+    """
+    instance = client.of(ComponentId(component))[index - 1]
+    resolved = instance.layout.by_name[register]
+
+    set_value(
+        client,
+        component,
+        register,
+        round(value / resolved.register.scale),
+        index=index,
+    )
+
+
+def written_by_name(
+    client: SolarfocusClient,
+    component: ComponentId | str,
+    *,
+    index: int = 1,
+) -> dict[str, float]:
+    """Return what was written to one component, keyed by register name.
+
+    A write used to be one call of the entity's own setter per register, so a
+    test could watch the setter. They go out as one group now - the register
+    document requires it - so what a test can watch is the wire, and this puts
+    the names back on it.
+    """
+    instance = client.of(ComponentId(component))[index - 1]
+    at_address = {
+        (resolved.kind, resolved.address): resolved
+        for resolved in instance.layout.registers
+    }
+
+    values: dict[str, float] = {}
+    for kind, address, words in controller_of(client).writes:
+        resolved = at_address.get((kind, address))
+        if resolved is None:
+            continue
+        raw = words_to_raw(words, signed=resolved.register.signed)
+        # A register that scales a write differently from a read says so;
+        # otherwise the two are the same.
+        scale = resolved.register.write_scale or resolved.register.scale
+        values[resolved.name] = raw * scale
+
+    return values
+
+
+def written(client: SolarfocusClient) -> list[tuple[RegisterKind, int, tuple[int, ...]]]:
+    """Return every write the controller has been asked for, in order."""
+    return list(controller_of(client).writes)
+
+
+def silence(
+    client: SolarfocusClient, component: ComponentId | str, *, index: int = 1
+) -> None:
+    """Have one component instance answer nothing, as a real one does.
+
+    A firmware that does not have a register range refuses a read that starts
+    in it, and the library attributes that to the components whose registers
+    were in the read. Taking the addresses away is how a fake controller says
+    the same thing - which is a good deal closer to the real failure than the
+    predecessor's tests got, where a component that could not be read was a
+    mock returning `False`.
+    """
+    instance = client.of(ComponentId(component))[index - 1]
+    controller = controller_of(client)
+
+    for resolved in instance.layout.registers:
+        controller.unmap(resolved.kind, *resolved.addresses)
+
+
+def revive(
+    client: SolarfocusClient, component: ComponentId | str, *, index: int = 1
+) -> None:
+    """Give one component instance its registers back, as a firmware never does.
+
+    The counterpart of `silence`, for the tests about a component coming back:
+    a real controller answering again is a register range that starts working,
+    which from here is the address being mapped once more.
+    """
+    instance = client.of(ComponentId(component))[index - 1]
+    controller = controller_of(client)
+
+    for resolved in instance.layout.registers:
+        for address in resolved.addresses:
+            controller.set(resolved.kind, address, 0)

--- a/tests/fixtures/ecotop.json
+++ b/tests/fixtures/ecotop.json
@@ -1,0 +1,410 @@
+{
+  "meta": {
+    "system": "Ecotop",
+    "api_version": "26.020"
+  },
+  "components": {
+    "heating_circuits.1": {
+      "supply_temperature": {
+        "address": 1100,
+        "kind": "input",
+        "raw": 280,
+        "value": 28.0,
+        "unit": "°C"
+      },
+      "room_temperature": {
+        "address": 1101,
+        "kind": "input",
+        "raw": 277,
+        "value": 27.7,
+        "unit": "°C"
+      },
+      "humidity": {
+        "address": 1102,
+        "kind": "input",
+        "raw": -1,
+        "value": null,
+        "unit": "%"
+      },
+      "limit_thermostat": {
+        "address": 1103,
+        "kind": "input",
+        "raw": 1,
+        "value": true,
+        "unit": null
+      },
+      "circulator_pump": {
+        "address": 1105,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "mixer_valve": {
+        "address": 1106,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": "%"
+      },
+      "state": {
+        "address": 1107,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      },
+      "target_supply_temperature": {
+        "address": 32600,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "cooling": {
+        "address": 32602,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      },
+      "mode": {
+        "address": 32603,
+        "kind": "holding",
+        "raw": 3,
+        "value": 3,
+        "unit": null
+      },
+      "target_room_temperature": {
+        "address": 32605,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "indoor_temperature_external": {
+        "address": 32606,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "indoor_humidity_external": {
+        "address": 32607,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "%"
+      },
+      "heating_mode": {
+        "address": 32608,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      }
+    },
+    "heating_circuits.2": {
+      "supply_temperature": {
+        "address": 1150,
+        "kind": "input",
+        "raw": 281,
+        "value": 28.1,
+        "unit": "°C"
+      },
+      "room_temperature": {
+        "address": 1151,
+        "kind": "input",
+        "raw": 196,
+        "value": 19.6,
+        "unit": "°C"
+      },
+      "humidity": {
+        "address": 1152,
+        "kind": "input",
+        "raw": -1,
+        "value": null,
+        "unit": "%"
+      },
+      "limit_thermostat": {
+        "address": 1153,
+        "kind": "input",
+        "raw": 1,
+        "value": true,
+        "unit": null
+      },
+      "circulator_pump": {
+        "address": 1155,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "mixer_valve": {
+        "address": 1156,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": "%"
+      },
+      "state": {
+        "address": 1157,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      },
+      "target_supply_temperature": {
+        "address": 32650,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "cooling": {
+        "address": 32652,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      },
+      "mode": {
+        "address": 32653,
+        "kind": "holding",
+        "raw": 3,
+        "value": 3,
+        "unit": null
+      },
+      "target_room_temperature": {
+        "address": 32655,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "indoor_temperature_external": {
+        "address": 32656,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "indoor_humidity_external": {
+        "address": 32657,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "%"
+      },
+      "heating_mode": {
+        "address": 32658,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      }
+    },
+    "buffers.1": {
+      "top_temperature": {
+        "address": 1900,
+        "kind": "input",
+        "raw": 719,
+        "value": 71.9,
+        "unit": "°C"
+      },
+      "bottom_temperature": {
+        "address": 1901,
+        "kind": "input",
+        "raw": 540,
+        "value": 54.0,
+        "unit": "°C"
+      },
+      "pump": {
+        "address": 1903,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "state": {
+        "address": 1904,
+        "kind": "input",
+        "raw": 1,
+        "value": 1,
+        "unit": null
+      },
+      "mode": {
+        "address": 1905,
+        "kind": "input",
+        "raw": 1,
+        "value": 1,
+        "unit": null
+      }
+    },
+    "boilers.1": {
+      "temperature": {
+        "address": 500,
+        "kind": "input",
+        "raw": 651,
+        "value": 65.1,
+        "unit": "°C"
+      },
+      "state": {
+        "address": 501,
+        "kind": "input",
+        "raw": 1,
+        "value": 1,
+        "unit": null
+      },
+      "mode": {
+        "address": 502,
+        "kind": "input",
+        "raw": 2,
+        "value": 2,
+        "unit": null
+      },
+      "target_temperature": {
+        "address": 32000,
+        "kind": "holding",
+        "raw": 750,
+        "value": 75.0,
+        "unit": "°C"
+      },
+      "single_charge": {
+        "address": 32001,
+        "kind": "holding",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "holding_mode": {
+        "address": 32002,
+        "kind": "holding",
+        "raw": 2,
+        "value": 2,
+        "unit": null
+      },
+      "circulation": {
+        "address": 32003,
+        "kind": "holding",
+        "raw": -1,
+        "value": null,
+        "unit": null
+      }
+    },
+    "biomass_boiler": {
+      "temperature": {
+        "address": 2400,
+        "kind": "input",
+        "raw": 302,
+        "value": 30.2,
+        "unit": "°C"
+      },
+      "status": {
+        "address": 2401,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      },
+      "time_of_operation_at_maintenance": {
+        "address": 2402,
+        "kind": "input",
+        "raw": 340595,
+        "value": 340595,
+        "unit": "min"
+      },
+      "message_number": {
+        "address": 2404,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      },
+      "door_contact": {
+        "address": 2405,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "cleaning": {
+        "address": 2406,
+        "kind": "input",
+        "raw": -1,
+        "value": null,
+        "unit": "%"
+      },
+      "ash_container": {
+        "address": 2407,
+        "kind": "input",
+        "raw": 8,
+        "value": 8,
+        "unit": "%"
+      },
+      "outdoor_temperature": {
+        "address": 2408,
+        "kind": "input",
+        "raw": 197,
+        "value": 19.7,
+        "unit": "°C"
+      },
+      "return_temperature": {
+        "address": 2410,
+        "kind": "input",
+        "raw": 304,
+        "value": 30.4,
+        "unit": "°C"
+      },
+      "pellet_usage_last_fill": {
+        "address": 2414,
+        "kind": "input",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "kg"
+      },
+      "pellet_usage_total": {
+        "address": 2416,
+        "kind": "input",
+        "raw": 233237,
+        "value": 23323.7,
+        "unit": "kg"
+      },
+      "heat_energy_total": {
+        "address": 2418,
+        "kind": "input",
+        "raw": 1065282,
+        "value": 106528.2,
+        "unit": "kWh"
+      },
+      "sweep_almost_done": {
+        "address": 2420,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "residual_oxygen_level": {
+        "address": 2421,
+        "kind": "input",
+        "raw": 210,
+        "value": 21.0,
+        "unit": "%"
+      },
+      "return_flow_booster_pump": {
+        "address": 2422,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "outdoor_temperature_external": {
+        "address": 33406,
+        "kind": "holding",
+        "raw": -9999,
+        "value": null,
+        "unit": "°C"
+      }
+    }
+  }
+}

--- a/tests/fixtures/pellet_elegance_21_110.json
+++ b/tests/fixtures/pellet_elegance_21_110.json
@@ -1,0 +1,352 @@
+{
+  "meta": {
+    "system": "Pellet Elegance",
+    "api_version": "26.020"
+  },
+  "components": {
+    "heating_circuits.1": {
+      "supply_temperature": {
+        "address": 1100,
+        "kind": "input",
+        "raw": 262,
+        "value": 26.2,
+        "unit": "°C"
+      },
+      "room_temperature": {
+        "address": 1101,
+        "kind": "input",
+        "raw": 1243,
+        "value": 124.3,
+        "unit": "°C"
+      },
+      "humidity": {
+        "address": 1102,
+        "kind": "input",
+        "raw": -1,
+        "value": -0.1,
+        "unit": "%"
+      },
+      "limit_thermostat": {
+        "address": 1103,
+        "kind": "input",
+        "raw": 1,
+        "value": true,
+        "unit": null
+      },
+      "circulator_pump": {
+        "address": 1105,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "mixer_valve": {
+        "address": 1106,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": "%"
+      },
+      "state": {
+        "address": 1107,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      },
+      "target_supply_temperature": {
+        "address": 32600,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "cooling": {
+        "address": 32602,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      },
+      "mode": {
+        "address": 32603,
+        "kind": "holding",
+        "raw": 3,
+        "value": 3,
+        "unit": null
+      },
+      "target_room_temperature": {
+        "address": 32605,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "indoor_temperature_external": {
+        "address": 32606,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "indoor_humidity_external": {
+        "address": 32607,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "%"
+      },
+      "heating_mode": {
+        "address": 32608,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      }
+    },
+    "buffers.1": {
+      "top_temperature": {
+        "address": 1900,
+        "kind": "input",
+        "raw": 539,
+        "value": 53.9,
+        "unit": "°C"
+      },
+      "bottom_temperature": {
+        "address": 1901,
+        "kind": "input",
+        "raw": 497,
+        "value": 49.7,
+        "unit": "°C"
+      },
+      "pump": {
+        "address": 1903,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "state": {
+        "address": 1904,
+        "kind": "input",
+        "raw": 1,
+        "value": 1,
+        "unit": null
+      },
+      "mode": {
+        "address": 1905,
+        "kind": "input",
+        "raw": 1,
+        "value": 1,
+        "unit": null
+      },
+      "external_top_temperature_x44": {
+        "address": 34000,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "external_middle_temperature_x36": {
+        "address": 34001,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "external_bottom_temperature_x35": {
+        "address": 34002,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      }
+    },
+    "boilers.1": {
+      "temperature": {
+        "address": 500,
+        "kind": "input",
+        "raw": 549,
+        "value": 54.9,
+        "unit": "°C"
+      },
+      "state": {
+        "address": 501,
+        "kind": "input",
+        "raw": 1,
+        "value": 1,
+        "unit": null
+      },
+      "mode": {
+        "address": 502,
+        "kind": "input",
+        "raw": 1,
+        "value": 1,
+        "unit": null
+      },
+      "target_temperature": {
+        "address": 32000,
+        "kind": "holding",
+        "raw": 499,
+        "value": 49.9,
+        "unit": "°C"
+      },
+      "single_charge": {
+        "address": 32001,
+        "kind": "holding",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "holding_mode": {
+        "address": 32002,
+        "kind": "holding",
+        "raw": 1,
+        "value": 1,
+        "unit": null
+      },
+      "circulation": {
+        "address": 32003,
+        "kind": "holding",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      }
+    },
+    "biomass_boiler": {
+      "temperature": {
+        "address": 2400,
+        "kind": "input",
+        "raw": 256,
+        "value": 25.6,
+        "unit": "°C"
+      },
+      "status": {
+        "address": 2401,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      },
+      "time_of_operation_at_maintenance": {
+        "address": 2402,
+        "kind": "input",
+        "raw": 250869,
+        "value": 250869,
+        "unit": "min"
+      },
+      "message_number": {
+        "address": 2404,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      },
+      "door_contact": {
+        "address": 2405,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "cleaning": {
+        "address": 2406,
+        "kind": "input",
+        "raw": -1,
+        "value": -1,
+        "unit": "%"
+      },
+      "ash_container": {
+        "address": 2407,
+        "kind": "input",
+        "raw": 30,
+        "value": 30,
+        "unit": "%"
+      },
+      "outdoor_temperature": {
+        "address": 2408,
+        "kind": "input",
+        "raw": 171,
+        "value": 17.1,
+        "unit": "°C"
+      },
+      "return_temperature": {
+        "address": 2410,
+        "kind": "input",
+        "raw": 257,
+        "value": 25.7,
+        "unit": "°C"
+      },
+      "pellet_usage_last_fill": {
+        "address": 2414,
+        "kind": "input",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "kg"
+      },
+      "pellet_usage_total": {
+        "address": 2416,
+        "kind": "input",
+        "raw": 84174,
+        "value": 8417.4,
+        "unit": "kg"
+      },
+      "heat_energy_total": {
+        "address": 2418,
+        "kind": "input",
+        "raw": 373881,
+        "value": 37388.1,
+        "unit": "kWh"
+      },
+      "sweep_almost_done": {
+        "address": 2420,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "residual_oxygen_level": {
+        "address": 2421,
+        "kind": "input",
+        "raw": 210,
+        "value": 21.0,
+        "unit": "%"
+      },
+      "return_flow_booster_pump": {
+        "address": 2422,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "outdoor_temperature_external": {
+        "address": 33406,
+        "kind": "holding",
+        "raw": -9999,
+        "value": -999.9,
+        "unit": "°C"
+      },
+      "sweep_function_start_stop": {
+        "address": 33410,
+        "kind": "holding",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "sweep_function_extend": {
+        "address": 33411,
+        "kind": "holding",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "pellet_usage_reset": {
+        "address": 33412,
+        "kind": "holding",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      }
+    }
+  }
+}

--- a/tests/fixtures/pellet_elegance_25_110.json
+++ b/tests/fixtures/pellet_elegance_25_110.json
@@ -1,0 +1,352 @@
+{
+  "meta": {
+    "system": "Pellet Elegance",
+    "api_version": "26.020"
+  },
+  "components": {
+    "heating_circuits.1": {
+      "supply_temperature": {
+        "address": 1100,
+        "kind": "input",
+        "raw": 222,
+        "value": 22.2,
+        "unit": "°C"
+      },
+      "room_temperature": {
+        "address": 1101,
+        "kind": "input",
+        "raw": 254,
+        "value": 25.4,
+        "unit": "°C"
+      },
+      "humidity": {
+        "address": 1102,
+        "kind": "input",
+        "raw": -1,
+        "value": -0.1,
+        "unit": "%"
+      },
+      "limit_thermostat": {
+        "address": 1103,
+        "kind": "input",
+        "raw": 1,
+        "value": true,
+        "unit": null
+      },
+      "circulator_pump": {
+        "address": 1105,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "mixer_valve": {
+        "address": 1106,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": "%"
+      },
+      "state": {
+        "address": 1107,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      },
+      "target_supply_temperature": {
+        "address": 32600,
+        "kind": "holding",
+        "raw": 290,
+        "value": 29.0,
+        "unit": "°C"
+      },
+      "cooling": {
+        "address": 32602,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      },
+      "mode": {
+        "address": 32603,
+        "kind": "holding",
+        "raw": 3,
+        "value": 3,
+        "unit": null
+      },
+      "target_room_temperature": {
+        "address": 32605,
+        "kind": "holding",
+        "raw": 170,
+        "value": 17.0,
+        "unit": "°C"
+      },
+      "indoor_temperature_external": {
+        "address": 32606,
+        "kind": "holding",
+        "raw": 254,
+        "value": 25.4,
+        "unit": "°C"
+      },
+      "indoor_humidity_external": {
+        "address": 32607,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "%"
+      },
+      "heating_mode": {
+        "address": 32608,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      }
+    },
+    "buffers.1": {
+      "top_temperature": {
+        "address": 1900,
+        "kind": "input",
+        "raw": 227,
+        "value": 22.7,
+        "unit": "°C"
+      },
+      "bottom_temperature": {
+        "address": 1901,
+        "kind": "input",
+        "raw": 220,
+        "value": 22.0,
+        "unit": "°C"
+      },
+      "pump": {
+        "address": 1903,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "state": {
+        "address": 1904,
+        "kind": "input",
+        "raw": 1,
+        "value": 1,
+        "unit": null
+      },
+      "mode": {
+        "address": 1905,
+        "kind": "input",
+        "raw": 1,
+        "value": 1,
+        "unit": null
+      },
+      "external_top_temperature_x44": {
+        "address": 34000,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "external_middle_temperature_x36": {
+        "address": 34001,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "external_bottom_temperature_x35": {
+        "address": 34002,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      }
+    },
+    "boilers.1": {
+      "temperature": {
+        "address": 500,
+        "kind": "input",
+        "raw": 514,
+        "value": 51.4,
+        "unit": "°C"
+      },
+      "state": {
+        "address": 501,
+        "kind": "input",
+        "raw": 1,
+        "value": 1,
+        "unit": null
+      },
+      "mode": {
+        "address": 502,
+        "kind": "input",
+        "raw": 3,
+        "value": 3,
+        "unit": null
+      },
+      "target_temperature": {
+        "address": 32000,
+        "kind": "holding",
+        "raw": 530,
+        "value": 53.0,
+        "unit": "°C"
+      },
+      "single_charge": {
+        "address": 32001,
+        "kind": "holding",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "holding_mode": {
+        "address": 32002,
+        "kind": "holding",
+        "raw": 3,
+        "value": 3,
+        "unit": null
+      },
+      "circulation": {
+        "address": 32003,
+        "kind": "holding",
+        "raw": -1,
+        "value": true,
+        "unit": null
+      }
+    },
+    "biomass_boiler": {
+      "temperature": {
+        "address": 2400,
+        "kind": "input",
+        "raw": 211,
+        "value": 21.1,
+        "unit": "°C"
+      },
+      "status": {
+        "address": 2401,
+        "kind": "input",
+        "raw": 6,
+        "value": 6,
+        "unit": null
+      },
+      "time_of_operation_at_maintenance": {
+        "address": 2402,
+        "kind": "input",
+        "raw": 82570,
+        "value": 82570,
+        "unit": "min"
+      },
+      "message_number": {
+        "address": 2404,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      },
+      "door_contact": {
+        "address": 2405,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "cleaning": {
+        "address": 2406,
+        "kind": "input",
+        "raw": -1,
+        "value": -1,
+        "unit": "%"
+      },
+      "ash_container": {
+        "address": 2407,
+        "kind": "input",
+        "raw": 70,
+        "value": 70,
+        "unit": "%"
+      },
+      "outdoor_temperature": {
+        "address": 2408,
+        "kind": "input",
+        "raw": 249,
+        "value": 24.9,
+        "unit": "°C"
+      },
+      "return_temperature": {
+        "address": 2410,
+        "kind": "input",
+        "raw": 211,
+        "value": 21.1,
+        "unit": "°C"
+      },
+      "pellet_usage_last_fill": {
+        "address": 2414,
+        "kind": "input",
+        "raw": 54186,
+        "value": 5418.6,
+        "unit": "kg"
+      },
+      "pellet_usage_total": {
+        "address": 2416,
+        "kind": "input",
+        "raw": 54186,
+        "value": 5418.6,
+        "unit": "kg"
+      },
+      "heat_energy_total": {
+        "address": 2418,
+        "kind": "input",
+        "raw": 249564,
+        "value": 24956.4,
+        "unit": "kWh"
+      },
+      "sweep_almost_done": {
+        "address": 2420,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "residual_oxygen_level": {
+        "address": 2421,
+        "kind": "input",
+        "raw": 210,
+        "value": 21.0,
+        "unit": "%"
+      },
+      "return_flow_booster_pump": {
+        "address": 2422,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "outdoor_temperature_external": {
+        "address": 33406,
+        "kind": "holding",
+        "raw": -9999,
+        "value": -999.9,
+        "unit": "°C"
+      },
+      "sweep_function_start_stop": {
+        "address": 33410,
+        "kind": "holding",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "sweep_function_extend": {
+        "address": 33411,
+        "kind": "holding",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "pellet_usage_reset": {
+        "address": 33412,
+        "kind": "holding",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      }
+    }
+  }
+}

--- a/tests/fixtures/therminator.json
+++ b/tests/fixtures/therminator.json
@@ -1,0 +1,310 @@
+{
+  "meta": {
+    "system": "Ecotop",
+    "api_version": "26.020"
+  },
+  "components": {
+    "heating_circuits.1": {
+      "supply_temperature": {
+        "address": 1100,
+        "kind": "input",
+        "raw": 226,
+        "value": 22.6,
+        "unit": "°C"
+      },
+      "room_temperature": {
+        "address": 1101,
+        "kind": "input",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "humidity": {
+        "address": 1102,
+        "kind": "input",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "%"
+      },
+      "limit_thermostat": {
+        "address": 1103,
+        "kind": "input",
+        "raw": 1,
+        "value": true,
+        "unit": null
+      },
+      "circulator_pump": {
+        "address": 1105,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "mixer_valve": {
+        "address": 1106,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": "%"
+      },
+      "state": {
+        "address": 1107,
+        "kind": "input",
+        "raw": 214,
+        "value": 214,
+        "unit": null
+      },
+      "target_supply_temperature": {
+        "address": 32600,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "cooling": {
+        "address": 32602,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      },
+      "mode": {
+        "address": 32603,
+        "kind": "holding",
+        "raw": 2,
+        "value": 2,
+        "unit": null
+      },
+      "target_room_temperature": {
+        "address": 32605,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "indoor_temperature_external": {
+        "address": 32606,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "indoor_humidity_external": {
+        "address": 32607,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "%"
+      },
+      "heating_mode": {
+        "address": 32608,
+        "kind": "holding",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      }
+    },
+    "buffers.1": {
+      "top_temperature": {
+        "address": 1900,
+        "kind": "input",
+        "raw": 226,
+        "value": 22.6,
+        "unit": "°C"
+      },
+      "bottom_temperature": {
+        "address": 1901,
+        "kind": "input",
+        "raw": 221,
+        "value": 22.1,
+        "unit": "°C"
+      },
+      "pump": {
+        "address": 1903,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "state": {
+        "address": 1904,
+        "kind": "input",
+        "raw": 201,
+        "value": 201,
+        "unit": null
+      },
+      "mode": {
+        "address": 1905,
+        "kind": "input",
+        "raw": 1,
+        "value": 1,
+        "unit": null
+      }
+    },
+    "boilers.1": {
+      "temperature": {
+        "address": 500,
+        "kind": "input",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "state": {
+        "address": 501,
+        "kind": "input",
+        "raw": 200,
+        "value": 200,
+        "unit": null
+      },
+      "mode": {
+        "address": 502,
+        "kind": "input",
+        "raw": 3,
+        "value": 3,
+        "unit": null
+      },
+      "target_temperature": {
+        "address": 32000,
+        "kind": "holding",
+        "raw": 550,
+        "value": 55.0,
+        "unit": "°C"
+      },
+      "single_charge": {
+        "address": 32001,
+        "kind": "holding",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "holding_mode": {
+        "address": 32002,
+        "kind": "holding",
+        "raw": 3,
+        "value": 3,
+        "unit": null
+      },
+      "circulation": {
+        "address": 32003,
+        "kind": "holding",
+        "raw": -1,
+        "value": true,
+        "unit": null
+      }
+    },
+    "biomass_boiler": {
+      "temperature": {
+        "address": 2400,
+        "kind": "input",
+        "raw": 219,
+        "value": 21.9,
+        "unit": "°C"
+      },
+      "status": {
+        "address": 2401,
+        "kind": "input",
+        "raw": 301,
+        "value": 301,
+        "unit": null
+      },
+      "time_of_operation_at_maintenance": {
+        "address": 2402,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": "min"
+      },
+      "message_number": {
+        "address": 2404,
+        "kind": "input",
+        "raw": 0,
+        "value": 0,
+        "unit": null
+      },
+      "door_contact": {
+        "address": 2405,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "cleaning": {
+        "address": 2406,
+        "kind": "input",
+        "raw": 94,
+        "value": 94,
+        "unit": "%"
+      },
+      "ash_container": {
+        "address": 2407,
+        "kind": "input",
+        "raw": -999,
+        "value": -999,
+        "unit": "%"
+      },
+      "outdoor_temperature": {
+        "address": 2408,
+        "kind": "input",
+        "raw": 221,
+        "value": 22.1,
+        "unit": "°C"
+      },
+      "return_temperature": {
+        "address": 2410,
+        "kind": "input",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "°C"
+      },
+      "pellet_usage_last_fill": {
+        "address": 2414,
+        "kind": "input",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "kg"
+      },
+      "pellet_usage_total": {
+        "address": 2416,
+        "kind": "input",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "kg"
+      },
+      "heat_energy_total": {
+        "address": 2418,
+        "kind": "input",
+        "raw": 0,
+        "value": 0.0,
+        "unit": "kWh"
+      },
+      "sweep_almost_done": {
+        "address": 2420,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "residual_oxygen_level": {
+        "address": 2421,
+        "kind": "input",
+        "raw": 210,
+        "value": 21.0,
+        "unit": "%"
+      },
+      "return_flow_booster_pump": {
+        "address": 2422,
+        "kind": "input",
+        "raw": 0,
+        "value": false,
+        "unit": null
+      },
+      "outdoor_temperature_external": {
+        "address": 33406,
+        "kind": "holding",
+        "raw": -9999,
+        "value": -999.9,
+        "unit": "°C"
+      }
+    }
+  }
+}

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -19,8 +19,11 @@ switches a circuit that is off back on, see the module docstring of climate.py.
 
 from unittest.mock import MagicMock, patch
 
-from pysolarfocus import ApiVersions
+from aiosolarfocus import ApiVersion, ComponentId
 import pytest
+from pytest_homeassistant_custom_component.common import (
+    mock_restore_cache_with_extra_data,
+)
 
 from custom_components.solarfocus.climate import (
     CLIMATE_TYPES,
@@ -32,7 +35,6 @@ from custom_components.solarfocus.climate import (
 from custom_components.solarfocus.const import (
     HEATING_CIRCUIT_COMPONENT,
     HEATING_CIRCUIT_COMPONENT_PREFIX,
-    HEATING_CIRCUIT_PREFIX,
 )
 from custom_components.solarfocus.entity import SolarfocusEntity, create_description
 from homeassistant.components.climate.const import (
@@ -45,9 +47,13 @@ from homeassistant.components.climate.const import (
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import State
 
-from pytest_homeassistant_custom_component.common import mock_restore_cache_with_extra_data
-
-from .conftest import build_api, build_config_entry, build_coordinator
+from .conftest import (
+    build_client,
+    build_config_entry,
+    build_coordinator,
+    set_reading,
+    written_by_name,
+)
 
 # The registers the specification requires to be written together.
 REGISTERS = ("target_supply_temperature", "cooling", "mode", "heating_mode")
@@ -62,27 +68,31 @@ MODE_OFF = 3
 
 
 def build_climate(
-    api_version: ApiVersions = ApiVersions.V_23_020,
+    api_version: ApiVersion = ApiVersion.V_23_020,
     state: int = STATE_HEATING,
     mode: int = MODE_CONTINUOUS,
     cooling: int = 0,
     target_supply_temperature: float = 38.0,
 ) -> SolarfocusClimateEntity:
-    """Return a thermostat for heating circuit 1 over a mocked heating circuit."""
-    api = build_api()
-    api.api_version = api_version
+    """Return a thermostat for heating circuit 1 over a fake controller."""
+    entry = build_config_entry(api_version=api_version.label, heating_circuit=1)
+    client = build_client(entry)
 
-    circuit = api.heating_circuits[0]
-    circuit.state.scaled_value = state
-    circuit.mode.scaled_value = mode
-    circuit.cooling.scaled_value = cooling
-    circuit.target_supply_temperature.scaled_value = target_supply_temperature
-    circuit.supply_temperature.scaled_value = 36.5
+    set_reading(client, ComponentId.HEATING_CIRCUITS, "state", state)
+    set_reading(client, ComponentId.HEATING_CIRCUITS, "mode", mode)
+    set_reading(client, ComponentId.HEATING_CIRCUITS, "cooling", cooling)
+    set_reading(
+        client,
+        ComponentId.HEATING_CIRCUITS,
+        "target_supply_temperature",
+        target_supply_temperature,
+    )
+    set_reading(client, ComponentId.HEATING_CIRCUITS, "supply_temperature", 36.5)
 
     entity = SolarfocusClimateEntity(
-        build_coordinator(build_config_entry(), api),
+        build_coordinator(entry, client),
         create_description(
-                        HEATING_CIRCUIT_COMPONENT,
+            HEATING_CIRCUIT_COMPONENT,
             HEATING_CIRCUIT_COMPONENT_PREFIX,
             "1",
             CLIMATE_TYPES[0],
@@ -92,9 +102,13 @@ def build_climate(
     return entity
 
 
-def written(set_value: MagicMock) -> dict[str, float]:
-    """Return the registers a call wrote, keyed by their item name."""
-    return {call.args[0]: call.args[1] for call in set_value.call_args_list}
+def written(climate: SolarfocusClimateEntity) -> dict[str, float]:
+    """Return the registers the thermostat wrote, keyed by their name.
+
+    They go out as one grouped write now, so what a test watches is the wire
+    rather than a call of the entity's own setter per register.
+    """
+    return written_by_name(climate.coordinator.client, ComponentId.HEATING_CIRCUITS)
 
 
 @pytest.fixture(name="climate")
@@ -108,10 +122,9 @@ def climate_fixture() -> SolarfocusClimateEntity:
 
 async def test_heating_writes_every_register(climate) -> None:
     """6.2.1, the circuit is switched to heating."""
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_set_hvac_mode(HVACMode.HEAT)
+    await climate.async_set_hvac_mode(HVACMode.HEAT)
 
-    assert written(set_value) == {
+    assert written(climate) == {
         "target_supply_temperature": 38.0,
         "cooling": 0,
         "mode": MODE_CONTINUOUS,
@@ -121,10 +134,9 @@ async def test_heating_writes_every_register(climate) -> None:
 
 async def test_cooling_writes_every_register(climate) -> None:
     """6.2.2, the circuit is switched to cooling."""
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_set_hvac_mode(HVACMode.COOL)
+    await climate.async_set_hvac_mode(HVACMode.COOL)
 
-    assert written(set_value) == {
+    assert written(climate) == {
         # No cooling setpoint has been set yet, a heating one must not be reused
         "target_supply_temperature": DEFAULT_TARGET_TEMPERATURE[HVACMode.COOL],
         "cooling": 1,
@@ -135,10 +147,9 @@ async def test_cooling_writes_every_register(climate) -> None:
 
 async def test_off_writes_every_register(climate) -> None:
     """6.2.3, the circuit is switched off, including the setpoint of 0."""
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_set_hvac_mode(HVACMode.OFF)
+    await climate.async_set_hvac_mode(HVACMode.OFF)
 
-    assert written(set_value) == {
+    assert written(climate) == {
         "target_supply_temperature": 0,
         "cooling": 0,
         "mode": MODE_OFF,
@@ -151,10 +162,9 @@ async def test_off_writes_every_register(climate) -> None:
 )
 async def test_no_register_is_left_out(climate, hvac_mode: HVACMode) -> None:
     """The specification requires all four registers on every transition."""
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_set_hvac_mode(hvac_mode)
+    await climate.async_set_hvac_mode(hvac_mode)
 
-    assert set(written(set_value)) == set(REGISTERS)
+    assert set(written(climate)) == set(REGISTERS)
 
 
 # --- the preset deviation ----------------------------------------------------
@@ -164,20 +174,18 @@ async def test_switching_on_keeps_the_configured_preset() -> None:
     """A circuit on an auto schedule keeps it when the mode is switched."""
     climate = build_climate(mode=MODE_AUTO)
 
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_set_hvac_mode(HVACMode.COOL)
+    await climate.async_set_hvac_mode(HVACMode.COOL)
 
-    assert written(set_value)["mode"] == MODE_AUTO
+    assert written(climate)["mode"] == MODE_AUTO
 
 
 async def test_switching_on_a_circuit_that_is_off_selects_continuous() -> None:
     """A circuit that is switched off has to be switched back on."""
     climate = build_climate(state=STATE_OFF, mode=MODE_OFF)
 
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_set_hvac_mode(HVACMode.HEAT)
+    await climate.async_set_hvac_mode(HVACMode.HEAT)
 
-    assert written(set_value)["mode"] == MODE_CONTINUOUS
+    assert written(climate)["mode"] == MODE_CONTINUOUS
 
 
 # --- api versions ------------------------------------------------------------
@@ -185,8 +193,8 @@ async def test_switching_on_a_circuit_that_is_off_selects_continuous() -> None:
 
 async def test_cooling_needs_api_version_22_090() -> None:
     """Register 32608 does not exist below 22.090, so cooling is not offered."""
-    old = build_climate(api_version=ApiVersions.V_21_140)
-    new = build_climate(api_version=ApiVersions.V_22_090)
+    old = build_climate(api_version=ApiVersion.V_21_140)
+    new = build_climate(api_version=ApiVersion.V_22_090)
 
     assert old.hvac_modes == [HVACMode.OFF, HVACMode.HEAT]
     assert new.hvac_modes == [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL]
@@ -194,12 +202,11 @@ async def test_cooling_needs_api_version_22_090() -> None:
 
 async def test_heating_mode_is_not_written_below_22_090() -> None:
     """Writing a register the api version does not have raises AttributeError."""
-    climate = build_climate(api_version=ApiVersions.V_21_140)
+    climate = build_climate(api_version=ApiVersion.V_21_140)
 
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_set_hvac_mode(HVACMode.HEAT)
+    await climate.async_set_hvac_mode(HVACMode.HEAT)
 
-    assert "heating_mode" not in written(set_value)
+    assert "heating_mode" not in written(climate)
 
 
 async def test_a_cooling_circuit_reports_cooling() -> None:
@@ -211,7 +218,7 @@ async def test_a_cooling_circuit_reports_cooling() -> None:
 
 async def test_an_old_circuit_never_reports_cooling() -> None:
     """Below 22.090 the cooling register is not part of the mode."""
-    climate = build_climate(api_version=ApiVersions.V_21_140, cooling=1)
+    climate = build_climate(api_version=ApiVersion.V_21_140, cooling=1)
 
     assert climate.hvac_mode == HVACMode.HEAT
 
@@ -221,64 +228,55 @@ async def test_an_old_circuit_never_reports_cooling() -> None:
 
 async def test_the_setpoint_survives_being_switched_off(climate) -> None:
     """Switching off writes 0, switching back on restores the setpoint."""
-    with patch.object(climate, "_set_native_value"):
-        await climate.async_set_temperature(**{ATTR_TEMPERATURE: 41.5})
+    await climate.async_set_temperature(**{ATTR_TEMPERATURE: 41.5})
 
     # The circuit is off, register 32600 reads 0
     climate.coordinator.api.heating_circuits[0].target_supply_temperature.scaled_value = 0
     climate.coordinator.api.heating_circuits[0].state.scaled_value = STATE_OFF
 
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_set_hvac_mode(HVACMode.HEAT)
+    await climate.async_set_hvac_mode(HVACMode.HEAT)
 
-    assert written(set_value)["target_supply_temperature"] == 41.5
+    assert written(climate)["target_supply_temperature"] == 41.5
 
 
 async def test_each_mode_keeps_its_own_setpoint(climate) -> None:
     """A heating setpoint is far outside the cooling range and vice versa."""
-    with patch.object(climate, "_set_native_value"):
-        await climate.async_set_temperature(**{ATTR_TEMPERATURE: 41.5})
+    await climate.async_set_temperature(**{ATTR_TEMPERATURE: 41.5})
 
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_set_hvac_mode(HVACMode.COOL)
-    assert written(set_value)["target_supply_temperature"] == 19.0
+    await climate.async_set_hvac_mode(HVACMode.COOL)
+    assert written(climate)["target_supply_temperature"] == 19.0
 
     climate.coordinator.api.heating_circuits[0].cooling.scaled_value = 1
-    with patch.object(climate, "_set_native_value"):
-        await climate.async_set_temperature(**{ATTR_TEMPERATURE: 18.0})
+    await climate.async_set_temperature(**{ATTR_TEMPERATURE: 18.0})
 
     climate.coordinator.api.heating_circuits[0].cooling.scaled_value = 0
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_set_hvac_mode(HVACMode.COOL)
+    await climate.async_set_hvac_mode(HVACMode.COOL)
 
-    assert written(set_value)["target_supply_temperature"] == 18.0
+    assert written(climate)["target_supply_temperature"] == 18.0
 
 
 async def test_setting_a_temperature_while_off_only_remembers_it() -> None:
     """Register 32600 has to stay 0 while the circuit is switched off."""
     climate = build_climate(state=STATE_OFF, target_supply_temperature=0)
 
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_set_temperature(**{ATTR_TEMPERATURE: 40.0})
+    await climate.async_set_temperature(**{ATTR_TEMPERATURE: 40.0})
 
-    assert not set_value.called
+    assert not written(climate)
     assert climate.target_temperature == 40.0
 
 
 async def test_setting_a_temperature_writes_the_setpoint(climate) -> None:
     """A running circuit takes the setpoint immediately."""
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_set_temperature(**{ATTR_TEMPERATURE: 42.0})
+    await climate.async_set_temperature(**{ATTR_TEMPERATURE: 42.0})
 
-    assert written(set_value) == {"target_supply_temperature": 42.0}
+    assert written(climate) == {"target_supply_temperature": 42.0}
 
 
 async def test_a_call_without_a_temperature_writes_nothing(climate) -> None:
     """The service can be called with other attributes only."""
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_set_temperature(hvac_mode=HVACMode.HEAT)
+    await climate.async_set_temperature(hvac_mode=HVACMode.HEAT)
 
-    assert not set_value.called
+    assert not written(climate)
 
 
 async def test_the_setpoint_of_a_switched_off_circuit_is_the_remembered_one() -> None:
@@ -295,8 +293,7 @@ async def test_switching_to_cooling_warns_about_the_dew_point(
     climate, caplog: pytest.LogCaptureFixture
 ) -> None:
     """The controller stops watching the dew point once 32602 is written."""
-    with patch.object(climate, "_set_native_value"):
-        await climate.async_set_hvac_mode(HVACMode.COOL)
+    await climate.async_set_hvac_mode(HVACMode.COOL)
 
     assert "dew point" in caplog.text
     assert "condensation" in caplog.text
@@ -306,9 +303,8 @@ async def test_the_dew_point_warning_is_logged_once(
     climate, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A thermostat in cooling mode must not warn on every service call."""
-    with patch.object(climate, "_set_native_value"):
-        await climate.async_set_hvac_mode(HVACMode.COOL)
-        await climate.async_set_hvac_mode(HVACMode.COOL)
+    await climate.async_set_hvac_mode(HVACMode.COOL)
+    await climate.async_set_hvac_mode(HVACMode.COOL)
 
     warnings = [record for record in caplog.records if record.levelname == "WARNING"]
     assert len(warnings) == 1
@@ -316,8 +312,7 @@ async def test_the_dew_point_warning_is_logged_once(
 
 async def test_heating_does_not_warn(climate, caplog: pytest.LogCaptureFixture) -> None:
     """Heating leaves the dew point monitoring of the controller alone."""
-    with patch.object(climate, "_set_native_value"):
-        await climate.async_set_hvac_mode(HVACMode.HEAT)
+    await climate.async_set_hvac_mode(HVACMode.HEAT)
 
     assert "dew point" not in caplog.text
 
@@ -360,10 +355,9 @@ def test_preset_mode(mode: int, preset: str) -> None:
 )
 async def test_set_preset_mode(climate, preset: str, expected: int) -> None:
     """Selecting a preset writes the numeric mode."""
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_set_preset_mode(preset)
+    await climate.async_set_preset_mode(preset)
 
-    assert set_value.call_args_list == [(("mode", expected),)]
+    assert written(climate) == {"mode": expected}
 
 
 @pytest.mark.parametrize(
@@ -380,11 +374,17 @@ def test_temperature_range_follows_cooling(
 
 
 def test_temperatures() -> None:
-    """The thermostat works on the supply temperature."""
+    """The thermostat works on the supply temperature.
+
+    Register 32600 holds tenths of a degree, so 40.123 is not a reading it can
+    give: the library rounds to the precision the scale carries, where the
+    predecessor passed `40.123000000000005` through for Home Assistant to
+    record.
+    """
     climate = build_climate(target_supply_temperature=40.123)
 
     assert climate.current_temperature == 36.5
-    assert climate.target_temperature == 40.12
+    assert climate.target_temperature == 40.1
     assert climate.temperature_unit == UnitOfTemperature.CELSIUS
 
 
@@ -398,8 +398,7 @@ def test_supported_features_include_the_setpoint(climate) -> None:
 
 async def test_setpoints_are_stored_for_a_restart(climate) -> None:
     """The remembered setpoints are written to the restore state."""
-    with patch.object(climate, "_set_native_value"):
-        await climate.async_set_temperature(**{ATTR_TEMPERATURE: 41.5})
+    await climate.async_set_temperature(**{ATTR_TEMPERATURE: 41.5})
 
     assert climate.extra_restore_state_data.as_dict() == {
         "target_temperatures": {"heat": 41.5},
@@ -445,39 +444,37 @@ async def test_a_first_start_has_nothing_to_restore(climate) -> None:
 
 async def test_turn_off(climate) -> None:
     """Turning off is the off state of the specification."""
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_turn_off()
+    await climate.async_turn_off()
 
-    assert written(set_value)["mode"] == MODE_OFF
-    assert written(set_value)["target_supply_temperature"] == 0
+    assert written(climate)["mode"] == MODE_OFF
+    assert written(climate)["target_supply_temperature"] == 0
 
 
 async def test_turn_on_heats(climate) -> None:
     """Turning on never starts cooling on its own."""
-    with patch.object(climate, "_set_native_value") as set_value:
-        await climate.async_turn_on()
+    await climate.async_turn_on()
 
-    assert written(set_value)["cooling"] == 0
+    assert written(climate)["cooling"] == 0
 
 
 # --- wiring ------------------------------------------------------------------
 
 
 async def test_the_thermostat_restores_its_setpoint_from_storage(
-    hass, enable_custom_integrations, mock_api, api
+    hass, enable_custom_integrations, mock_client
 ) -> None:
     """A restart must not lose the setpoint of a circuit that is switched off.
 
     Goes through the platform rather than calling async_added_to_hass directly,
     so that the restore is exercised the way Home Assistant drives it.
     """
-    circuit = api.heating_circuits[0]
-    circuit.state.scaled_value = STATE_OFF
-    circuit.mode.scaled_value = MODE_OFF
-    circuit.cooling.scaled_value = 0
+    circuit = ComponentId.HEATING_CIRCUITS
+    mock_client.reads(circuit, "state", STATE_OFF)
+    mock_client.reads(circuit, "mode", MODE_OFF)
+    mock_client.reads(circuit, "cooling", 0)
     # The circuit is switched off, so register 32600 reads 0
-    circuit.target_supply_temperature.scaled_value = 0
-    circuit.supply_temperature.scaled_value = 21.0
+    mock_client.reads(circuit, "target_supply_temperature", 0)
+    mock_client.reads(circuit, "supply_temperature", 21.0)
 
     mock_restore_cache_with_extra_data(
         hass,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,7 +6,7 @@ quality scale (issue #125): every step, every error path and the options flow.
 
 from unittest.mock import patch
 
-from pysolarfocus import ApiVersions, Systems
+from aiosolarfocus import ApiVersion, Systems
 import pytest
 
 from custom_components.solarfocus.config_flow import (
@@ -50,7 +50,7 @@ USER_INPUT = {
     CONF_PORT: 502,
     CONF_SCAN_INTERVAL: 10,
     CONF_SOLARFOCUS_SYSTEM: Systems.VAMPAIR,
-    CONF_API_VERSION: ApiVersions.V_23_020.value,
+    CONF_API_VERSION: ApiVersion.V_23_020.label,
 }
 
 VAMPAIR_COMPONENTS = {
@@ -103,7 +103,7 @@ async def test_form_shown_without_input(
 
 @pytest.mark.parametrize("step", ["user", "reconfigure"])
 async def test_every_api_version_of_the_library_is_offered(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, step: str
+    hass: HomeAssistant, enable_custom_integrations, mock_client, step: str
 ) -> None:
     """Regression test for #218: 25.100 was missing from the hand-kept list.
 
@@ -123,8 +123,11 @@ async def test_every_api_version_of_the_library_is_offered(
 
     versions = _offered_api_versions(result)
 
-    assert versions == [api_version.value for api_version in reversed(ApiVersions)]
-    assert ApiVersions.V_25_100.value in versions
+    # `label`, not `value`: an `ApiVersion` is numbered so that `>=` is the
+    # comparison the register table needs, and the entry stores the version
+    # the way the controller prints it on its own screen.
+    assert versions == [api_version.label for api_version in reversed(ApiVersion)]
+    assert ApiVersion.V_25_100.label in versions
 
 
 def _offered_api_versions(result) -> list[str]:
@@ -137,11 +140,11 @@ def _offered_api_versions(result) -> list[str]:
 
 
 async def test_a_newly_offered_api_version_can_be_chosen(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The version the selector gained is the version the entry ends up on."""
     result = await _start_user_step(
-        hass, {**USER_INPUT, CONF_API_VERSION: ApiVersions.V_25_100.value}
+        hass, {**USER_INPUT, CONF_API_VERSION: ApiVersion.V_25_100.label}
     )
 
     with patch("custom_components.solarfocus.async_setup_entry", return_value=True):
@@ -151,11 +154,11 @@ async def test_a_newly_offered_api_version_can_be_chosen(
         await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_API_VERSION] == ApiVersions.V_25_100.value
+    assert result["data"][CONF_API_VERSION] == ApiVersion.V_25_100.label
 
 
 async def test_full_flow_vampair(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """A vampair system is stored with the heat pump enabled."""
     result = await _start_user_step(hass, USER_INPUT)
@@ -180,7 +183,7 @@ async def test_full_flow_vampair(
         CONF_SOLARFOCUS_SYSTEM: Systems.VAMPAIR,
         CONF_HOST: "solarfocus.local",
         CONF_PORT: 502,
-        CONF_API_VERSION: ApiVersions.V_23_020.value,
+        CONF_API_VERSION: ApiVersion.V_23_020.label,
     }
     assert result["options"] == {
         CONF_SCAN_INTERVAL: 10,
@@ -215,7 +218,7 @@ async def test_full_flow_vampair(
     ],
 )
 async def test_full_flow_biomass_systems(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, system: Systems
+    hass: HomeAssistant, enable_custom_integrations, mock_client, system: Systems
 ) -> None:
     """Biomass systems are stored with the heat pump disabled."""
     result = await _start_user_step(hass, {**USER_INPUT, CONF_SOLARFOCUS_SYSTEM: system})
@@ -240,10 +243,10 @@ async def test_full_flow_biomass_systems(
 
 
 async def test_form_cannot_connect(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """A device that does not answer keeps the user on the first step."""
-    api.connect.return_value = False
+    mock_client.offline()
 
     result = await _start_user_step(hass, USER_INPUT)
 
@@ -253,14 +256,14 @@ async def test_form_cannot_connect(
 
 
 async def test_form_recovers_after_connection_error(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The user can retry once the device is reachable."""
-    api.connect.return_value = False
+    mock_client.offline()
     result = await _start_user_step(hass, USER_INPUT)
     assert result["errors"] == {"base": "cannot_connect"}
 
-    api.connect.return_value = True
+    mock_client.online()
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], USER_INPUT
     )
@@ -296,7 +299,7 @@ async def test_form_unknown_error(
 
 
 async def test_form_scan_interval_below_minimum(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """A scan interval below five seconds is reported on the field it is in.
 
@@ -311,7 +314,7 @@ async def test_form_scan_interval_below_minimum(
 
 
 async def test_entry_is_identified_by_its_address(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The address the controller is reached at identifies the entry."""
     result = await _start_user_step(hass, USER_INPUT)
@@ -327,7 +330,7 @@ async def test_entry_is_identified_by_its_address(
 
 
 async def test_the_same_system_cannot_be_added_twice(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """A second entry for the same address would poll one system twice."""
     build_config_entry().add_to_hass(hass)
@@ -339,7 +342,7 @@ async def test_the_same_system_cannot_be_added_twice(
 
 
 async def test_a_second_system_can_be_added(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """A different address is a different heating system."""
     build_config_entry().add_to_hass(hass)
@@ -353,7 +356,7 @@ async def test_a_second_system_can_be_added(
 
 
 async def test_a_second_system_may_share_the_name_of_the_first(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """Nothing of an entry is identified by its name any more.
 
@@ -371,7 +374,7 @@ async def test_a_second_system_may_share_the_name_of_the_first(
 
 
 async def test_a_different_port_is_a_different_system(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """Two controllers can sit behind one address on different ports."""
     build_config_entry().add_to_hass(hass)
@@ -385,24 +388,24 @@ async def test_a_different_port_is_a_different_system(
 
 
 async def test_validate_input_raises_cannot_connect(
-    hass: HomeAssistant, mock_api, api
+    hass: HomeAssistant, mock_client
 ) -> None:
     """Validate_input surfaces a failed connection."""
-    api.connect.return_value = False
+    mock_client.offline()
 
     with pytest.raises(CannotConnect):
         await validate_input(hass, USER_INPUT)
 
 
 async def test_validate_input_raises_invalid_scan_interval(
-    hass: HomeAssistant, mock_api
+    hass: HomeAssistant, mock_client
 ) -> None:
     """Validate_input enforces the minimum scan interval."""
     with pytest.raises(InvalidScanInterval):
         await validate_input(hass, {**USER_INPUT, CONF_SCAN_INTERVAL: 4})
 
 
-async def test_validate_input_returns_title(hass: HomeAssistant, mock_api) -> None:
+async def test_validate_input_returns_title(hass: HomeAssistant, mock_client) -> None:
     """Validate_input returns the entry title on success."""
     assert await validate_input(hass, USER_INPUT) == {"title": DEFAULT_NAME}
 
@@ -411,7 +414,7 @@ async def test_validate_input_returns_title(hass: HomeAssistant, mock_api) -> No
     "system", [Systems.VAMPAIR, Systems.THERMINATOR, Systems.ECOTOP]
 )
 async def test_options_flow_form(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, system: Systems
+    hass: HomeAssistant, enable_custom_integrations, mock_client, system: Systems
 ) -> None:
     """Each system gets an options form prefilled from the stored options."""
     entry = build_config_entry(system, heating_circuit=1, buffer=1, boiler=1)
@@ -439,7 +442,7 @@ OPTIONS_INPUT = {
 
 
 async def test_options_flow_updates_options(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """Submitting the options form stores the new values."""
     entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
@@ -461,7 +464,7 @@ async def test_options_flow_updates_options(
 
 
 async def test_the_options_form_does_not_ask_for_the_connection(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """Where the system is belongs to the entry data and the reconfigure flow.
 
@@ -482,7 +485,7 @@ async def test_the_options_form_does_not_ask_for_the_connection(
 
 
 async def test_saving_options_leaves_the_connection_alone(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The data of the entry is not the options flow's to write."""
     entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
@@ -502,7 +505,7 @@ async def test_saving_options_leaves_the_connection_alone(
 
 
 async def test_a_legacy_duplicate_can_still_edit_its_options(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The migration leaves one of two entries for a system without a unique id.
 
@@ -529,7 +532,7 @@ async def test_a_legacy_duplicate_can_still_edit_its_options(
 
 
 async def test_options_flow_biomass_system_disables_heatpump(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """A therminator keeps the biomass boiler flag and never enables the heat pump."""
     entry = build_config_entry(
@@ -568,7 +571,7 @@ RECONFIGURE_INPUT = {
     CONF_HOST: "10.0.0.5",
     CONF_PORT: 503,
     CONF_SCAN_INTERVAL: 30,
-    CONF_API_VERSION: ApiVersions.V_25_030.value,
+    CONF_API_VERSION: ApiVersion.V_25_030.label,
 }
 
 
@@ -581,7 +584,7 @@ async def _start_reconfigure(hass: HomeAssistant, entry) -> dict:
 
 
 async def test_reconfigure_form_starts_from_the_current_connection(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The form is for correcting an address, so it starts at the current one."""
     entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
@@ -601,7 +604,7 @@ async def test_reconfigure_form_starts_from_the_current_connection(
 
 
 async def test_reconfigure_moves_the_entry_and_its_unique_id(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The address is the unique id, so changing one changes the other."""
     entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
@@ -621,12 +624,12 @@ async def test_reconfigure_moves_the_entry_and_its_unique_id(
     assert entry.data[CONF_HOST] == "10.0.0.5"
     assert entry.data[CONF_PORT] == 503
     assert entry.options[CONF_SCAN_INTERVAL] == 30
-    assert entry.data[CONF_API_VERSION] == ApiVersions.V_25_030.value
+    assert entry.data[CONF_API_VERSION] == ApiVersion.V_25_030.label
     assert entry.unique_id == "10.0.0.5:503"
 
 
 async def test_reconfigure_reloads_the_entry_once(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """Saving the new address is what reloads the entry, and only that.
 
@@ -652,7 +655,7 @@ async def test_reconfigure_reloads_the_entry_once(
 
 
 async def test_reconfigure_leaves_the_components_alone(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The component layout belongs to the other form.
 
@@ -676,7 +679,7 @@ async def test_reconfigure_leaves_the_components_alone(
 
 
 async def test_reconfigure_changes_the_system(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """Regression test for #217.
 
@@ -702,7 +705,7 @@ async def test_reconfigure_changes_the_system(
 
 
 async def test_reconfigure_starts_from_the_current_system(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The system is being corrected, not chosen again from scratch."""
     entry = build_config_entry(Systems.ECOTOP, biomassboiler=True)
@@ -718,7 +721,7 @@ async def test_reconfigure_starts_from_the_current_system(
 
 
 async def test_reconfigure_between_biomass_systems_keeps_the_heat_source(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """Both have a biomass boiler, so there is nothing to switch over.
 
@@ -742,7 +745,7 @@ async def test_reconfigure_between_biomass_systems_keeps_the_heat_source(
 
 
 async def test_reconfigure_to_a_heat_pump_switches_the_heat_source(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The component step only ever offers the heat source the system has.
 
@@ -766,7 +769,7 @@ async def test_reconfigure_to_a_heat_pump_switches_the_heat_source(
 
 
 async def test_reconfigure_to_a_biomass_system_switches_the_heat_source(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """And the same crossing the other way."""
     entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
@@ -784,7 +787,7 @@ async def test_reconfigure_to_a_biomass_system_switches_the_heat_source(
 
 
 async def test_reconfigure_refuses_the_address_of_another_entry(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """Two entries on one controller is what the unique id is there to stop."""
     other = build_config_entry(Systems.VAMPAIR, host="10.0.0.5", port=503)
@@ -803,13 +806,13 @@ async def test_reconfigure_refuses_the_address_of_another_entry(
 
 
 async def test_reconfigure_reports_a_system_it_cannot_reach(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """An address that answers nothing is the mistake this form is for."""
     entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
     entry.add_to_hass(hass)
 
-    api.connect.return_value = False
+    mock_client.offline()
 
     result = await _start_reconfigure(hass, entry)
     result = await hass.config_entries.flow.async_configure(
@@ -822,7 +825,7 @@ async def test_reconfigure_reports_a_system_it_cannot_reach(
 
 
 async def test_reconfigure_rejects_a_polling_interval_below_five(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The same floor the user step enforces, reported on the field itself."""
     entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
@@ -838,7 +841,7 @@ async def test_reconfigure_rejects_a_polling_interval_below_five(
 
 
 async def test_reconfigure_keeps_a_duplicate_entry_without_a_unique_id(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The migration left it without one on purpose, see #185.
 
@@ -862,7 +865,7 @@ async def test_reconfigure_keeps_a_duplicate_entry_without_a_unique_id(
 
 
 async def test_reconfigure_reports_an_unexpected_failure(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """Anything the library raises is the user's problem to see, not a traceback."""
     entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)
@@ -884,7 +887,7 @@ async def test_reconfigure_reports_an_unexpected_failure(
 
 
 async def test_options_flow_scan_interval_below_minimum(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The options form has the same floor, and reports it the same way."""
     entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, heatpump=True)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,9 +1,16 @@
-"""Test the Solarfocus data update coordinator."""
+"""Test the Solarfocus data update coordinator.
+
+The library reports a failed refresh in two different ways, and the whole point
+of this file is that the coordinator keeps them apart: a connection that is not
+there raises, because that says nothing about any component, and everything
+else - a range this firmware refuses, an exception response - is attributed to
+the components whose registers were in that read.
+"""
 
 from datetime import timedelta
 import logging
 
-from pysolarfocus import ApiVersions
+from aiosolarfocus import ApiVersion, ComponentId, SolarfocusConnectionError, Systems
 import pytest
 
 from custom_components.solarfocus.const import (
@@ -25,85 +32,97 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from .conftest import build_api, build_config_entry
+from .conftest import build_client, build_config_entry, controller_of, revive, silence
 
 # The api version that has every component of the table below - the circulation
 # and the differential module arrived in it, and the entries the tests build
 # are older than that by default.
-EVERY_COMPONENT_VERSION = ApiVersions.V_25_030.value
+EVERY_COMPONENT_VERSION = ApiVersion.V_25_030.label
 
-# Config option -> the library call the coordinator has to make for it.
-COMPONENT_UPDATES = [
-    (CONF_HEATING_CIRCUIT, 1, "update_heating"),
-    (CONF_BUFFER, 1, "update_buffer"),
-    (CONF_BOILER, 1, "update_boiler"),
-    (CONF_HEATPUMP, True, "update_heatpump"),
-    (CONF_PHOTOVOLTAIC, True, "update_photovoltaic"),
-    (CONF_BIOMASS_BOILER, True, "update_biomassboiler"),
-    (CONF_SOLAR, 1, "update_solar"),
-    (CONF_FRESH_WATER_MODULE, 1, "update_fresh_water_modules"),
-    (CONF_CIRCULATION, 1, "update_circulation"),
-    (CONF_DIFFERENTIAL_MODULE, 1, "update_differential_modules"),
+# Config option -> what it is configured as, what the library calls it, and the
+# system that has it. The heat source is the one part of the layout the system
+# decides rather than the user, and the library refuses the combination the
+# config flow has never offered: a Vampair has the heat pump, everything else
+# has the biomass boiler.
+COMPONENTS = [
+    (CONF_HEATING_CIRCUIT, 1, ComponentId.HEATING_CIRCUITS, Systems.VAMPAIR),
+    (CONF_BUFFER, 1, ComponentId.BUFFERS, Systems.VAMPAIR),
+    (CONF_BOILER, 1, ComponentId.BOILERS, Systems.VAMPAIR),
+    (CONF_HEATPUMP, True, ComponentId.HEAT_PUMP, Systems.VAMPAIR),
+    (CONF_PHOTOVOLTAIC, True, ComponentId.PHOTOVOLTAIC, Systems.VAMPAIR),
+    (CONF_BIOMASS_BOILER, True, ComponentId.BIOMASS_BOILER, Systems.THERMINATOR),
+    (CONF_SOLAR, 1, ComponentId.SOLAR, Systems.VAMPAIR),
+    (CONF_FRESH_WATER_MODULE, 1, ComponentId.FRESH_WATER_MODULES, Systems.VAMPAIR),
+    (CONF_CIRCULATION, 1, ComponentId.CIRCULATIONS, Systems.VAMPAIR),
+    (CONF_DIFFERENTIAL_MODULE, 1, ComponentId.DIFFERENTIAL_MODULES, Systems.VAMPAIR),
 ]
 
-ALL_UPDATES = [update for _, _, update in COMPONENT_UPDATES]
+# Everything a vampair can have at once, which is everything but the heat
+# source it does not have.
+EVERY_VAMPAIR_COMPONENT = {
+    option: value
+    for option, value, _, _ in COMPONENTS
+    if option != CONF_BIOMASS_BOILER
+}
 
 
-def _coordinator(hass: HomeAssistant, api, **options) -> SolarfocusDataUpdateCoordinator:
-    """Create a coordinator for an entry with the given options."""
-    entry = build_config_entry(**options)
+def _coordinator(
+    hass: HomeAssistant, system: Systems = Systems.VAMPAIR, **options
+) -> SolarfocusDataUpdateCoordinator:
+    """Create a coordinator over a controller that is not real."""
+    entry = build_config_entry(system, **options)
     entry.add_to_hass(hass)
-    return SolarfocusDataUpdateCoordinator(hass, entry, api)
+
+    return SolarfocusDataUpdateCoordinator(hass, entry, build_client(entry))
 
 
-@pytest.mark.parametrize(("option", "value", "update"), COMPONENT_UPDATES)
+@pytest.mark.parametrize(("option", "value", "component", "system"), COMPONENTS)
 async def test_only_configured_components_are_polled(
-    hass: HomeAssistant, option: str, value, update: str
+    hass: HomeAssistant, option: str, value, component: ComponentId, system: Systems
 ) -> None:
     """A component that is not configured must not be read from the device."""
-    api = build_api()
     coordinator = _coordinator(
-        hass, api, api_version=EVERY_COMPONENT_VERSION, **{option: value}
+        hass, system, api_version=EVERY_COMPONENT_VERSION, **{option: value}
     )
 
     await coordinator._async_update_data()
 
-    assert getattr(api, update).called
-    for other in ALL_UPDATES:
-        if other != update:
-            assert not getattr(api, other).called, f"{other} was polled unexpectedly"
+    assert set(coordinator.client.components) == {
+        key for key in coordinator.client.components if key.id is component
+    }
+    assert coordinator.client.of(component)
 
 
 async def test_no_configured_components_polls_nothing(hass: HomeAssistant) -> None:
     """An entry without components does not talk to the device at all."""
-    api = build_api()
-    coordinator = _coordinator(hass, api)
+    coordinator = _coordinator(hass)
 
     await coordinator._async_update_data()
 
-    for update in ALL_UPDATES:
-        assert not getattr(api, update).called
+    assert not controller_of(coordinator.client).reads
 
 
 async def test_all_components_are_polled(hass: HomeAssistant) -> None:
     """Every configured component is refreshed on a single update."""
-    api = build_api()
     coordinator = _coordinator(
-        hass,
-        api,
-        api_version=EVERY_COMPONENT_VERSION,
-        **{option: value for option, value, _ in COMPONENT_UPDATES},
+        hass, api_version=EVERY_COMPONENT_VERSION, **EVERY_VAMPAIR_COMPONENT
     )
 
     await coordinator._async_update_data()
 
-    for update in ALL_UPDATES:
-        assert getattr(api, update).called
+    assert all(
+        component.available for component in coordinator.client.components.values()
+    )
+    assert {key.id for key in coordinator.client.components} == {
+        component
+        for option, _, component, _ in COMPONENTS
+        if option != CONF_BIOMASS_BOILER
+    }
 
 
 async def test_scan_interval_is_taken_from_the_options(hass: HomeAssistant) -> None:
     """The configured scan interval becomes the update interval."""
-    coordinator = _coordinator(hass, build_api(), scan_interval=42)
+    coordinator = _coordinator(hass, scan_interval=42)
 
     assert coordinator.update_interval == timedelta(seconds=42)
 
@@ -113,7 +132,7 @@ async def test_coordinator_keeps_the_entry(hass: HomeAssistant) -> None:
     entry = build_config_entry()
     entry.add_to_hass(hass)
 
-    coordinator = SolarfocusDataUpdateCoordinator(hass, entry, build_api())
+    coordinator = SolarfocusDataUpdateCoordinator(hass, entry, build_client(entry))
 
     assert coordinator._entry is entry
     # The coordinator is named after the integration, the device name entities
@@ -122,69 +141,52 @@ async def test_coordinator_keeps_the_entry(hass: HomeAssistant) -> None:
     assert entry.title == "Solarfocus"
 
 
-async def test_reconnects_before_updating(hass: HomeAssistant) -> None:
-    """A dropped connection is re-established on the next refresh."""
-    api = build_api()
-    coordinator = _coordinator(hass, api, heating_circuit=1)
+async def test_the_refresh_connects_on_its_own(hass: HomeAssistant) -> None:
+    """A dropped connection is re-established on the next refresh.
 
-    api.connect.reset_mock()
-    api.is_connected = False
-
-    await coordinator._async_update_data()
-
-    assert api.connect.called
-    assert api.update_heating.called
-
-
-async def test_does_not_reconnect_while_connected(hass: HomeAssistant) -> None:
-    """A healthy connection is reused."""
-    api = build_api()
-    coordinator = _coordinator(hass, api, heating_circuit=1)
-
-    api.connect.reset_mock()
+    `update` opens the socket if it is not open, so there is no connection flag
+    for the coordinator to check first - which is what it used to do, and what
+    it then had to consult again afterwards to work out what a `False` meant.
+    """
+    coordinator = _coordinator(hass, heating_circuit=1)
+    assert not coordinator.client.connected
 
     await coordinator._async_update_data()
 
-    assert not api.connect.called
+    assert coordinator.client.connected
 
 
 async def test_constructing_the_coordinator_does_not_talk_to_the_device(
     hass: HomeAssistant,
 ) -> None:
-    """Connecting is blocking I/O and belongs in the refresh, not in __init__."""
-    api = build_api()
+    """Connecting is I/O and belongs in the refresh, not in __init__."""
+    coordinator = _coordinator(hass, heating_circuit=1)
 
-    _coordinator(hass, api, heating_circuit=1)
-
-    assert not api.connect.called
+    assert not coordinator.client.connected
+    assert not controller_of(coordinator.client).reads
 
 
 async def test_unreachable_device_fails_the_update(hass: HomeAssistant) -> None:
     """A refresh that cannot connect must not look like a successful one."""
-    api = build_api()
-    api.connect.return_value = False
-    api.is_connected = False
-    coordinator = _coordinator(hass, api, heating_circuit=1)
+    coordinator = _coordinator(hass, heating_circuit=1)
+    controller_of(coordinator.client).fail_with = SolarfocusConnectionError("gone")
 
     with pytest.raises(UpdateFailed) as failure:
         await coordinator._async_update_data()
 
     assert failure.value.translation_key == "cannot_connect"
     assert failure.value.translation_placeholders == {"address": "solarfocus.local:502"}
-    assert not api.update_heating.called
 
 
 async def test_all_reads_failing_fails_the_refresh(hass: HomeAssistant) -> None:
     """Nothing could be read, so the system is gone.
 
-    The library reports a failed read by returning False. Swallowing that left
-    every entity of the entry available and showing its last value, with nothing
-    telling the user that the values had stopped being updated.
+    Swallowing that left every entity of the entry available and showing its
+    last value, with nothing telling the user the values had stopped moving.
     """
-    api = build_api()
-    api.update_heating.return_value = False
-    api.update_buffer.return_value = False
-    coordinator = _coordinator(hass, api, heating_circuit=1, buffer=1)
+    coordinator = _coordinator(hass, heating_circuit=1, buffer=1)
+    silence(coordinator.client, ComponentId.HEATING_CIRCUITS)
+    silence(coordinator.client, ComponentId.BUFFERS)
 
     with pytest.raises(UpdateFailed) as failure:
         await coordinator._async_update_data()
@@ -192,55 +194,45 @@ async def test_all_reads_failing_fails_the_refresh(hass: HomeAssistant) -> None:
     assert failure.value.translation_key == "cannot_read"
     assert failure.value.translation_placeholders == {
         "address": "solarfocus.local:502",
-        "components": f"{CONF_HEATING_CIRCUIT}, {CONF_BUFFER}",
+        # What the device page calls them, index and all, rather than the
+        # config keys - this text is shown to the user.
+        "components": "Buffer 1, Heating circuit 1",
     }
 
 
-@pytest.mark.parametrize(
-    ("option", "update"),
-    [
-        (CONF_CIRCULATION, "update_circulation"),
-        (CONF_DIFFERENTIAL_MODULE, "update_differential_modules"),
-    ],
-)
-async def test_a_component_the_api_version_lacks_is_not_polled(
-    hass: HomeAssistant, option: str, update: str
+@pytest.mark.parametrize("option", [CONF_CIRCULATION, CONF_DIFFERENTIAL_MODULE])
+async def test_a_component_the_api_version_lacks_is_not_built(
+    hass: HomeAssistant, option: str
 ) -> None:
-    """A component that arrived in a later api version is not read below it.
+    """A component that arrived in a later api version is not there below it.
 
-    The library call for one of those returns True without asking the
-    controller anything, so polling it is not merely pointless: it is a read
-    that always succeeds.
+    It used to be built and polled by a library call that returned success
+    without asking the controller anything, so it was a read that could not
+    fail - which is why the coordinator had to count configured components
+    rather than trusting the answer.
     """
-    api = build_api()
-    coordinator = _coordinator(hass, api, **{option: 2})
+    coordinator = _coordinator(hass, **{option: 2})
 
     await coordinator._async_update_data()
 
-    assert not getattr(api, update).called
+    assert not coordinator.client.components
 
 
 @pytest.mark.parametrize("option", [CONF_CIRCULATION, CONF_DIFFERENTIAL_MODULE])
 async def test_a_component_the_api_version_lacks_does_not_hide_an_outage(
     hass: HomeAssistant, option: str
 ) -> None:
-    """Nothing is read, so the refresh fails - whatever else is configured.
-
-    A component the selected version does not have is counted as configured
-    before it is counted as read successfully, and every component reading
-    successfully is what a total outage was told apart from a component that
-    is unhappy on its own. An entry configured with one of these on an older
-    version would have set up as if the controller answered.
-    """
-    api = build_api()
-    api.update_heating.return_value = False
-    coordinator = _coordinator(hass, api, heating_circuit=1, **{option: 2})
+    """Nothing is read, so the refresh fails - whatever else is configured."""
+    coordinator = _coordinator(hass, heating_circuit=1, **{option: 2})
+    silence(coordinator.client, ComponentId.HEATING_CIRCUITS)
 
     with pytest.raises(UpdateFailed) as failure:
         await coordinator._async_update_data()
 
     assert failure.value.translation_key == "cannot_read"
-    assert failure.value.translation_placeholders["components"] == CONF_HEATING_CIRCUIT
+    assert (
+        failure.value.translation_placeholders["components"] == "Heating circuit 1"
+    )
 
 
 async def test_one_failing_component_keeps_the_others_working(
@@ -254,47 +246,58 @@ async def test_one_failing_component_keeps_the_others_working(
     unavailable entities from service calls, so the user could not control the
     parts that do work.
     """
-    api = build_api()
-    api.update_heating.return_value = False
-    coordinator = _coordinator(hass, api, heating_circuit=1, buffer=1)
+    coordinator = _coordinator(hass, heating_circuit=1, buffer=1)
+    silence(coordinator.client, ComponentId.HEATING_CIRCUITS)
 
     await coordinator.async_refresh()
 
     assert coordinator.last_update_success
-    assert api.update_buffer.called
-    assert "Could not read heating_circuit" in caplog.text
+    assert coordinator.client.buffers[0].available
+    assert "Could not read Heating circuit 1" in caplog.text
 
 
-async def test_a_connection_dropping_mid_poll_is_an_outage(hass: HomeAssistant) -> None:
-    """The components after the drop failed for want of a socket, not a register.
+async def test_one_failing_instance_leaves_the_others_alone(
+    hass: HomeAssistant,
+) -> None:
+    """Two buffers, one of which answers nothing.
 
-    A read on a closed connection returns False without asking the device
-    anything, so a connection that goes away half way through a poll fails an
-    arbitrary tail of the components. Calling those unreadable would grey them
-    out and raise an issue per component telling the user to switch it off, for
-    a connection that is re-established on the next refresh.
+    The predecessor read all four buffers in one call and stopped at the first
+    that failed, so a buffer that answered nothing was every buffer as far as
+    anything here could tell. The library reads them as slices of the whole
+    system and attributes a refusal to the instances it was actually for.
     """
-    api = build_api()
+    coordinator = _coordinator(hass, buffer=2)
+    silence(coordinator.client, ComponentId.BUFFERS, index=2)
 
-    def drop_the_connection() -> bool:
-        api.is_connected = False
-        return False
+    await coordinator.async_refresh()
 
-    api.update_boiler.side_effect = drop_the_connection
-    api.update_heatpump.return_value = False
-    coordinator = _coordinator(hass, api, heating_circuit=1, boiler=1, heatpump=True)
+    assert coordinator.last_update_success
+    assert coordinator.failed_components == frozenset({(CONF_BUFFER, "2")})
+    assert coordinator.client.buffers[0].available
+    assert not coordinator.client.buffers[1].available
+
+
+async def test_a_connection_dropping_mid_poll_is_an_outage(
+    hass: HomeAssistant,
+) -> None:
+    """A socket that goes away is not a component to be configured away.
+
+    Calling it one would grey out whatever the drop happened to land on and
+    raise an issue telling the user to switch that component off, for a
+    connection that is re-established on the next refresh.
+    """
+    coordinator = _coordinator(hass, heating_circuit=1, boiler=1, heatpump=True)
+    controller_of(coordinator.client).fail_with = SolarfocusConnectionError("dropped")
 
     with pytest.raises(UpdateFailed) as failure:
         await coordinator._async_update_data()
 
     assert failure.value.translation_key == "cannot_connect"
-    assert failure.value.translation_placeholders == {"address": "solarfocus.local:502"}
-    # Not the boiler and not the heat pump: neither of them was asked anything.
     assert coordinator.failed_components == frozenset()
 
 
 async def test_a_connection_dropping_mid_poll_raises_no_component_issue(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """End to end: an outage is not a component to be configured away."""
     entry = build_config_entry(heating_circuit=1, boiler=1)
@@ -303,11 +306,7 @@ async def test_a_connection_dropping_mid_poll_raises_no_component_issue(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    def drop_the_connection() -> bool:
-        api.is_connected = False
-        return False
-
-    api.update_boiler.side_effect = drop_the_connection
+    mock_client.controller.fail_with = SolarfocusConnectionError("dropped")
     await entry.runtime_data.async_refresh()
 
     assert not entry.runtime_data.last_update_success
@@ -317,15 +316,14 @@ async def test_a_connection_dropping_mid_poll_raises_no_component_issue(
 async def test_a_failing_component_on_a_live_connection_is_still_partial(
     hass: HomeAssistant,
 ) -> None:
-    """The guard is about the connection, not about a read that returns False."""
-    api = build_api()
-    api.update_boiler.return_value = False
-    coordinator = _coordinator(hass, api, heating_circuit=1, boiler=1)
+    """The guard is about the connection, not about a read that was refused."""
+    coordinator = _coordinator(hass, heating_circuit=1, boiler=1)
+    silence(coordinator.client, ComponentId.BOILERS)
 
     await coordinator.async_refresh()
 
     assert coordinator.last_update_success
-    assert coordinator.failed_components == frozenset({CONF_BOILER})
+    assert coordinator.failed_components == frozenset({(CONF_BOILER, "1")})
 
 
 async def test_failed_components_is_handed_out_rather_than_copied(
@@ -337,9 +335,8 @@ async def test_failed_components_is_handed_out_rather_than_copied(
     eight names. A frozenset cannot be added to by whoever reads it, which is
     what the copy was there for.
     """
-    api = build_api()
-    api.update_boiler.return_value = False
-    coordinator = _coordinator(hass, api, heating_circuit=1, boiler=1)
+    coordinator = _coordinator(hass, heating_circuit=1, boiler=1)
+    silence(coordinator.client, ComponentId.BOILERS)
 
     await coordinator.async_refresh()
 
@@ -348,7 +345,7 @@ async def test_failed_components_is_handed_out_rather_than_copied(
 
 
 async def test_only_the_failing_component_is_greyed_out(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """End to end: the heating circuit answers nothing, the boiler answers.
 
@@ -357,11 +354,14 @@ async def test_only_the_failing_component_is_greyed_out(
     unavailable rather than keeping the last value they read, which they used to
     do for as long as the entry was loaded.
     """
-    api.update_heating.return_value = False
     entry = build_config_entry(heating_circuit=1, boiler=1)
     entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_client.silence(ComponentId.HEATING_CIRCUITS)
+    await entry.runtime_data.async_refresh()
     await hass.async_block_till_done()
 
     def states(device: str) -> list[str]:
@@ -383,18 +383,17 @@ async def test_a_partial_failure_is_logged_once_and_the_recovery_too(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Once per outage, not once per poll."""
-    api = build_api()
-    api.update_heating.return_value = False
-    coordinator = _coordinator(hass, api, heating_circuit=1, buffer=1)
+    coordinator = _coordinator(hass, heating_circuit=1, buffer=1)
+    silence(coordinator.client, ComponentId.HEATING_CIRCUITS)
 
     await coordinator.async_refresh()
     await coordinator.async_refresh()
     await coordinator.async_refresh()
 
-    assert caplog.text.count("Could not read heating_circuit") == 1
+    assert caplog.text.count("Could not read Heating circuit 1") == 1
 
     caplog.clear()
-    api.update_heating.return_value = True
+    revive(coordinator.client, ComponentId.HEATING_CIRCUITS)
     await coordinator.async_refresh()
     await coordinator.async_refresh()
 
@@ -403,17 +402,16 @@ async def test_a_partial_failure_is_logged_once_and_the_recovery_too(
 
 async def test_entities_become_unavailable_and_recover(hass: HomeAssistant) -> None:
     """`last_update_success` is what the entities report as availability."""
-    api = build_api()
-    coordinator = _coordinator(hass, api, heating_circuit=1)
+    coordinator = _coordinator(hass, heating_circuit=1)
 
     await coordinator.async_refresh()
     assert coordinator.last_update_success
 
-    api.update_heating.return_value = False
+    silence(coordinator.client, ComponentId.HEATING_CIRCUITS)
     await coordinator.async_refresh()
     assert not coordinator.last_update_success
 
-    api.update_heating.return_value = True
+    revive(coordinator.client, ComponentId.HEATING_CIRCUITS)
     await coordinator.async_refresh()
     assert coordinator.last_update_success
 
@@ -426,12 +424,11 @@ async def test_a_failure_is_logged_once_and_the_recovery_too(
     Raising `UpdateFailed` hands that to the coordinator, which logs the first
     failure and the recovery and keeps quiet in between.
     """
-    api = build_api()
-    coordinator = _coordinator(hass, api, heating_circuit=1)
+    coordinator = _coordinator(hass, heating_circuit=1)
     await coordinator.async_refresh()
 
     caplog.clear()
-    api.update_heating.return_value = False
+    silence(coordinator.client, ComponentId.HEATING_CIRCUITS)
     await coordinator.async_refresh()
     await coordinator.async_refresh()
     await coordinator.async_refresh()
@@ -439,7 +436,7 @@ async def test_a_failure_is_logged_once_and_the_recovery_too(
     assert caplog.text.count(f"Error fetching {DOMAIN} data") == 1
 
     caplog.clear()
-    api.update_heating.return_value = True
+    revive(coordinator.client, ComponentId.HEATING_CIRCUITS)
     await coordinator.async_refresh()
 
     assert caplog.text.count(f"Fetching {DOMAIN} data recovered") == 1
@@ -448,9 +445,8 @@ async def test_a_failure_is_logged_once_and_the_recovery_too(
 async def test_successful_update_is_logged(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """A successful refresh is reported."""
-    api = build_api()
-    coordinator = _coordinator(hass, api, heating_circuit=1)
+    """A successful refresh is reported, with what it took to make it."""
+    coordinator = _coordinator(hass, heating_circuit=1)
 
     with caplog.at_level(logging.DEBUG):
         await coordinator._async_update_data()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -7,10 +7,7 @@ it, and that the address of their controller is not.
 
 import json
 
-from pysolarfocus import ApiVersions
-from pysolarfocus.components.boiler import Boiler
-from pysolarfocus.components.heat_pump import HeatPump
-from pysolarfocus.components.heating_circuit import HeatingCircuit
+from aiosolarfocus import ApiVersion, ComponentId
 from pytest_homeassistant_custom_component.components.diagnostics import (
     get_diagnostics_for_config_entry,
 )
@@ -25,12 +22,8 @@ from homeassistant.setup import async_setup_component
 from .conftest import CURRENT_VERSION, build_config_entry
 
 
-async def _diagnostics(hass: HomeAssistant, api, **options) -> dict:
+async def _diagnostics(hass: HomeAssistant, **options) -> dict:
     """Set an entry up and return its diagnostics."""
-    api.heating_circuits = [HeatingCircuit()]
-    api.boilers = [Boiler()]
-    api.heatpump = HeatPump(api_version=ApiVersions.V_23_020)
-
     entry = build_config_entry(**options)
     entry.add_to_hass(hass)
 
@@ -41,10 +34,10 @@ async def _diagnostics(hass: HomeAssistant, api, **options) -> dict:
 
 
 async def test_diagnostics_hide_the_address_of_the_controller(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The host is the one thing in the options a user should not have to strip."""
-    diagnostics = await _diagnostics(hass, api, heating_circuit=1)
+    diagnostics = await _diagnostics(hass, heating_circuit=1)
 
     assert diagnostics["entry"]["data"][CONF_HOST] == REDACTED
     # The port says nothing on its own and tells a non-standard setup apart
@@ -56,8 +49,7 @@ async def test_home_assistant_serves_the_download(
     hass: HomeAssistant,
     hass_client,
     enable_custom_integrations,
-    mock_api,
-    api,
+    mock_client,
 ) -> None:
     """Only a module named `diagnostics.py` next to the platforms is found at all.
 
@@ -65,8 +57,6 @@ async def test_home_assistant_serves_the_download(
     working function: nothing declares the platform, Home Assistant looks for
     the module by name.
     """
-    api.heating_circuits = [HeatingCircuit()]
-
     entry = build_config_entry(heating_circuit=1)
     entry.add_to_hass(hass)
 
@@ -78,80 +68,89 @@ async def test_home_assistant_serves_the_download(
     diagnostics = await get_diagnostics_for_config_entry(hass, hass_client, entry)
 
     assert diagnostics["entry"]["data"][CONF_HOST] == REDACTED
-    assert diagnostics["components"]["heating_circuits"][0]["supply_temperature"] == 0
+    assert (
+        diagnostics["components"]["heating_circuits.1"]["supply_temperature"]["value"]
+        == 0
+    )
 
 
 async def test_diagnostics_survive_being_written_out(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """Home Assistant serves the download as JSON, so it has to encode.
 
     Nothing in a register is exotic, but the system of an entry is an enum and
     the values come out of a library, which is where this would break.
     """
-    diagnostics = await _diagnostics(hass, api, heating_circuit=1, heatpump=True)
+    diagnostics = await _diagnostics(hass, heating_circuit=1, heatpump=True)
 
     assert json.loads(json.dumps(diagnostics, cls=ExtendedJSONEncoder))
 
 
 async def test_diagnostics_describe_how_the_entry_is_configured(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The component counts and the api version are what a report has to state."""
-    diagnostics = await _diagnostics(hass, api, heating_circuit=2, boiler=1)
+    diagnostics = await _diagnostics(hass, heating_circuit=2, boiler=1)
 
     entry = diagnostics["entry"]
 
     assert entry["version"] == CURRENT_VERSION
     assert entry["options"]["heating_circuit"] == 2
-    assert entry["data"]["api_version"] == ApiVersions.V_23_020.value
+    assert entry["data"]["api_version"] == ApiVersion.V_23_020.label
     assert entry["data"]["system"] is not None
 
 
 async def test_diagnostics_report_the_registers_of_every_component(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """A value the heating system reports is the point of the whole download.
 
     The components that can exist several times over are a list even when only
     one is configured, so that the index in an entity name lines up with it.
     """
-    diagnostics = await _diagnostics(hass, api, heating_circuit=1, heatpump=True)
+    diagnostics = await _diagnostics(hass, heating_circuit=1, heatpump=True)
 
     components = diagnostics["components"]
+    circuit = components["heating_circuits.1"]
 
-    assert components["heating_circuits"][0]["supply_temperature"] == 0
-    assert "mixer_valve" in components["heating_circuits"][0]
-    assert components["heatpump"]["compressor_speed"] == 0
+    assert circuit["supply_temperature"]["value"] == 0
+    assert "mixer_valve" in circuit
+    assert components["heat_pump"]["compressor_speed"]["value"] == 0
     # A calculated value is not a register but is read like one, and it is the
     # first thing asked about when a COP looks wrong
-    assert "cop_heating" in components["heatpump"]
+    assert "cop_heating" in components["heat_pump"]
+    # More than the value: the address it came from, the raw words before
+    # scaling and the unit. A sentinel reading has a raw value and no decoded
+    # one, which is how a report tells "no sensor fitted" from "never read" -
+    # and it is the same shape as `python -m aiosolarfocus dump`.
+    assert circuit["supply_temperature"]["address"] == 1100
+    assert circuit["supply_temperature"]["unit"] == "°C"
+    assert circuit["supply_temperature"]["raw"] == 0
 
 
 async def test_diagnostics_leave_out_a_component_that_is_not_configured(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
-    """A component the user does not have has no registers to report."""
-    api.biomassboiler = None
-    api.photovoltaic = None
+    """A component the user does not have is not in the snapshot at all.
 
-    diagnostics = await _diagnostics(hass, api, heating_circuit=1)
+    It used to be reported as `null`, because the shape of the download was a
+    fixed list of every component the integration knows. The snapshot is what
+    the entry actually has.
+    """
+    diagnostics = await _diagnostics(hass, heating_circuit=1)
 
-    assert diagnostics["components"]["biomassboiler"] is None
-    assert diagnostics["components"]["photovoltaic"] is None
+    assert set(diagnostics["components"]) == {"heating_circuits.1"}
 
 
 async def test_diagnostics_name_the_components_that_could_not_be_read(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """Which component is failing is what a partial failure comes down to.
 
     It is only in the log otherwise, once, so a download taken later would not
     show it at all.
     """
-    api.heating_circuits = [HeatingCircuit()]
-    api.boilers = [Boiler()]
-
     entry = build_config_entry(heating_circuit=1, boiler=1)
     entry.add_to_hass(hass)
 
@@ -163,17 +162,17 @@ async def test_diagnostics_name_the_components_that_could_not_be_read(
     assert diagnostics["coordinator"]["last_update_success"] is True
     assert diagnostics["coordinator"]["failed_components"] == []
 
-    api.update_boiler.return_value = False
+    mock_client.silence(ComponentId.BOILERS)
     await entry.runtime_data.async_refresh()
 
     diagnostics = await async_get_config_entry_diagnostics(hass, entry)
 
     assert diagnostics["coordinator"]["last_update_success"] is True
-    assert diagnostics["coordinator"]["failed_components"] == ["boiler"]
+    assert diagnostics["coordinator"]["failed_components"] == ["boiler.1"]
 
 
 async def test_diagnostics_do_not_blame_one_component_for_a_whole_outage(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """A component named here is one that fails while the others read fine.
 
@@ -181,23 +180,20 @@ async def test_diagnostics_do_not_blame_one_component_for_a_whole_outage(
     that is what the download says. Naming the component that happened to be
     failing before would point a report at the wrong thing.
     """
-    api.heating_circuits = [HeatingCircuit()]
-    api.boilers = [Boiler()]
-
     entry = build_config_entry(heating_circuit=1, boiler=1)
     entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    api.update_boiler.return_value = False
+    mock_client.silence(ComponentId.BOILERS)
     await entry.runtime_data.async_refresh()
 
     assert (await async_get_config_entry_diagnostics(hass, entry))["coordinator"][
         "failed_components"
-    ] == ["boiler"]
+    ] == ["boiler.1"]
 
-    api.update_heating.return_value = False
+    mock_client.silence(ComponentId.HEATING_CIRCUITS)
     await entry.runtime_data.async_refresh()
 
     diagnostics = await async_get_config_entry_diagnostics(hass, entry)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,12 +1,14 @@
 """Test what the entity classes read from and write to the device.
 
 Every entity reads its value through `_get_native_value` and writes it through
-`_set_native_value`, which address a pysolarfocus component by name and index.
+`_async_set_native_value`, which address a component of the library by name and
+index.
 These tests pin the mapping down for one entity of every platform.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from aiosolarfocus import ComponentId, RegisterKind
 import pytest
 
 from custom_components.solarfocus.binary_sensor import (
@@ -31,7 +33,7 @@ from custom_components.solarfocus.const import (
     MANUFACTURER,
     ComponentDevice,
 )
-from custom_components.solarfocus.coordinator import COMPONENT_UPDATES
+from custom_components.solarfocus.coordinator import COMPONENT_IDS
 from custom_components.solarfocus.entity import create_description
 from custom_components.solarfocus.number import (
     BOILER_NUMBER_TYPES,
@@ -65,12 +67,30 @@ from custom_components.solarfocus.water_heater import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, UnitOfTemperature
 
-from .conftest import build_config_entry, build_coordinator
+from .conftest import (
+    build_client,
+    build_config_entry,
+    build_coordinator,
+    controller_of,
+    set_reading,
+    written,
+)
+
+# Enough of everything that any index a test asks for exists. What a component
+# is configured as is the entry's business; these tests are about the entity.
+FULLY_EQUIPPED = {
+    "heating_circuit": 4,
+    "buffer": 4,
+    "boiler": 4,
+    "heatpump": True,
+    "photovoltaic": True,
+}
 
 
 def _make(entity_class, description, component, component_prefix, idx="1"):
-    """Create an entity of the given class on a mocked coordinator."""
-    coordinator = build_coordinator(build_config_entry())
+    """Create an entity of the given class over a controller that is not real."""
+    entry = build_config_entry(**FULLY_EQUIPPED)
+    coordinator = build_coordinator(entry, build_client(entry))
     entity = entity_class(
         coordinator,
         create_description(component, component_prefix, idx, description),
@@ -119,8 +139,8 @@ def test_device_info_puts_the_entity_on_its_own_component() -> None:
     device drops the index - so raising the count of a component renames its
     first device rather than orphaning it.
     """
-    entry = build_config_entry()
-    coordinator = build_coordinator(entry)
+    entry = build_config_entry(**FULLY_EQUIPPED)
+    coordinator = build_coordinator(entry, build_client(entry))
     coordinator.hub_device_id = "hub"
     entity = SolarfocusSensor(
         coordinator,
@@ -145,7 +165,8 @@ def test_device_info_puts_the_entity_on_its_own_component() -> None:
 
 def test_a_component_that_exists_once_is_not_numbered() -> None:
     """There is one heat pump, so its device is `Heat pump`, not `Heat pump 1`."""
-    coordinator = build_coordinator(build_config_entry())
+    entry = build_config_entry(**FULLY_EQUIPPED)
+    coordinator = build_coordinator(entry, build_client(entry))
     coordinator.hub_device_id = "hub"
     entity = SolarfocusSwitchEntity(
         coordinator,
@@ -207,7 +228,8 @@ def test_only_the_component_that_failed_goes_unavailable() -> None:
     instead. One device per component is what makes that visible: the boiler
     greys out its own page and the rest of the system carries on.
     """
-    coordinator = build_coordinator(build_config_entry())
+    entry = build_config_entry(**FULLY_EQUIPPED)
+    coordinator = build_coordinator(entry, build_client(entry))
     boiler = SolarfocusSensor(
         coordinator,
         create_description(
@@ -221,7 +243,7 @@ def test_only_the_component_that_failed_goes_unavailable() -> None:
         ),
     )
 
-    coordinator.failed_components = {CONF_BOILER}
+    coordinator.failed_components = {(CONF_BOILER, "1")}
 
     assert boiler.available is False
     assert heat_pump.available is True
@@ -239,16 +261,17 @@ def test_every_component_goes_unavailable_under_its_own_option(
     is pinned here rather than the boiler alone, because a mismatch is one
     component with entities that never go unavailable and nothing else.
     """
-    coordinator = build_coordinator(build_config_entry())
+    entry = build_config_entry(**FULLY_EQUIPPED)
+    coordinator = build_coordinator(entry, build_client(entry))
     entity = SolarfocusSensor(
         coordinator,
         create_description(BOILER_COMPONENT, prefix, "1", BOILER_SENSOR_TYPES[0]),
     )
 
-    coordinator.failed_components = {device.option}
+    coordinator.failed_components = {(device.option, "1")}
     assert entity.available is False
 
-    coordinator.failed_components = {device.translation_key + "_renamed"}
+    coordinator.failed_components = {(device.translation_key + "_renamed", "1")}
     assert entity.available is True
 
 
@@ -260,13 +283,20 @@ def test_every_component_device_names_an_option_the_coordinator_polls() -> None:
     """
     assert (
         {device.option for device in COMPONENT_DEVICES.values()}
-        == {option for option, _ in COMPONENT_UPDATES}
+        == set(COMPONENT_IDS)
     )
 
 
-def test_a_failing_component_takes_every_instance_of_it() -> None:
-    """The library reads all boilers in one call, so all of them failed."""
-    coordinator = build_coordinator(build_config_entry())
+def test_a_failing_instance_leaves_the_others_alone() -> None:
+    """One boiler that answers nothing is one boiler.
+
+    The predecessor read all four in one call and stopped at the first that
+    failed, so a boiler that answered nothing greyed out every boiler. The
+    library plans its reads across the whole system and attributes a refusal to
+    the instances it was for, which is what makes this worth asking.
+    """
+    entry = build_config_entry(**FULLY_EQUIPPED)
+    coordinator = build_coordinator(entry, build_client(entry))
     boilers = [
         SolarfocusSensor(
             coordinator,
@@ -277,9 +307,9 @@ def test_a_failing_component_takes_every_instance_of_it() -> None:
         for idx in ("1", "2")
     ]
 
-    coordinator.failed_components = {CONF_BOILER}
+    coordinator.failed_components = {(CONF_BOILER, "1")}
 
-    assert [boiler.available for boiler in boilers] == [False, False]
+    assert [boiler.available for boiler in boilers] == [False, True]
 
 
 def test_a_writable_entity_of_a_failing_component_goes_unavailable() -> None:
@@ -290,7 +320,8 @@ def test_a_writable_entity_of_a_failing_component_goes_unavailable() -> None:
     every component that does answer keep taking them, which is the whole
     difference to failing the refresh.
     """
-    coordinator = build_coordinator(build_config_entry())
+    entry = build_config_entry(**FULLY_EQUIPPED)
+    coordinator = build_coordinator(entry, build_client(entry))
     number = SolarfocusNumberEntity(
         coordinator,
         create_description(
@@ -298,7 +329,7 @@ def test_a_writable_entity_of_a_failing_component_goes_unavailable() -> None:
         ),
     )
 
-    coordinator.failed_components = {CONF_BOILER}
+    coordinator.failed_components = {(CONF_BOILER, "1")}
 
     assert number.available is False
 
@@ -312,10 +343,10 @@ def test_a_component_that_reads_again_comes_back() -> None:
         BOILER_COMPONENT_PREFIX,
     )
 
-    entity.coordinator.failed_components = {CONF_BOILER}
+    entity.coordinator.failed_components = {(CONF_BOILER, "1")}
     assert entity.available is False
 
-    entity.coordinator.failed_components = set()
+    entity.coordinator.failed_components = frozenset()
     assert entity.available is True
 
 
@@ -333,7 +364,7 @@ def test_the_whole_system_being_gone_still_beats_a_working_component() -> None:
     )
 
     entity.coordinator.last_update_success = False
-    entity.coordinator.failed_components = set()
+    entity.coordinator.failed_components = frozenset()
 
     assert entity.available is False
 
@@ -347,9 +378,12 @@ def test_indexed_components_are_addressed_by_position() -> None:
         BOILER_COMPONENT_PREFIX,
         idx="3",
     )
-    boilers = [MagicMock() for _ in range(3)]
-    boilers[2].temperature.scaled_value = 55
-    entity.coordinator.api.boilers = boilers
+    set_reading(
+        entity.coordinator.client, ComponentId.BOILERS, "temperature", 55, index=3
+    )
+    set_reading(
+        entity.coordinator.client, ComponentId.BOILERS, "temperature", 20, index=1
+    )
 
     assert entity._get_native_value("temperature") == 55
 
@@ -363,7 +397,7 @@ def test_components_without_an_index_are_read_directly() -> None:
         HEAT_PUMP_COMPONENT_PREFIX,
         idx="",
     )
-    entity.coordinator.api.heatpump.evu_lock.scaled_value = 1
+    set_reading(entity.coordinator.client, ComponentId.HEAT_PUMP, "evu_lock", 1)
 
     assert entity._get_native_value("evu_lock") == 1
 
@@ -416,7 +450,12 @@ def test_sensor_reports_the_component_value() -> None:
         BOILER_COMPONENT,
         BOILER_COMPONENT_PREFIX,
     )
-    getattr(entity.coordinator.api.boilers[0], description.key).scaled_value = 42
+    set_reading(
+        entity.coordinator.client,
+        ComponentId.BOILERS,
+        entity.entity_description.item,
+        42,
+    )
 
     assert entity.native_value == 42
 
@@ -434,11 +473,18 @@ def test_binary_sensor_compares_against_its_on_state(
     """Some binary sensors are active on 0 (a problem) and some on 1 (running)."""
     entity = _make(
         SolarfocusBinarySensorEntity,
-        SolarfocusBinarySensorEntityDescription(key="pump", on_state=on_state),
+        SolarfocusBinarySensorEntityDescription(
+            key="circulator_pump", on_state=on_state
+        ),
         HEATING_CIRCUIT_COMPONENT,
         HEATING_CIRCUIT_COMPONENT_PREFIX,
     )
-    entity.coordinator.api.heating_circuits[0].pump.scaled_value = value
+    set_reading(
+        entity.coordinator.client,
+        ComponentId.HEATING_CIRCUITS,
+        "circulator_pump",
+        value,
+    )
 
     assert entity.is_on is expected
 
@@ -455,7 +501,7 @@ async def test_number_writes_the_value() -> None:
         BOILER_COMPONENT_PREFIX,
     )
 
-    with patch.object(entity, "_set_native_value") as set_value:
+    with patch.object(entity, "_async_set_native_value", new_callable=AsyncMock) as set_value:
         await entity.async_set_native_value(60)
 
     assert set_value.call_args_list == [(("target_temperature", 60),)]
@@ -469,7 +515,7 @@ def test_number_reads_the_value() -> None:
         BOILER_COMPONENT,
         BOILER_COMPONENT_PREFIX,
     )
-    entity.coordinator.api.boilers[0].target_temperature.scaled_value = 55
+    set_reading(entity.coordinator.client, ComponentId.BOILERS, "target_temperature", 55, index=1)
 
     assert entity.native_value == 55
 
@@ -489,12 +535,14 @@ async def test_select_writes_and_reports_the_option() -> None:
 
     assert entity.options == HEATPUMP_SELECT_TYPES[0].solarfocus_options
 
-    with patch.object(entity, "_set_native_value") as set_value:
+    with patch.object(entity, "_async_set_native_value", new_callable=AsyncMock) as set_value:
         await entity.async_select_option("3")
 
-    assert set_value.call_args_list == [(("smart_grid", "3"),)]
+    # The number the register holds, not the string the form offered: the
+    # library encodes an int or a member of the register's own enumeration.
+    assert set_value.call_args_list == [(("smart_grid", 3),)]
 
-    entity.coordinator.api.heatpump.smart_grid.scaled_value = 3
+    set_reading(entity.coordinator.client, ComponentId.HEAT_PUMP, "smart_grid", 3)
     assert entity.current_option == "3"
 
 
@@ -511,7 +559,7 @@ async def test_switch_turns_the_lock_on_and_off() -> None:
         idx="",
     )
 
-    with patch.object(entity, "_set_native_value") as set_value:
+    with patch.object(entity, "_async_set_native_value", new_callable=AsyncMock) as set_value:
         await entity.async_turn_on()
         await entity.async_turn_off()
 
@@ -530,7 +578,7 @@ def test_switch_reports_its_state() -> None:
         HEAT_PUMP_COMPONENT_PREFIX,
         idx="",
     )
-    entity.coordinator.api.heatpump.evu_lock.scaled_value = 1
+    set_reading(entity.coordinator.client, ComponentId.HEAT_PUMP, "evu_lock", 1)
 
     assert entity.is_on == 1
 
@@ -553,7 +601,7 @@ async def test_button_triggers_its_item(description) -> None:
         BOILER_COMPONENT_PREFIX,
     )
 
-    with patch.object(entity, "_set_native_value") as set_value:
+    with patch.object(entity, "_async_set_native_value", new_callable=AsyncMock) as set_value:
         await entity.async_press()
 
     assert set_value.call_args_list == [((description.key, 1),)]
@@ -565,9 +613,9 @@ async def test_button_triggers_its_item(description) -> None:
 
 def test_water_heater_reports_temperatures(boiler_water_heater) -> None:
     """The water heater reads the boiler it belongs to."""
-    boiler = boiler_water_heater.coordinator.api.boilers[1]
-    boiler.temperature.scaled_value = 48.5
-    boiler.target_temperature.scaled_value = 55.0
+    client = boiler_water_heater.coordinator.client
+    set_reading(client, ComponentId.BOILERS, "temperature", 48.5, index=2)
+    set_reading(client, ComponentId.BOILERS, "target_temperature", 55.0, index=2)
 
     assert boiler_water_heater.current_temperature == 48.5
     assert boiler_water_heater.target_temperature == 55.0
@@ -588,7 +636,7 @@ def test_water_heater_maps_the_device_mode(
     boiler_water_heater, mode: int, expected: str
 ) -> None:
     """The numeric device mode is translated into the displayed operation."""
-    boiler_water_heater.coordinator.api.boilers[1].mode.scaled_value = mode
+    set_reading(boiler_water_heater.coordinator.client, ComponentId.BOILERS, "mode", mode, index=2)
 
     assert boiler_water_heater.current_operation == expected
 
@@ -608,7 +656,7 @@ def test_water_heater_operation_list_covers_every_device_mode(
 
 async def test_water_heater_sets_the_target_temperature(boiler_water_heater) -> None:
     """Setting the temperature writes the boiler target temperature."""
-    with patch.object(boiler_water_heater, "_set_native_value") as set_value:
+    with patch.object(boiler_water_heater, "_async_set_native_value", new_callable=AsyncMock) as set_value:
         await boiler_water_heater.async_set_temperature(**{ATTR_TEMPERATURE: 52})
 
     assert set_value.call_args_list == [(("target_temperature", 52),)]
@@ -618,7 +666,7 @@ async def test_water_heater_ignores_a_call_without_a_temperature(
     boiler_water_heater,
 ) -> None:
     """A service call without a temperature must not write anything."""
-    with patch.object(boiler_water_heater, "_set_native_value") as set_value:
+    with patch.object(boiler_water_heater, "_async_set_native_value", new_callable=AsyncMock) as set_value:
         await boiler_water_heater.async_set_temperature(operation_mode="auto")
 
     assert not set_value.called
@@ -626,7 +674,7 @@ async def test_water_heater_ignores_a_call_without_a_temperature(
 
 async def test_water_heater_sets_the_operation_mode(boiler_water_heater) -> None:
     """The displayed operation is written back as the numeric device mode."""
-    with patch.object(boiler_water_heater, "_set_native_value") as set_value:
+    with patch.object(boiler_water_heater, "_async_set_native_value", new_callable=AsyncMock) as set_value:
         await boiler_water_heater.async_set_operation_mode(HA_DISPLAY_MODE_BLOCKWISE)
 
     assert set_value.call_args_list == [
@@ -636,7 +684,7 @@ async def test_water_heater_sets_the_operation_mode(boiler_water_heater) -> None
 
 async def test_water_heater_turns_on_and_off(boiler_water_heater) -> None:
     """On and off map to the always on and always off modes."""
-    with patch.object(boiler_water_heater, "_set_native_value") as set_value:
+    with patch.object(boiler_water_heater, "_async_set_native_value", new_callable=AsyncMock) as set_value:
         await boiler_water_heater.async_turn_on()
         await boiler_water_heater.async_turn_off()
 
@@ -649,21 +697,26 @@ async def test_water_heater_turns_on_and_off(boiler_water_heater) -> None:
 # --- writing ----------------------------------------------------------------
 
 
-def test_set_native_value_writes_and_refreshes_the_component() -> None:
-    """Writing commits the register and reads the component back."""
+async def test_a_write_reaches_the_register_and_is_reported_at_once() -> None:
+    """Writing puts the word on the wire and reports the value immediately.
+
+    There is no read afterwards: a write the controller took updates the
+    component's own cache. It used to commit the register and then read the
+    whole component back, blocking, on the event loop.
+    """
     entity = _make(
         SolarfocusNumberEntity,
         BOILER_NUMBER_TYPES[0],
         BOILER_COMPONENT,
         BOILER_COMPONENT_PREFIX,
     )
-    boiler = entity.coordinator.api.boilers[0]
-    boiler.target_temperature.value = 55
-    boiler.target_temperature.count = 1
 
-    entity._set_native_value("target_temperature", 55)
+    await entity._async_set_native_value("target_temperature", 55)
 
-    boiler.target_temperature.set_unscaled_value.assert_called_once_with(55)
-    boiler.target_temperature.commit.assert_called_once()
-    boiler.update.assert_called_once()
+    # 32000 holding, in tenths of a degree.
+    assert written(entity.coordinator.client) == [
+        (RegisterKind.HOLDING, 32000, (550,))
+    ]
+    assert not controller_of(entity.coordinator.client).reads
+    assert entity._get_native_value("target_temperature") == 55
     entity.async_write_ha_state.assert_called_once()

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,58 +1,91 @@
-"""Test the Solarfocus base entity."""
+"""Test the Solarfocus base entity.
+
+What both of these are about is the wire: register 33409 is signed, and a
+negative setpoint has to leave as a two's complement word or the controller
+reads it as 65036 watts of export. The arithmetic used to be here, reaching
+into the library's value objects to do it; it is the library's now, and these
+hold it to the same words.
+"""
 
 from unittest.mock import MagicMock
 
-from pysolarfocus import ApiVersions
-from pysolarfocus.components.photovoltaic import Photovoltaic
+from aiosolarfocus import ApiVersion, RegisterKind
 
-from custom_components.solarfocus.const import PHOTOVOLTAIC_COMPONENT
+from custom_components.solarfocus.const import (
+    PHOTOVOLTAIC_COMPONENT,
+    PHOTOVOLTAIC_COMPONENT_PREFIX,
+)
 from custom_components.solarfocus.entity import (
     SolarfocusEntity,
     SolarfocusEntityDescription,
+    create_description,
+)
+
+from .conftest import (
+    build_client,
+    build_config_entry,
+    build_coordinator,
+    controller_of,
+    written,
 )
 
 
-def _entity(photovoltaic: Photovoltaic) -> SolarfocusEntity:
+def _entity() -> SolarfocusEntity:
     """Create an entity writing to the photovoltaic component."""
-    coordinator = MagicMock()
-    coordinator.api.photovoltaic = photovoltaic
+    entry = build_config_entry(
+        api_version=ApiVersion.V_26_020.label, photovoltaic=True
+    )
+    coordinator = build_coordinator(entry, build_client(entry))
 
     entity = SolarfocusEntity(
         coordinator,
-        SolarfocusEntityDescription(
-            key="grid_im_export",
-            item="grid_im_export",
-            component=PHOTOVOLTAIC_COMPONENT,
+        create_description(
+            PHOTOVOLTAIC_COMPONENT,
+            PHOTOVOLTAIC_COMPONENT_PREFIX,
+            "",
+            SolarfocusEntityDescription(key="grid_im_export"),
         ),
     )
+    # Not added to Home Assistant, so there is no state machine to write to.
     entity.async_write_ha_state = MagicMock()
+
     return entity
 
 
-def test_set_native_value_writes_negative_value_as_twos_complement():
+async def test_a_negative_value_goes_out_as_twos_complement() -> None:
     """Negative values have to be written as unsigned words."""
-    modbus = MagicMock()
-    modbus.write_register.return_value = True
-    photovoltaic = Photovoltaic(api_version=ApiVersions.V_26_020).initialize(modbus)
-    # Don't let the read-back of the component overwrite the written value
-    photovoltaic.update = MagicMock()
+    entity = _entity()
 
-    _entity(photovoltaic)._set_native_value("grid_im_export", -500)
+    await entity._async_set_native_value("grid_im_export", -500)
 
-    modbus.write_register.assert_called_once_with(65036, 33409)
-    # The entity keeps reporting the signed value
-    assert photovoltaic.grid_im_export.scaled_value == -500
+    assert written(entity.coordinator.client) == [
+        (RegisterKind.HOLDING, 33409, (65036,))
+    ]
+    # The entity keeps reporting the signed value, without re-reading anything:
+    # a write the controller took updates the component's own cache.
+    assert entity._get_native_value("grid_im_export") == -500
 
 
-def test_set_native_value_writes_positive_value_unchanged():
+async def test_a_positive_value_goes_out_unchanged() -> None:
     """Positive values are written as they are."""
-    modbus = MagicMock()
-    modbus.write_register.return_value = True
-    photovoltaic = Photovoltaic(api_version=ApiVersions.V_26_020).initialize(modbus)
-    # Don't let the read-back of the component overwrite the written value
-    photovoltaic.update = MagicMock()
+    entity = _entity()
 
-    _entity(photovoltaic)._set_native_value("grid_im_export", 500)
+    await entity._async_set_native_value("grid_im_export", 500)
 
-    modbus.write_register.assert_called_once_with(500, 33409)
-    assert photovoltaic.grid_im_export.scaled_value == 500
+    assert written(entity.coordinator.client) == [
+        (RegisterKind.HOLDING, 33409, (500,))
+    ]
+    assert entity._get_native_value("grid_im_export") == 500
+
+
+async def test_a_write_does_not_re_read_the_component() -> None:
+    """The re-read after every write is gone.
+
+    It used to be a blocking `component.update()` on the event loop, per write -
+    so a climate service call was four writes and four whole-component reads.
+    """
+    entity = _entity()
+
+    await entity._async_set_native_value("grid_im_export", 500)
+
+    assert not controller_of(entity.coordinator.client).reads

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -1,27 +1,29 @@
-"""Verify entity descriptions against the components pysolarfocus actually exposes.
+"""Verify entity descriptions against the values the library actually carries.
 
-Every entity description names a `key` that is read off a pysolarfocus component at
-runtime via `getattr`. If the component for a given Solarfocus system does not carry
-that attribute, the entity is still created and every coordinator refresh raises
-`AttributeError` -- see issue #163, where the buffer `external_*` sensors were declared
-for all systems although `TherminatorBuffer` does not have them.
+Every entity description names an `item` that is read off a component at
+runtime. The integration used to decide for itself which systems and firmware
+versions had it, carrying a `min_required_version` and an `unsupported_systems`
+list on every description - a second copy of the register document, which
+drifted from it: see #163, where the buffer `external_*` sensors were declared
+for all systems although a Therminator buffer has none of them, and #217, where
+four registers the document gives to one system were read on all of them.
 
-These tests walk every description in every platform and assert the attribute exists
-for each system the description is not explicitly excluded from.
+The library owns that now, so `supports` decides what is built. What is left to
+check here is the half it cannot: that every description names something the
+library has heard of, that no two descriptions of one key survive together, and
+that the register-document facts these regressions were about still hold.
 """
 
+from aiosolarfocus import ApiVersion, ComponentId, Systems
 import pytest
-from pysolarfocus import ApiVersions, SolarfocusAPI, Systems
 
 from custom_components.solarfocus import (
     binary_sensor,
     button,
-    climate,
     number,
     select,
     sensor,
     switch,
-    water_heater,
 )
 from custom_components.solarfocus.const import (
     BIOMASS_BOILER_COMPONENT,
@@ -31,12 +33,16 @@ from custom_components.solarfocus.const import (
     DIFFERENTIAL_MODULE_COMPONENT,
     FRESH_WATER_MODULE_COMPONENT,
     HEAT_PUMP_COMPONENT,
+    HEAT_PUMP_COMPONENT_PREFIX,
     HEATING_CIRCUIT_COMPONENT,
     PHOTOVOLTAIC_COMPONENT,
     SOLAR_COMPONENT,
 )
+from custom_components.solarfocus.entity import create_description
 
-# Entity description list -> the SolarfocusAPI attribute it is read from.
+from .conftest import build_client, build_config_entry
+
+# Entity description list -> the component it is read from.
 # Mirrors the wiring in each platform's async_setup_entry.
 DESCRIPTION_LISTS = [
     (sensor.HEATING_CIRCUIT_SENSOR_TYPES, HEATING_CIRCUIT_COMPONENT),
@@ -76,110 +82,103 @@ DESCRIPTION_LISTS = [
 COMPOSITE_ITEMS = [
     (
         BOILER_COMPONENT,
-        water_heater.WATER_HEATER_TYPES,
         ["temperature", "target_temperature", "mode", "holding_mode"],
     ),
     (
         HEATING_CIRCUIT_COMPONENT,
-        climate.CLIMATE_TYPES,
         ["cooling", "target_supply_temperature", "supply_temperature", "state", "mode"],
     ),
 ]
 
-# Highest version the installed pysolarfocus knows about, so that no register is
-# hidden behind a version gate while checking.
-LATEST_API_VERSION = list(ApiVersions)[-1]
+# The newest firmware the library knows, so that nothing is hidden behind a
+# version gate while checking what exists at all.
+LATEST_API_VERSION = list(ApiVersion)[-1]
+
+# The heat source each system has, since the library refuses a configuration
+# with the other one.
+BIOMASS_SYSTEMS = [system for system in Systems if system is not Systems.VAMPAIR]
 
 
-def _component(system: Systems, component: str):
-    """Return the pysolarfocus component instance for a system."""
-    api = SolarfocusAPI(
-        ip="127.0.0.1", system=system, api_version=LATEST_API_VERSION
-    )
-    comp = getattr(api, component)
-    return comp[0] if isinstance(comp, list) else comp
+# The component -> the entry option that configures one of it. A component the
+# entry does not ask for is not built, and one the firmware predates is
+# refused, so an entry is built asking for exactly the component under test.
+OPTION_OF = {
+    HEATING_CIRCUIT_COMPONENT: ("heating_circuit", 1),
+    BUFFER_COMPONENT: ("buffer", 1),
+    BOILER_COMPONENT: ("boiler", 1),
+    SOLAR_COMPONENT: ("solar", 1),
+    FRESH_WATER_MODULE_COMPONENT: ("fresh_water_module", 1),
+    CIRCULATION_COMPONENT: ("circulation", 1),
+    DIFFERENTIAL_MODULE_COMPONENT: ("differential_module", 1),
+    PHOTOVOLTAIC_COMPONENT: ("photovoltaic", True),
+    HEAT_PUMP_COMPONENT: ("heatpump", True),
+    BIOMASS_BOILER_COMPONENT: ("biomassboiler", True),
+}
 
 
-def _cases():
-    """Yield (system, component, key) for every description/system combination."""
-    for descriptions, component in DESCRIPTION_LISTS:
-        for description in descriptions:
-            unsupported = description.unsupported_systems or []
-            for system in Systems:
-                if system in unsupported:
-                    continue
-                yield pytest.param(
-                    system,
-                    component,
-                    description.key,
-                    id=f"{system.name}-{component}-{description.key}",
-                )
-
-
-@pytest.mark.parametrize(("system", "component", "key"), list(_cases()))
-def test_description_key_exists_on_component(
-    system: Systems, component: str, key: str
-) -> None:
-    """Every entity key must exist on the component for every supported system."""
-    obj = _component(system, component)
-    assert hasattr(obj, key), (
-        f"{type(obj).__name__} (system {system.name}) has no attribute '{key}'. "
-        f"Either the key is wrong or the description needs "
-        f"unsupported_systems=[Systems.{system.name}]."
+def _component(system: Systems, component: str, api_version: ApiVersion | None = None):
+    """Return the library's component instance for a system and firmware."""
+    option, value = OPTION_OF[component]
+    entry = build_config_entry(
+        system,
+        api_version=(api_version or LATEST_API_VERSION).label,
+        **{option: value},
     )
 
-
-def _composite_cases():
-    """Yield (system, component, item) for the composite entities."""
-    for component, descriptions, items in COMPOSITE_ITEMS:
-        unsupported = {
-            s for d in descriptions for s in (d.unsupported_systems or [])
-        }
-        for system in Systems:
-            if system in unsupported:
-                continue
-            for item in items:
-                yield pytest.param(
-                    system, component, item, id=f"{system.name}-{component}-{item}"
-                )
+    return build_client(entry).of(ComponentId(component))[0]
 
 
-@pytest.mark.parametrize(("system", "component", "item"), list(_composite_cases()))
-def test_composite_entity_item_exists_on_component(
-    system: Systems, component: str, item: str
-) -> None:
-    """Registers read inline by water_heater/climate must exist too."""
-    obj = _component(system, component)
-    assert hasattr(obj, item), (
-        f"{type(obj).__name__} (system {system.name}) has no attribute '{item}'"
-    )
+def _values(system: Systems, component: str) -> set[str]:
+    """Every value the library offers on that component for that system."""
+    return set(_component(system, component).available_values())
 
 
-def test_buffer_external_sensors_excluded_for_therminator_buffer() -> None:
-    """Regression test for #163.
+def test_every_description_names_a_value_the_library_carries() -> None:
+    """A key the library has never heard of would simply never become an entity.
 
-    THERMINATOR and ECOTOP use TherminatorBuffer, which has no external_* registers.
+    Which is a quiet way to lose a sensor: nothing raises, nothing is logged,
+    and the entity is just not there. So each key has to be a value the library
+    offers on at least one system - the systems it is *not* offered on are the
+    library gating it, which is the point.
     """
-    external = [
-        d
-        for d in sensor.BUFFER_SENSOR_TYPES
-        if d.key.startswith("external_")
-    ]
-    assert external, "expected external_* buffer sensors to exist"
+    orphaned: list[str] = []
 
-    for description in external:
-        assert Systems.THERMINATOR in (description.unsupported_systems or [])
-        assert Systems.ECOTOP in (description.unsupported_systems or [])
+    for descriptions, component in DESCRIPTION_LISTS:
+        everywhere: set[str] = set()
+        for system in Systems:
+            if component == HEAT_PUMP_COMPONENT and system is not Systems.VAMPAIR:
+                continue
+            if component == BIOMASS_BOILER_COMPONENT and system is Systems.VAMPAIR:
+                continue
+            everywhere |= _values(system, component)
 
+        orphaned += [
+            f"{component}.{description.item or description.key}"
+            for description in descriptions
+            if (description.item or description.key) not in everywhere
+        ]
 
-def test_buffer_x35_excluded_where_missing() -> None:
-    """x35_temperature only exists on TherminatorBuffer, not on the plain Buffer."""
-    description = next(
-        d for d in sensor.BUFFER_SENSOR_TYPES if d.key == "x35_temperature"
+    assert not orphaned, (
+        f"{sorted(orphaned)} are described but named by no value of that "
+        f"component on any system."
     )
-    unsupported = description.unsupported_systems or []
-    for system in (Systems.VAMPAIR, Systems.PELLETELEGANCE, Systems.OCTOPLUS):
-        assert system in unsupported
+
+
+@pytest.mark.parametrize(("component", "items"), COMPOSITE_ITEMS)
+def test_composite_entity_items_exist_on_every_system(
+    component: str, items: list[str]
+) -> None:
+    """Registers read inline by water_heater/climate must exist too.
+
+    These two are passed through the gating filter rather than asked about -
+    their key is a label - so nothing else would notice if one of the registers
+    they name inline went away.
+    """
+    for system in Systems:
+        available = _values(system, component)
+        missing = [item for item in items if item not in available]
+
+        assert not missing, f"{system.name} has no {missing} on its {component}"
 
 
 @pytest.mark.parametrize("system", list(Systems), ids=lambda s: s.name)
@@ -187,23 +186,72 @@ def test_no_key_is_described_twice_for_one_system(system: Systems) -> None:
     """One system may only ever reach one description per key.
 
     A description list is allowed to carry the same key more than once - the
-    biomass boiler door is described twice because register 2405 is reported
-    the other way round on a therminator than on an EcoTop. What the duplicates
-    must not do is survive the system filter together: the key is half of the
-    `unique_id`, so Home Assistant would create the first entity and drop the
-    second, with nothing to say which of the two it kept.
+    biomass boiler door was described twice while register 2405 was believed to
+    read the other way round on a therminator than on an EcoTop. What the
+    duplicates must not do is survive the filter together: the key is half of
+    the `unique_id`, so Home Assistant would create the first entity and drop
+    the second, with nothing to say which of the two it kept.
     """
     for descriptions, component in DESCRIPTION_LISTS:
+        if component == HEAT_PUMP_COMPONENT and system is not Systems.VAMPAIR:
+            continue
+        if component == BIOMASS_BOILER_COMPONENT and system is Systems.VAMPAIR:
+            continue
+
+        available = _values(system, component)
         reached = [
             description.key
             for description in descriptions
-            if system not in (description.unsupported_systems or [])
+            if (description.item or description.key) in available
+            and system not in (description.unverified_systems or [])
         ]
         duplicates = {key for key in reached if reached.count(key) > 1}
+
         assert not duplicates, (
             f"{component} describes {sorted(duplicates)} more than once for "
             f"system {system.name}; only one of them can become an entity."
         )
+
+
+def test_buffer_external_sensors_are_not_offered_to_therminator_or_ecotop() -> None:
+    """Regression test for #163.
+
+    A Therminator and an EcoTop buffer never read the external X44/X36/X35
+    holding registers. Neither the register document nor the predecessor
+    explains why, and no hardware was available to check - two sources agreeing
+    was enough to carry the behaviour over rather than "fix" it against
+    hardware nobody has.
+    """
+    external = [
+        description
+        for description in sensor.BUFFER_SENSOR_TYPES
+        if description.key.startswith("external_")
+    ]
+    assert external, "expected external_* buffer sensors to exist"
+
+    for system in (Systems.THERMINATOR, Systems.ECOTOP):
+        available = _values(system, BUFFER_COMPONENT)
+        for description in external:
+            assert description.key not in available
+
+
+def test_buffer_x35_reaches_the_therminator_alone() -> None:
+    """Regression test for #217, and a change of behaviour in version 7.
+
+    Buffer 1902 is "Puffertemperatur X35" and the register document gives it to
+    the therminator. The integration offered it to the EcoTop as well, which is
+    one of the four registers #217 was about: a read spanning an address the
+    firmware does not map comes back compacted, not padded. An EcoTop loses
+    this sensor in version 7.
+    """
+    assert any(
+        description.key == "x35_temperature"
+        for description in sensor.BUFFER_SENSOR_TYPES
+    )
+
+    for system in Systems:
+        available = _values(system, BUFFER_COMPONENT)
+        assert ("x35_temperature" in available) is (system is Systems.THERMINATOR)
 
 
 # Register -> the one system the register document grants it to. The document
@@ -229,18 +277,36 @@ def test_single_system_biomass_registers_reach_only_that_system(
     everything else, which handed a pellet boiler a log wood register and a
     therminator two buffer temperatures its controller does not have.
     """
-    description = next(
-        d for d in sensor.BIOMASS_BOILER_SENSOR_TYPES if d.key == key
+    assert any(
+        description.key == key for description in sensor.BIOMASS_BOILER_SENSOR_TYPES
     )
-    unsupported = description.unsupported_systems or []
 
-    assert supported not in unsupported
-    for system in Systems:
-        if system is not supported:
-            assert system in unsupported, (
-                f"{key} is documented for {supported.name} only, but reaches "
-                f"{system.name}."
-            )
+    for system in BIOMASS_SYSTEMS:
+        available = _values(system, BIOMASS_BOILER_COMPONENT)
+        assert (key in available) is (system is supported), (
+            f"{key} is documented for {supported.name} only, but "
+            f"{'reaches' if key in available else 'does not reach'} "
+            f"{system.name}."
+        )
+
+
+def test_log_wood_arrives_with_22_090() -> None:
+    """A change of behaviour in version 7.
+
+    2412 arrived in 22.090. The integration offered it to a therminator on any
+    firmware, so a 21.140 controller was read at an address it does not map -
+    and a read that spans an unmapped address is compacted rather than padded,
+    which shifts every value after it into the wrong name.
+    """
+    older = _component(
+        Systems.THERMINATOR, BIOMASS_BOILER_COMPONENT, ApiVersion.V_21_140
+    )
+    newer = _component(
+        Systems.THERMINATOR, BIOMASS_BOILER_COMPONENT, ApiVersion.V_22_090
+    )
+
+    assert not older.supports("log_wood")
+    assert newer.supports("log_wood")
 
 
 # What register 2405 was measured to hold, and on which boiler. A door contact
@@ -248,7 +314,7 @@ def test_single_system_biomass_registers_reach_only_that_system(
 # it just says the opposite of the truth, which is how #91 and #101 stayed open
 # for two years - this integration had the EcoTop backwards from #79/#80 until
 # #91 measured a real one directly: register 2405 on QModMaster, the
-# controller's own display, and pysolarfocus all agreed on 0 closed / 1 open,
+# controller's own display, and the library all agreed on 0 closed / 1 open,
 # the same as the specification and every other system below.
 MEASURED_DOOR_POLARITIES = [
     (Systems.THERMINATOR, "1"),
@@ -270,11 +336,13 @@ def test_the_door_contact_reads_the_way_it_was_measured(
     the other way round at its terminal - it does not change what the
     description itself says here.
     """
+    available = _values(system, BIOMASS_BOILER_COMPONENT)
     reaching = [
-        d
-        for d in binary_sensor.BIOMASS_BOILER_BINARY_SENSOR_TYPES
-        if d.key == "door_contact"
-        and system not in (d.unsupported_systems or [])
+        description
+        for description in binary_sensor.BIOMASS_BOILER_BINARY_SENSOR_TYPES
+        if description.key == "door_contact"
+        and description.key in available
+        and system not in (description.unverified_systems or [])
     ]
 
     assert len(reaching) == 1, (
@@ -287,16 +355,77 @@ def test_the_door_contact_reads_the_way_it_was_measured(
 def test_the_octoplus_has_no_door_contact() -> None:
     """Nobody has read 2405 on an octoplus.
 
-    The two polarities above are both attested on real boilers, so picking one
-    for an unmeasured system is a coin toss that produces a door sensor which
-    is confidently wrong half the time. Better to have no entity until someone
+    The library maps the register on every biomass boiler and is right to: it
+    is there and it answers. What is unmeasured is which way round. The two
+    polarities are both attested on real boilers, so picking one for an
+    unmeasured system is a coin toss that produces a door sensor which is
+    confidently wrong half the time. Better to have no entity until someone
     reads the register with the door open and with it closed.
+
+    This is the only thing `unverified_systems` is for, and it is deliberately
+    not `supports`: the question it answers is not whether the controller has
+    the register.
     """
+    assert "door_contact" in _values(Systems.OCTOPLUS, BIOMASS_BOILER_COMPONENT)
+
     reaching = [
-        d
-        for d in binary_sensor.BIOMASS_BOILER_BINARY_SENSOR_TYPES
-        if d.key == "door_contact"
-        and Systems.OCTOPLUS not in (d.unsupported_systems or [])
+        description
+        for description in binary_sensor.BIOMASS_BOILER_BINARY_SENSOR_TYPES
+        if description.key == "door_contact"
+        and Systems.OCTOPLUS not in (description.unverified_systems or [])
     ]
 
     assert not reaching
+
+
+# The three the library renamed on the way from `pysolarfocus`: a "performance
+# overall" that is a seasonal figure reads better as one.
+RENAMED = [
+    ("performance_overall", "seasonal_performance"),
+    ("performance_overall_heating", "seasonal_performance_heating"),
+    ("performance_overall_drinking_water", "seasonal_performance_drinking_water"),
+]
+
+
+@pytest.mark.parametrize(("key", "item"), RENAMED)
+def test_a_renamed_register_keeps_the_entity_id_it_had(key: str, item: str) -> None:
+    """The key is what an entity id, its history and its name are built from.
+
+    So the rename stays inside the library: the description goes on naming the
+    entity `performance_overall` and names the register it reads separately.
+    An installation upgrading to version 7 keeps `sensor.heat_pump_performance
+    _overall`, everything recorded against it, and anything the user set on it.
+    """
+    description = next(
+        description
+        for description in sensor.HEATPUMP_SENSOR_TYPES
+        if description.key == key
+    )
+
+    assert description.item == item
+    assert _component(Systems.VAMPAIR, HEAT_PUMP_COMPONENT).supports(item)
+
+    bound = create_description(
+        HEAT_PUMP_COMPONENT, HEAT_PUMP_COMPONENT_PREFIX, "", description
+    )
+
+    assert bound.key == f"hp_{key}"
+    assert bound.translation_key == f"hp_{key}"
+    assert bound.object_id_name == key.replace("_", " ")
+    assert bound.item == item
+
+
+def test_only_the_renamed_registers_have_an_item_of_their_own() -> None:
+    """`item` differing from `key` is the exception, not a second naming scheme.
+
+    Every other description reads the register its key names, so a stray `item`
+    would be an entity id nobody can trace back to what it reports.
+    """
+    overridden = {
+        description.key
+        for descriptions, _ in DESCRIPTION_LISTS
+        for description in descriptions
+        if description.item and description.item != description.key
+    }
+
+    assert overridden == {key for key, _ in RENAMED}

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -18,7 +18,7 @@ import json
 import pathlib
 import re
 
-from pysolarfocus import ApiVersions, Systems
+from aiosolarfocus import ApiVersion, Systems
 import pytest
 
 from custom_components.solarfocus import (
@@ -35,7 +35,7 @@ from custom_components.solarfocus.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.icon import async_get_icons
 
-from .conftest import build_config_entry, build_coordinator
+from .conftest import build_config_entry, build_coordinator, every_component
 
 COMPONENT_DIR = pathlib.Path(sensor.__file__).parent
 
@@ -112,17 +112,8 @@ async def _entities(hass: HomeAssistant, module) -> list:
     for system in Systems:
         entry = build_config_entry(
             system,
-            api_version=ApiVersions.V_26_020.value,
-            heating_circuit=1,
-            buffer=1,
-            boiler=1,
-            fresh_water_module=1,
-            circulation=1,
-            differential_module=1,
-            solar=1,
-            heatpump=True,
-            biomassboiler=True,
-            photovoltaic=True,
+            api_version=ApiVersion.V_26_020.label,
+            **every_component(system),
         )
         entry.add_to_hass(hass)
         entry.runtime_data = build_coordinator(entry)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from pysolarfocus import ApiVersions, Systems
+from aiosolarfocus import ApiVersion, ComponentId, Systems
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -46,7 +46,7 @@ from .conftest import CURRENT_VERSION, build_config_entry, build_options
 
 
 async def test_setup_and_unload_entry(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, config_entry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, config_entry
 ) -> None:
     """A reachable device sets up the entry and unloading cleans up again."""
     config_entry.add_to_hass(hass)
@@ -64,12 +64,12 @@ async def test_setup_and_unload_entry(
 
 
 async def test_setup_passes_component_counts_to_the_library(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
-    """The configured component counts are handed to pysolarfocus."""
+    """The configured component counts are handed to the library."""
     entry = build_config_entry(
         Systems.THERMINATOR,
-        api_version=ApiVersions.V_25_030.value,
+        api_version=ApiVersion.V_25_030.label,
         heating_circuit=3,
         buffer=2,
         boiler=1,
@@ -82,16 +82,17 @@ async def test_setup_passes_component_counts_to_the_library(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    kwargs = mock_api.call_args.kwargs
-    assert kwargs["heating_circuit_count"] == 3
-    assert kwargs["buffer_count"] == 2
-    assert kwargs["boiler_count"] == 1
+    config = mock_client.instance.config
+
+    assert config.heating_circuits == 3
+    assert config.buffers == 2
+    assert config.boilers == 1
     # Was never passed, so the library built its default of one module and
     # every entity of a second one raised IndexError on read.
-    assert kwargs["fresh_water_module_count"] == 2
-    assert kwargs["solar_count"] == 2
-    assert kwargs["system"] is Systems.THERMINATOR
-    assert kwargs["api_version"] is ApiVersions.V_25_030
+    assert config.fresh_water_modules == 2
+    assert config.solar == 2
+    assert config.system is Systems.THERMINATOR
+    assert config.api_version is ApiVersion.V_25_030
 
 
 @pytest.mark.parametrize(
@@ -100,14 +101,14 @@ async def test_setup_passes_component_counts_to_the_library(
 async def test_setup_accepts_legacy_boolean_solar_option(
     hass: HomeAssistant,
     enable_custom_integrations,
-    mock_api,
+    mock_client,
     stored_solar,
     expected_count: int,
 ) -> None:
     """Entries written before solar became a count still set up."""
     entry = build_config_entry(
         Systems.VAMPAIR,
-        api_version=ApiVersions.V_25_030.value,
+        api_version=ApiVersion.V_25_030.label,
         heating_circuit=1,
         solar=stored_solar,
     )
@@ -116,12 +117,12 @@ async def test_setup_accepts_legacy_boolean_solar_option(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_api.call_args.kwargs["solar_count"] == expected_count
+    assert mock_client.instance.config.solar == expected_count
 
 
 @pytest.mark.parametrize("stored_solar", [2, 4])
 async def test_setup_caps_solar_below_the_version_that_supports_several(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, stored_solar: int
+    hass: HomeAssistant, enable_custom_integrations, mock_client, stored_solar: int
 ) -> None:
     """The options allow a count the selected api version cannot have.
 
@@ -131,7 +132,7 @@ async def test_setup_caps_solar_below_the_version_that_supports_several(
     """
     entry = build_config_entry(
         Systems.VAMPAIR,
-        api_version=ApiVersions.V_23_020.value,
+        api_version=ApiVersion.V_23_020.label,
         heating_circuit=1,
         solar=stored_solar,
     )
@@ -140,16 +141,14 @@ async def test_setup_caps_solar_below_the_version_that_supports_several(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_api.call_args.kwargs["solar_count"] == 1
+    assert mock_client.instance.config.solar == 1
 
 
 async def test_setup_retries_when_the_device_is_unreachable(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api, config_entry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, config_entry
 ) -> None:
     """A failing first refresh raises ConfigEntryNotReady."""
-    api.connect.return_value = False
-    api.is_connected = False
-    api.update_heating.side_effect = OSError("no route to host")
+    mock_client.offline()
     config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
@@ -159,15 +158,14 @@ async def test_setup_retries_when_the_device_is_unreachable(
 
 
 async def test_a_refused_connection_says_so(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api, config_entry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, config_entry
 ) -> None:
     """Nothing to talk to at the address is the common half of a failed setup.
 
     Telling that user their controller answered and then went quiet sends them
     looking at the heating system for a problem that is in the network.
     """
-    api.connect.return_value = False
-    api.is_connected = False
+    mock_client.offline()
     config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
@@ -178,12 +176,16 @@ async def test_a_refused_connection_says_so(
 
 
 async def test_a_controller_that_answers_nothing_says_that_instead(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api, config_entry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, config_entry
 ) -> None:
     """A connection that is accepted and read from anyway is the other half."""
-    api.is_connected = True
-    for component in ("heating", "buffer", "boiler", "heatpump"):
-        getattr(api, f"update_{component}").return_value = False
+    for component in (
+        ComponentId.HEATING_CIRCUITS,
+        ComponentId.BUFFERS,
+        ComponentId.BOILERS,
+        ComponentId.HEAT_PUMP,
+    ):
+        mock_client.silence(component)
     config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
@@ -194,7 +196,7 @@ async def test_a_controller_that_answers_nothing_says_that_instead(
 
 
 async def test_updating_options_reloads_the_entry(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, config_entry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, config_entry
 ) -> None:
     """The update listener reloads the entry so entities follow the new options."""
     config_entry.add_to_hass(hass)
@@ -224,7 +226,7 @@ async def test_unload_without_setup_is_a_noop(hass: HomeAssistant) -> None:
 
 
 async def test_reload_entry(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, config_entry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, config_entry
 ) -> None:
     """Reloading tears the entry down and sets it up again."""
     config_entry.add_to_hass(hass)
@@ -495,7 +497,7 @@ async def test_migration_from_version_4_renames_the_pellets_boiler(
 
 @pytest.mark.parametrize("version", [1, 2, 3, 4, 5])
 async def test_migrated_entries_can_be_set_up(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, version: int
+    hass: HomeAssistant, enable_custom_integrations, mock_client, version: int
 ) -> None:
     """Every supported old entry ends up in the layout async_setup_entry reads.
 
@@ -541,12 +543,14 @@ async def test_migrated_entries_can_be_set_up(
 
 
 def _version_6_entry(**option_overrides) -> MockConfigEntry:
-    """Return an entry as version 6 stored one: no unique id, and the
-    connection still among the options."""
+    """Return an entry as version 6 stored one.
+
+    No unique id, and the connection still among the options.
+    """
     options = {
         CONF_HOST: "solarfocus.local",
         CONF_PORT: 502,
-        CONF_API_VERSION: ApiVersions.V_23_020.value,
+        CONF_API_VERSION: ApiVersion.V_23_020.label,
         **build_options(**option_overrides),
     }
     return MockConfigEntry(
@@ -560,7 +564,7 @@ def _version_6_entry(**option_overrides) -> MockConfigEntry:
 
 
 async def test_setup_moves_the_unique_id_to_the_configured_address(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The address can change, and the unique id follows it on the next load."""
     entry = build_config_entry(heating_circuit=1)
@@ -574,7 +578,7 @@ async def test_setup_moves_the_unique_id_to_the_configured_address(
 
 
 async def test_setup_leaves_a_unique_id_less_entry_alone(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """A duplicate the migration left without a unique id keeps it that way."""
     first = build_config_entry()
@@ -593,7 +597,7 @@ async def test_setup_leaves_a_unique_id_less_entry_alone(
 async def test_setup_does_not_move_a_unique_id_onto_another_entry(
     hass: HomeAssistant,
     enable_custom_integrations,
-    mock_api,
+    mock_client,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """The options flow refuses this, a hand-edited entry can still get here."""
@@ -1165,7 +1169,7 @@ async def test_migration_leaves_the_entities_of_another_entry_alone(
 
 
 async def test_a_migrated_entry_sets_up_on_the_entities_it_already_had(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, entity_registry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, entity_registry
 ) -> None:
     """The whole point of rewriting the ids rather than registering new ones.
 
@@ -1198,7 +1202,7 @@ async def test_a_migrated_entry_sets_up_on_the_entities_it_already_had(
 
 
 async def test_a_renamed_entry_keeps_its_device(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, device_registry
 ) -> None:
     """What the whole migration is for.
 
@@ -1227,7 +1231,7 @@ async def test_a_renamed_entry_keeps_its_device(
 
 
 async def test_a_renamed_entry_keeps_its_entities(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, entity_registry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, entity_registry
 ) -> None:
     """The other half of what the rename used to cost, and the point of #212.
 
@@ -1259,7 +1263,7 @@ async def test_a_renamed_entry_keeps_its_entities(
 
 
 async def test_every_component_is_its_own_device_under_the_hub(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, device_registry
 ) -> None:
     """The layout a user sees: a controller, and the components of it.
 
@@ -1293,7 +1297,7 @@ async def test_every_component_is_its_own_device_under_the_hub(
 
 
 async def test_the_hub_is_the_controller(
-    hass: HomeAssistant, enable_custom_integrations, api, mock_api, device_registry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, device_registry
 ) -> None:
     """The device every component hangs off is the box they are wired to.
 
@@ -1301,8 +1305,6 @@ async def test_the_hub_is_the_controller(
     does not vary with the system - `Solarfocus` is the make, and the model of
     the device says which system it is.
     """
-    api.system = Systems.THERMINATOR
-
     entry = build_config_entry(Systems.THERMINATOR, biomassboiler=True)
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -1316,7 +1318,7 @@ async def test_the_hub_is_the_controller(
 
 
 async def test_the_hub_keeps_the_name_the_user_gave_it(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, device_registry
 ) -> None:
     """Telling two heating systems apart by name is renaming their controllers.
 
@@ -1342,7 +1344,7 @@ async def test_the_hub_keeps_the_name_the_user_gave_it(
 
 
 async def test_every_entity_sits_on_the_component_it_reads(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry,
+    hass: HomeAssistant, enable_custom_integrations, mock_client, device_registry,
     entity_registry,
 ) -> None:
     """An entity of heating circuit 2 belongs to the device of heating circuit 2."""
@@ -1370,7 +1372,7 @@ async def test_every_entity_sits_on_the_component_it_reads(
 
 
 async def test_the_entity_id_is_the_device_and_the_english_key(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, entity_registry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, entity_registry
 ) -> None:
     """Home Assistant composes the id; the integration only supplies half of it.
 
@@ -1406,7 +1408,7 @@ async def test_the_entity_id_is_the_device_and_the_english_key(
 
 
 async def test_lowering_a_count_removes_the_device_and_its_entities(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry,
+    hass: HomeAssistant, enable_custom_integrations, mock_client, device_registry,
     entity_registry,
 ) -> None:
     """A component a user takes away must not leave anything behind.
@@ -1439,7 +1441,7 @@ async def test_lowering_a_count_removes_the_device_and_its_entities(
 
 @pytest.mark.parametrize("component", ["circulation", "differential_module"])
 async def test_lowering_the_api_version_removes_the_devices_it_takes_away(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry,
+    hass: HomeAssistant, enable_custom_integrations, mock_client, device_registry,
     component: str,
 ) -> None:
     """A component the selected version lacks is as gone as one switched off.
@@ -1454,7 +1456,7 @@ async def test_lowering_the_api_version_removes_the_devices_it_takes_away(
         "differential_module": DIFFERENTIAL_MODULE_COMPONENT_PREFIX,
     }[component]
     entry = build_config_entry(
-        Systems.VAMPAIR, api_version=ApiVersions.V_25_030.value, **{component: 2}
+        Systems.VAMPAIR, api_version=ApiVersion.V_25_030.label, **{component: 2}
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -1463,7 +1465,7 @@ async def test_lowering_the_api_version_removes_the_devices_it_takes_away(
     assert device_registry.async_get_device({(DOMAIN, f"{entry.entry_id}_{prefix}2")})
 
     hass.config_entries.async_update_entry(
-        entry, data={**entry.data, CONF_API_VERSION: ApiVersions.V_23_020.value}
+        entry, data={**entry.data, CONF_API_VERSION: ApiVersion.V_23_020.label}
     )
     await hass.async_block_till_done()
 
@@ -1478,7 +1480,7 @@ async def test_lowering_the_api_version_removes_the_devices_it_takes_away(
 
 
 async def test_switching_a_component_off_removes_its_device(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, device_registry
 ) -> None:
     """The same for the components that are a switch rather than a count."""
     entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1, photovoltaic=True)
@@ -1497,7 +1499,7 @@ async def test_switching_a_component_off_removes_its_device(
 
 
 async def test_raising_a_count_adds_a_device(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, device_registry
 ) -> None:
     """The other direction, and the hub keeps every one of them."""
     entry = build_config_entry(Systems.VAMPAIR, heating_circuit=1)
@@ -1518,7 +1520,7 @@ async def test_raising_a_count_adds_a_device(
 
 
 async def test_removing_the_entry_removes_every_device(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, device_registry
 ) -> None:
     """The components go with the controller they hang off."""
     entry = build_config_entry(Systems.VAMPAIR, heating_circuit=2, heatpump=True)
@@ -1535,7 +1537,7 @@ async def test_removing_the_entry_removes_every_device(
 
 
 async def test_a_device_can_only_be_deleted_once_its_component_is_gone(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, device_registry
 ) -> None:
     """Deleting a configured device by hand would only have it built again.
 
@@ -1560,7 +1562,7 @@ async def test_a_device_can_only_be_deleted_once_its_component_is_gone(
 
 
 async def test_a_new_component_device_lands_in_the_area_of_its_controller(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry,
+    hass: HomeAssistant, enable_custom_integrations, mock_client, device_registry,
     area_registry,
 ) -> None:
     """Splitting the components off must not take them out of their room.
@@ -1591,7 +1593,7 @@ async def test_a_new_component_device_lands_in_the_area_of_its_controller(
 
 
 async def test_a_component_the_user_moved_stays_where_they_put_it(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry,
+    hass: HomeAssistant, enable_custom_integrations, mock_client, device_registry,
     area_registry,
 ) -> None:
     """Inheriting the area is for devices that are new, and only then."""
@@ -1617,7 +1619,7 @@ async def test_a_component_the_user_moved_stays_where_they_put_it(
 
 
 async def test_the_solar_entities_follow_the_key_the_count_uses(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, entity_registry
+    hass: HomeAssistant, enable_custom_integrations, mock_client, entity_registry
 ) -> None:
     """One solar circuit is keyed without its index, several are keyed with it.
 
@@ -1627,7 +1629,7 @@ async def test_the_solar_entities_follow_the_key_the_count_uses(
     value it had when the count changed.
     """
     entry = build_config_entry(
-        Systems.VAMPAIR, api_version=ApiVersions.V_25_030.value, solar=1
+        Systems.VAMPAIR, api_version=ApiVersion.V_25_030.label, solar=1
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/test_library_polling.py
+++ b/tests/test_library_polling.py
@@ -1,27 +1,23 @@
-"""Check what the integration offers against what pysolarfocus actually reads.
+"""Check what the integration offers against what the library actually reads.
 
-An entity is only as good as the poll behind it, and the library's `update_*`
-methods return True both when they read a component and when they decided the
-system has none to read. A component the library quietly skips therefore
-produces entities that sit at their default value forever and a refresh that
-reports success: no exception, no unavailable entity, no repair issue, and
-nothing in the rest of this suite notices.
+An entity is only as good as the poll behind it. The predecessor's `update_*`
+methods returned True both when they read a component and when they decided the
+system had none to read, so a component the library quietly skipped produced
+entities that sat at their default value forever and a refresh that reported
+success: no exception, no unavailable entity, no repair issue, and nothing in
+the rest of this suite noticed.
 
 That is what happened when Pellet Elegance and Octoplus were first added to the
 dropdown - `update_biomassboiler` named THERMINATOR and ECOTOP, so both new
-systems showed a boiler at 0.0 degrees and called it fine. These tests tie the
-dropdown to the library, so offering a system the library does not poll fails
-here instead of in somebody's dashboard.
+systems showed a boiler at 0.0 degrees and called it fine.
 
-The same goes for the registers under a component. An entity reads its value by
-`getattr`-ing its key off the pysolarfocus component, so a description whose key
-the library does not carry for that system raises an `AttributeError` on the
-first read - which is why register 2410 could not simply be renamed here and
-needed the library to name it first (issue #223).
+`aiosolarfocus` closes that hole by construction: a component the system does
+not have is not built, and a read that fails is attributed rather than
+swallowed. These tests hold the dropdown to it anyway, because the failure they
+guard against is silent and the cost of asking is one client per system.
 """
 
-from packaging import version
-from pysolarfocus import ApiVersions, SolarfocusAPI, Systems
+from aiosolarfocus import ApiVersion, ComponentId, Systems
 import pytest
 
 from custom_components.solarfocus.binary_sensor import (
@@ -29,21 +25,16 @@ from custom_components.solarfocus.binary_sensor import (
 )
 from custom_components.solarfocus.config_flow import SOLARFOCUS_SYSTEMS
 from custom_components.solarfocus.const import CONF_BIOMASS_BOILER, CONF_HEATPUMP
-from custom_components.solarfocus.coordinator import COMPONENT_UPDATES
+from custom_components.solarfocus.coordinator import COMPONENT_IDS
 from custom_components.solarfocus.sensor import BIOMASS_BOILER_SENSOR_TYPES
+
+from .conftest import build_client, build_config_entry, controller_of
 
 # The systems a user can actually pick, read off the dropdown itself so that
 # adding one to the form brings it under these tests with it.
 OFFERED_SYSTEMS = [Systems(option["value"]) for option in SOLARFOCUS_SYSTEMS]
 
-# The heat source the config flow switches on for a system, and the attribute on
-# the API that the matching `update_*` call is supposed to read.
-HEAT_SOURCE_COMPONENTS = {
-    CONF_HEATPUMP: "heatpump",
-    CONF_BIOMASS_BOILER: "biomassboiler",
-}
-
-LATEST_API_VERSION = list(ApiVersions)[-1]
+LATEST_API_VERSION = list(ApiVersion)[-1]
 
 
 def _heat_source_of(system: Systems) -> str:
@@ -51,61 +42,53 @@ def _heat_source_of(system: Systems) -> str:
     return CONF_HEATPUMP if system == Systems.VAMPAIR else CONF_BIOMASS_BOILER
 
 
-def _update_method(flag: str) -> str:
-    """Return the API method the coordinator calls for a component flag."""
-    return next(method for conf, method in COMPONENT_UPDATES if conf == flag)
+def _client(system: Systems, **options):
+    """Return a client for a system, on the newest firmware the library knows."""
+    entry = build_config_entry(
+        system, api_version=LATEST_API_VERSION.label, **options
+    )
+
+    return build_client(entry)
 
 
 @pytest.mark.parametrize("system", OFFERED_SYSTEMS, ids=lambda s: s.name)
-def test_the_heat_source_of_every_offered_system_is_read(
-    system: Systems, monkeypatch: pytest.MonkeyPatch
+async def test_the_heat_source_of_every_offered_system_is_read(
+    system: Systems,
 ) -> None:
     """Whichever heat source a system is set up with has to actually be polled."""
-    api = SolarfocusAPI(
-        ip="127.0.0.1", system=system, api_version=LATEST_API_VERSION
-    )
     flag = _heat_source_of(system)
-    component = getattr(api, HEAT_SOURCE_COMPONENTS[flag])
+    component_id = COMPONENT_IDS[flag]
+    client = _client(system, **{flag: True})
 
-    reads: list[str] = []
-    monkeypatch.setattr(
-        type(component), "update", lambda self: reads.append(system.name) or True
-    )
+    result = await client.update()
 
-    assert getattr(api, _update_method(flag))() is True
-    assert reads, (
-        f"{system.name} is offered in the dropdown and set up with "
-        f"{flag}, but pysolarfocus never reads its {HEAT_SOURCE_COMPONENTS[flag]}. "
-        f"Every entity on it would sit at its default value and the refresh "
-        f"would still report success."
+    assert client.of(component_id), (
+        f"{system.name} is offered in the dropdown and set up with {flag}, "
+        f"but the library builds no {component_id.value} for it. Every entity "
+        f"on it would sit at its default value."
     )
+    assert controller_of(client).reads, f"{system.name} read nothing at all"
+    assert result.ok
 
 
 @pytest.mark.parametrize("system", OFFERED_SYSTEMS, ids=lambda s: s.name)
-def test_the_heat_source_a_system_does_not_have_is_skipped(
-    system: Systems, monkeypatch: pytest.MonkeyPatch
+def test_the_heat_source_a_system_does_not_have_is_refused(
+    system: Systems,
 ) -> None:
-    """And the other one is left alone, rather than read and reported as real."""
-    api = SolarfocusAPI(
-        ip="127.0.0.1", system=system, api_version=LATEST_API_VERSION
-    )
+    """And the other one is refused outright rather than built and read.
+
+    The predecessor built it and read nothing into it. The library will not
+    take the configuration at all, which is the difference between a boiler
+    reporting 0.0 degrees and an entry that says why it cannot be set up.
+    """
     absent = (
         CONF_BIOMASS_BOILER
         if _heat_source_of(system) == CONF_HEATPUMP
         else CONF_HEATPUMP
     )
-    component = getattr(api, HEAT_SOURCE_COMPONENTS[absent])
 
-    reads: list[str] = []
-    monkeypatch.setattr(
-        type(component), "update", lambda self: reads.append(system.name) or True
-    )
-
-    assert getattr(api, _update_method(absent))() is True
-    assert not reads, (
-        f"{system.name} has no {HEAT_SOURCE_COMPONENTS[absent]}, but pysolarfocus "
-        f"reads one for it."
-    )
+    with pytest.raises(Exception, match="has no"):
+        _client(system, **{absent: True})
 
 
 # Every description of the biomass boiler, whichever platform reports it.
@@ -115,42 +98,46 @@ BIOMASS_BOILER_DESCRIPTIONS = [
 ]
 
 
-def _reaches(system: Systems, description) -> bool:
-    """Return whether a description survives the system and version filter."""
-    return system not in (
-        description.unsupported_systems or []
-    ) and version.parse(description.min_required_version) <= version.parse(
-        LATEST_API_VERSION.value
-    )
-
-
 @pytest.mark.parametrize("system", OFFERED_SYSTEMS, ids=lambda s: s.name)
 def test_every_biomass_boiler_entity_has_a_register_behind_it(
     system: Systems,
 ) -> None:
-    """A description the library has no attribute for cannot be read at all.
+    """A description the library has no value for cannot be read at all.
 
-    `_get_native_value` does `getattr(component, key).scaled_value`, so the
-    entity is built, added, and raises on the first refresh. Nothing else in
-    this suite notices: the platform tests build their components from mocks,
-    which answer to any name.
+    The entities are built from `supports` now, so this is less a guard against
+    a broken entity than a check that every description this integration
+    carries still names something - a description the library has never heard
+    of would simply never be built, and would sit here unnoticed instead.
     """
     if _heat_source_of(system) != CONF_BIOMASS_BOILER:
         pytest.skip(f"{system.name} has no biomass boiler")
 
-    boiler = SolarfocusAPI(
-        ip="127.0.0.1", system=system, api_version=LATEST_API_VERSION
-    ).biomassboiler
+    boiler = _client(system, biomassboiler=True).of(ComponentId.BIOMASS_BOILER)[0]
+    available = set(boiler.available_values())
 
-    missing = [
+    unknown = [
         description.key
         for description in BIOMASS_BOILER_DESCRIPTIONS
-        if _reaches(system, description) and not hasattr(boiler, description.key)
+        if (description.item or description.key) not in available
     ]
 
-    assert not missing, (
-        f"{system.name} would build {sorted(missing)} on its biomass boiler, "
-        f"but pysolarfocus carries no such register for that system."
+    # Only what no system has: a register the document grants to one system is
+    # legitimately absent on the others, and the entity is not built there.
+    everything = set()
+    for other in OFFERED_SYSTEMS:
+        if _heat_source_of(other) != CONF_BIOMASS_BOILER:
+            continue
+        everything |= set(
+            _client(other, biomassboiler=True)
+            .of(ComponentId.BIOMASS_BOILER)[0]
+            .available_values()
+        )
+
+    orphaned = [key for key in unknown if key not in everything]
+
+    assert not orphaned, (
+        f"the biomass boiler describes {sorted(orphaned)}, which the library "
+        f"carries no value of that name for on any system."
     )
 
 
@@ -187,15 +174,10 @@ def test_register_2410_is_reported_under_one_name_per_system(
         f"and both of {sorted(REGISTER_2410)} have to be there."
     )
 
-    reached = [key for key in REGISTER_2410 if _reaches(system, described[key])]
-    expected = [
-        key for key, systems in REGISTER_2410.items() if system in systems
-    ]
+    if _heat_source_of(system) != CONF_BIOMASS_BOILER:
+        pytest.skip(f"{system.name} has no biomass boiler")
 
-    assert reached == expected
+    boiler = _client(system, biomassboiler=True).of(ComponentId.BIOMASS_BOILER)[0]
+    expected = [key for key, systems in REGISTER_2410.items() if system in systems]
 
-    if _heat_source_of(system) == CONF_BIOMASS_BOILER:
-        boiler = SolarfocusAPI(
-            ip="127.0.0.1", system=system, api_version=LATEST_API_VERSION
-        ).biomassboiler
-        assert [key for key in REGISTER_2410 if hasattr(boiler, key)] == expected
+    assert [key for key in REGISTER_2410 if boiler.supports(key)] == expected

--- a/tests/test_live_controller.py
+++ b/tests/test_live_controller.py
@@ -1,0 +1,188 @@
+"""Set the integration up against a real eco manager-touch.
+
+Skipped unless `SOLARFOCUS_HOST` names one, so CI and everyone without hardware
+go straight past it:
+
+    SOLARFOCUS_HOST=10.0.0.5 uv run pytest tests/test_live_controller.py -s
+
+Only the vampair has ever been available to this project, and #217 is what
+happens when the other four systems are reasoned from a specification alone.
+`tests/test_recorded_controllers.py` is one answer to that - the register dumps
+their owners contributed. This is the other: the one system that *can* be held
+against real hardware, held against it, through the whole chain rather than at
+the library's edge.
+
+**Reads only.** Nothing here writes to the heating system, and nothing here
+should: a write can damage a heating system or the building it heats.
+"""
+
+import os
+
+from aiosolarfocus import Detection, detect
+import pytest
+import pytest_socket
+
+from custom_components.solarfocus.diagnostics import async_get_config_entry_diagnostics
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import build_config_entry
+
+HOST = os.environ.get("SOLARFOCUS_HOST")
+
+pytestmark = pytest.mark.skipif(
+    not HOST, reason="set SOLARFOCUS_HOST to a real controller to run this"
+)
+
+
+@pytest.fixture(name="reachable")
+def reachable_fixture(socket_enabled):
+    """Let this one test out of the sandbox the rest of the suite runs in.
+
+    Home Assistant's plugin re-pins the allowed hosts to localhost before every
+    test, which is what keeps the rest of this suite honest. A fixture runs
+    after that hook, so this is the one place the real controller is reachable.
+    """
+    pytest_socket.socket_allow_hosts([HOST, "127.0.0.1"], allow_unix_socket=True)
+
+
+@pytest.fixture(name="detected")
+async def detected_fixture(reachable) -> Detection:
+    """Ask the controller what it is, rather than being told."""
+    found = await detect(HOST)
+    print(f"\n{HOST}: {found.system.value} on {found.api_version.label}")
+
+    return found
+
+
+def _entry(detected: Detection, **overrides):
+    """Return the entry this controller describes for itself."""
+    counts = detected.counts
+    options = {
+        "heating_circuit": counts.heating_circuits,
+        "buffer": counts.buffers,
+        "boiler": counts.boilers,
+        "fresh_water_module": counts.fresh_water_modules,
+        "circulation": counts.circulations,
+        "differential_module": counts.differential_modules,
+        "solar": counts.solar,
+        "heatpump": detected.has_heat_pump,
+        "biomassboiler": detected.has_biomass_boiler,
+        "photovoltaic": detected.has_photovoltaic,
+        **overrides,
+    }
+
+    return build_config_entry(
+        detected.system,
+        host=HOST,
+        api_version=detected.api_version.label,
+        **options,
+    )
+
+
+async def test_the_entry_sets_up_and_every_entity_reads(
+    hass: HomeAssistant,
+    enable_custom_integrations,
+    reachable,
+    detected: Detection,
+) -> None:
+    """The whole chain against real registers: setup, poll, entities, values.
+
+    An entity that is `unavailable` here is one this integration built for a
+    register the controller does not answer - which is the failure the recorded
+    dumps cannot catch, because they only contain what a controller *did*
+    answer.
+    """
+    entry = _entry(detected)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert not entry.runtime_data.failed_components, (
+        f"answered nothing: {sorted(entry.runtime_data.failed_components)}"
+    )
+
+    states = sorted(
+        (hass.states.get(entity_id) for entity_id in hass.states.async_entity_ids()),
+        key=lambda state: state.entity_id,
+    )
+    assert states
+
+    print(f"\n{len(states)} entities\n")
+    for state in states:
+        unit = state.attributes.get("unit_of_measurement", "")
+        print(f"  {state.entity_id:62} {state.state} {unit}")
+
+    unavailable = [state.entity_id for state in states if state.state == STATE_UNAVAILABLE]
+    assert not unavailable, f"built but unreadable: {unavailable}"
+
+
+async def test_every_entity_it_registers_is_one_it_can_read(
+    hass: HomeAssistant,
+    enable_custom_integrations,
+    reachable,
+    detected: Detection,
+) -> None:
+    """An entity in the registry with no state is one nothing will ever fill.
+
+    Disabled by default is a decision; enabled and stateless is a bug, and it
+    is invisible on a dashboard because the entity simply is not there.
+    """
+    entry = _entry(detected)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    entries = sorted(
+        er.async_entries_for_config_entry(registry, entry.entry_id),
+        key=lambda registered: registered.entity_id,
+    )
+    disabled = [one.entity_id for one in entries if one.disabled_by is not None]
+
+    print(f"\n{len(entries)} registered, {len(disabled)} disabled by default")
+    for entity_id in disabled:
+        print(f"  disabled  {entity_id}")
+
+    live = set(hass.states.async_entity_ids())
+    stateless = [
+        one.entity_id
+        for one in entries
+        if one.disabled_by is None and one.entity_id not in live
+    ]
+
+    assert not stateless, f"registered, enabled and never filled: {stateless}"
+
+
+async def test_the_diagnostics_download_is_what_a_report_needs(
+    hass: HomeAssistant,
+    enable_custom_integrations,
+    reachable,
+    detected: Detection,
+) -> None:
+    """Every register the controller answered, as an issue report carries it."""
+    entry = _entry(detected)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diagnostics["entry"]["data"][CONF_HOST] == "**REDACTED**"
+    assert HOST not in str(diagnostics), "the address of the controller leaked"
+
+    for name, readings in diagnostics["components"].items():
+        print(f"\n{name}")
+        for register, reading in readings.items():
+            unit = reading["unit"] or ""
+            address = reading["address"] or ""
+            print(
+                f"  {register:38} {address:>6}  "
+                f"raw={str(reading['raw']):>10}  {reading['value']} {unit}"
+            )

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,62 +1,64 @@
 """Test the Solarfocus number entities."""
 
-from types import SimpleNamespace
-
-from pysolarfocus import ApiVersions, Systems
-from pysolarfocus.components.photovoltaic import Photovoltaic
+from aiosolarfocus import ApiVersion, ComponentId
 
 from custom_components.solarfocus.const import (
     PHOTOVOLTAIC_COMPONENT,
     PHOTOVOLTAIC_COMPONENT_PREFIX,
-    PHOTOVOLTAIC_PREFIX,
 )
-from custom_components.solarfocus.entity import (
-    create_description,
-    filterVersionAndSystem,
+from custom_components.solarfocus.entity import create_description, supported_entities
+from custom_components.solarfocus.number import (
+    PHOTOVOLTAIC_NUMBER_TYPES,
+    SolarfocusNumberEntity,
 )
-from custom_components.solarfocus.number import PHOTOVOLTAIC_NUMBER_TYPES
-from homeassistant.const import CONF_API_VERSION
+
+from .conftest import build_client, build_config_entry, build_coordinator
 
 
-def _config_entry(api_version: str):
-    """Create a minimal config entry stub for entity filtering."""
-    return SimpleNamespace(
-        data={CONF_API_VERSION: api_version, "system": Systems.VAMPAIR},
-        options={},
-    )
+def _entities(api_version: str) -> list[str]:
+    """Return the photovoltaic numbers an entry on this firmware would build."""
+    entry = build_config_entry(api_version=api_version, photovoltaic=True)
+    coordinator = build_coordinator(entry, build_client(entry))
 
-
-def _entities(api_version: str):
-    """Create the photovoltaic number entities for the given api version."""
     entities = [
-        SimpleNamespace(
-            entity_description=create_description(
-                                PHOTOVOLTAIC_COMPONENT,
+        SolarfocusNumberEntity(
+            coordinator,
+            create_description(
+                PHOTOVOLTAIC_COMPONENT,
                 PHOTOVOLTAIC_COMPONENT_PREFIX,
                 "",
                 description,
-            )
+            ),
         )
         for description in PHOTOVOLTAIC_NUMBER_TYPES
     ]
+
     return [
         entity.entity_description.item
-        for entity in filterVersionAndSystem(_config_entry(api_version), entities)
+        for entity in supported_entities(entry, entities)
     ]
 
 
 def test_photovoltaic_numbers_match_library_holding_registers():
     """Every number entity has to map to a writable value of the library."""
-    photovoltaic = Photovoltaic(api_version=ApiVersions.V_26_020)
+    entry = build_config_entry(
+        api_version=ApiVersion.V_26_020.label, photovoltaic=True
+    )
+    photovoltaic = build_client(entry).of(ComponentId.PHOTOVOLTAIC)[0]
 
     for description in PHOTOVOLTAIC_NUMBER_TYPES:
-        assert hasattr(photovoltaic, description.key)
+        item = description.item or description.key
+        assert photovoltaic.supports(item)
+        # A number entity writes, so the register has to take a write - which
+        # the library says outright rather than leaving to be inferred from
+        # which block the register is in.
+        assert photovoltaic.info(item).writable
 
 
 def test_photovoltaic_number_keys_and_names():
     """Entity keys and translation keys are prefixed with the component."""
     description = create_description(
-                PHOTOVOLTAIC_COMPONENT,
+        PHOTOVOLTAIC_COMPONENT,
         PHOTOVOLTAIC_COMPONENT_PREFIX,
         "",
         PHOTOVOLTAIC_NUMBER_TYPES[0],

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -6,9 +6,7 @@ one too few means a silently missing entity, and both only show up once an entry
 is actually set up.
 """
 
-from pysolarfocus import ApiVersions, Systems
-from pysolarfocus.components.circulation import Circulation
-from pysolarfocus.components.differential_module import DifferentialModule
+from aiosolarfocus import ApiVersion, ComponentId, Systems
 import pytest
 
 from custom_components.solarfocus import (
@@ -114,7 +112,7 @@ async def test_entity_keys_are_unique(hass: HomeAssistant, platform) -> None:
     """Duplicate keys would collide on the same unique id."""
     entry = build_config_entry(
         Systems.THERMINATOR,
-        api_version=ApiVersions.V_26_020.value,
+        api_version=ApiVersion.V_26_020.label,
         heating_circuit=3,
         buffer=2,
         boiler=2,
@@ -230,12 +228,17 @@ async def test_version_specific_entities_are_filtered(hass: HomeAssistant) -> No
 
 
 async def test_system_specific_entities_are_filtered(hass: HomeAssistant) -> None:
-    """Entities excluded for a system are not created for it (issue #163)."""
+    """Entities the library says a system does not have are not created (#163).
+
+    Which those are is the library's answer now rather than a list carried on
+    the description: a Therminator buffer has none of the external X44/X36/X35
+    holding registers, and the entities for them used to be built anyway and
+    raise on the first read.
+    """
     unsupported = {
         description.key
         for description in sensor.BUFFER_SENSOR_TYPES
-        if description.unsupported_systems
-        and Systems.THERMINATOR in description.unsupported_systems
+        if description.key.startswith("external_")
     }
     assert unsupported, "expected at least one system specific buffer sensor"
 
@@ -324,7 +327,7 @@ async def test_binary_sensors_cover_all_configured_components(
     entry = build_config_entry(
         Systems.THERMINATOR,
         # The fresh water module binary sensors need at least 23.040
-        api_version=ApiVersions.V_26_020.value,
+        api_version=ApiVersion.V_26_020.label,
         heating_circuit=1,
         buffer=1,
         fresh_water_module=1,
@@ -393,7 +396,7 @@ async def test_one_set_of_sensors_per_circulation_group(
 ) -> None:
     """The circulation of every boiler is read as its own component."""
     entry = build_config_entry(
-        api_version=ApiVersions.V_26_020.value, circulation=count
+        api_version=ApiVersion.V_26_020.label, circulation=count
     )
 
     keys = _keys(await _setup(hass, sensor, entry))
@@ -409,7 +412,7 @@ async def test_both_control_loops_of_every_differential_module(
 ) -> None:
     """Each module reports the two temperatures of each of its two loops."""
     entry = build_config_entry(
-        api_version=ApiVersions.V_26_020.value, differential_module=count
+        api_version=ApiVersion.V_26_020.label, differential_module=count
     )
 
     keys = _keys(await _setup(hass, sensor, entry))
@@ -442,7 +445,7 @@ async def test_the_new_modules_need_the_version_that_added_them(
     rather than a set that reads zero forever.
     """
     entry = build_config_entry(
-        api_version=ApiVersions.V_25_020.value, **{component: 1}
+        api_version=ApiVersion.V_25_020.label, **{component: 1}
     )
 
     keys = _keys(await _setup(hass, sensor, entry)) + _keys(
@@ -453,7 +456,7 @@ async def test_the_new_modules_need_the_version_that_added_them(
 
 
 async def test_the_new_modules_report_what_the_library_read(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The whole chain, on the components the library really builds.
 
@@ -462,16 +465,16 @@ async def test_the_new_modules_report_what_the_library_read(
     attribute of the description and the register behind it all have to name the
     same thing for a value to come out the other end.
     """
-    api.circulations = [Circulation()]
-    api.differential_modules = [DifferentialModule()]
     # The raw register, which is what the heating system answers with: both
     # temperatures are scaled by 0.1 on the way out.
-    api.circulations[0].temperature.value = 425
-    api.differential_modules[0].temperature_1_control_loop_2.value = 610
-    api.differential_modules[0].relay_control_loop_o1.value = 1
+    mock_client.reads(ComponentId.CIRCULATIONS, "temperature", 42.5)
+    mock_client.reads(
+        ComponentId.DIFFERENTIAL_MODULES, "temperature_1_control_loop_2", 61.0
+    )
+    mock_client.reads(ComponentId.DIFFERENTIAL_MODULES, "relay_control_loop_o1", 1)
 
     entry = build_config_entry(
-        api_version=ApiVersions.V_26_020.value,
+        api_version=ApiVersion.V_26_020.label,
         circulation=1,
         differential_module=1,
     )

--- a/tests/test_quality_scale.py
+++ b/tests/test_quality_scale.py
@@ -10,6 +10,7 @@ fail this file and be answered for, which is exactly what a list that has to be
 updated by hand does.
 """
 
+import importlib.resources
 import json
 import pathlib
 
@@ -244,11 +245,20 @@ def test_every_error_a_form_shows_is_a_string(strings_file: str) -> None:
     assert not unused
 
 
-def test_the_platinum_rules_are_still_open() -> None:
-    """Typing and the library, the two that need work outside the checklist."""
-    assert _status("strict-typing") == "todo"
-    assert not (COMPONENT_DIR / "py.typed").exists()
+def test_the_platinum_rules_are_closed() -> None:
+    """The two the migration to `aiosolarfocus` was for.
 
-    assert _status("async-dependency") == "todo"
-    # The library is synchronous, which is what the executor calls are for
-    assert "async_add_executor_job" in _source("coordinator")
+    `async-dependency` wants a library that does not block, and
+    `strict-typing` wants one that is PEP 561 compliant. `pysolarfocus` was
+    neither, which is why both rules named it rather than anything here.
+    """
+    assert _status("async-dependency") == "done"
+    # Nothing goes through a thread pool any more: the library is awaited.
+    assert "async_add_executor_job" not in _source("coordinator")
+    assert "async_add_executor_job" not in _source("entity")
+    assert "async_add_executor_job" not in _source("config_flow")
+
+    assert _status("strict-typing") == "done"
+    assert (
+        importlib.resources.files("aiosolarfocus").joinpath("py.typed").is_file()
+    ), "the rule wants the dependency to ship a py.typed marker"

--- a/tests/test_recorded_controllers.py
+++ b/tests/test_recorded_controllers.py
@@ -1,0 +1,251 @@
+"""Set the integration up against four controllers that really exist.
+
+Only the vampair has ever been tested against hardware. The other four systems
+are reasoned from the register specification, which is exactly how #217
+happened: four registers the document grants to one system were read on all of
+them, a Pellet Elegance maps neither 2409 nor 2413, and the read that spanned
+them came back compacted - the return flow temperature reported 270.0 °C where
+the sensor said 22.1 °C.
+
+`aiosolarfocus` fixed that, but the fix is only as good as the evidence, and the
+evidence is these four dumps: real register readings filed on #237 by the owners
+of an EcoTop, two Pellet Elegances and a Therminator. Feeding them to a fake
+controller and setting an entry up on top is the only coverage those four
+systems will ever get without hardware.
+
+Refresh them with `python -m aiosolarfocus dump --host <controller> --json`.
+"""
+
+import json
+import pathlib
+
+from aiosolarfocus import ApiVersion, Systems
+import pytest
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+
+from .conftest import build_config_entry, controller_of
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures"
+
+# The dump, the system it was taken from, and what the entry has to be
+# configured with to read it. The Therminator dump is filed with `"system":
+# "Ecotop"` in its own metadata - the contributor ran `dump` without correcting
+# the system - so the file name is the only record of what the boiler is, and
+# the registers were read as an EcoTop's either way. It is listed as what it was
+# read as.
+RECORDED = [
+    ("ecotop.json", Systems.ECOTOP, {"heating_circuit": 2, "buffer": 1, "boiler": 1}),
+    (
+        "pellet_elegance_21_110.json",
+        Systems.PELLETELEGANCE,
+        {"heating_circuit": 1, "buffer": 1, "boiler": 1},
+    ),
+    (
+        "pellet_elegance_25_110.json",
+        Systems.PELLETELEGANCE,
+        {"heating_circuit": 1, "buffer": 1, "boiler": 1},
+    ),
+    ("therminator.json", Systems.ECOTOP, {"heating_circuit": 1, "buffer": 1, "boiler": 1}),
+]
+
+
+def _dump(name: str) -> dict:
+    """Return one recorded controller."""
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _replay(client, dump: dict) -> None:
+    """Put every word the controller answered back where it answered it.
+
+    A dump records a register as one number, so how many words that was is a
+    fact about the register rather than about the number: 54186 is one word as
+    a heating circuit's setpoint and two as a pellet counter, and guessing from
+    the magnitude puts a 32-bit counter's whole value in its high word.
+    """
+    controller = controller_of(client)
+
+    for key, readings in dump["components"].items():
+        component = _component_of(client, key)
+        if component is None:
+            # The dump records more than this entry is configured for - the
+            # EcoTop has two heating circuits and some tests want one.
+            continue
+        for register, reading in readings.items():
+            resolved = component.layout.by_name.get(register)
+            if resolved is None or reading["raw"] is None:
+                continue
+
+            raw = reading["raw"]
+            width = len(resolved.addresses)
+            for offset, address in enumerate(resolved.addresses):
+                word = (raw >> (16 * (width - 1 - offset))) & 0xFFFF
+                controller.set(resolved.kind, address, word)
+
+
+def _component_of(client, name: str):
+    """Return the component a dump names as a string, if this entry has it."""
+    key = next((key for key in client.components if str(key) == name), None)
+
+    return None if key is None else client.components[key]
+
+
+@pytest.mark.parametrize(("name", "system", "options"), RECORDED, ids=lambda v: str(v))
+async def test_a_recorded_controller_sets_up_and_reports_its_readings(
+    hass: HomeAssistant,
+    enable_custom_integrations,
+    mock_client,
+    name: str,
+    system: Systems,
+    options: dict,
+) -> None:
+    """The whole chain, on registers a real controller really answered with."""
+    dump = _dump(name)
+    entry = build_config_entry(
+        system,
+        api_version=ApiVersion.parse(dump["meta"]["api_version"]).label,
+        biomassboiler=True,
+        **options,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    _replay(mock_client.instance, dump)
+    await entry.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert not entry.runtime_data.failed_components
+
+    states = [
+        hass.states.get(entity_id)
+        for entity_id in hass.states.async_entity_ids()
+        if entity_id.split(".", 1)[1].startswith(("heating_circuit", "boiler", "buffer", "biomass_boiler"))
+    ]
+
+    assert states, "the entry built no entities at all"
+    assert not [state for state in states if state.state == STATE_UNAVAILABLE]
+
+
+@pytest.mark.parametrize(("name", "system", "options"), RECORDED, ids=lambda v: str(v))
+async def test_a_recorded_controller_reports_what_the_dump_recorded(
+    hass: HomeAssistant,
+    enable_custom_integrations,
+    mock_client,
+    name: str,
+    system: Systems,
+    options: dict,
+) -> None:
+    """Every value the dump decoded reaches the entity that reports it.
+
+    This is the assertion #217 would have failed: a Pellet Elegance read its
+    return flow temperature as 270.0 °C where the sensor said 22.1, because the
+    read spanned an address the firmware does not map. Holding the entity
+    against the value the library decoded from the same words is what says the
+    register map and the entity agree.
+    """
+    dump = _dump(name)
+    entry = build_config_entry(
+        system,
+        api_version=ApiVersion.parse(dump["meta"]["api_version"]).label,
+        biomassboiler=True,
+        **options,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    client = mock_client.instance
+    _replay(client, dump)
+    await entry.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+
+    mismatched = []
+    compared = 0
+    for key, readings in dump["components"].items():
+        component = _component_of(client, key)
+        if component is None:
+            continue
+        for register, reading in readings.items():
+            if reading["value"] is None or not component.supports(register):
+                continue
+
+            now = component.value_of(getattr(type(component), register))
+            if now == reading["value"]:
+                compared += 1
+                continue
+            # A reading the library has since learned to recognise as a
+            # sentinel decodes to None: these dumps were taken with 0.1.0, and
+            # they are what taught it. -1% cleaning, -0.1% humidity, -999.9 °C
+            # outdoor and a flag register of 0xFFFF are all in here.
+            if now is None and component.raw(getattr(type(component), register)) is not None:
+                continue
+            mismatched.append((key, register, reading["value"], now))
+
+    assert not mismatched, (
+        f"{name} decodes differently now than when it was recorded: {mismatched}"
+    )
+    # The sentinel exemption above must not be the whole of it: if every value
+    # were exempt this test would assert nothing at all.
+    assert compared >= 20, f"only {compared} readings were actually compared"
+
+
+@pytest.mark.parametrize(
+    ("name", "system", "expected"),
+    [
+        ("pellet_elegance_21_110.json", Systems.PELLETELEGANCE, 25.7),
+        ("pellet_elegance_25_110.json", Systems.PELLETELEGANCE, 21.1),
+        ("ecotop.json", Systems.ECOTOP, 30.4),
+    ],
+)
+async def test_the_return_flow_temperature_is_the_one_the_sensor_read(
+    hass: HomeAssistant,
+    enable_custom_integrations,
+    mock_client,
+    name: str,
+    system: Systems,
+    expected: float,
+) -> None:
+    """Regression test for #217, on the controllers it was reported from.
+
+    Register 2410 is the boiler's return flow temperature on a Pellet Elegance
+    and an EcoTop. A Pellet Elegance maps neither 2409 nor 2413, so the read
+    that spanned them came back compacted and the sensor reported 270.0 °C
+    where the thermometer said 22.1. These are the words those controllers
+    really answered with.
+    """
+    dump = _dump(name)
+    entry = build_config_entry(
+        system,
+        api_version=ApiVersion.parse(dump["meta"]["api_version"]).label,
+        biomassboiler=True,
+        heating_circuit=1,
+        buffer=1,
+        boiler=1,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    _replay(mock_client.instance, dump)
+    await entry.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.biomass_boiler_return_temperature")
+
+    assert state is not None
+    assert state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN)
+    assert float(state.state) == expected
+
+
+def test_the_recordings_are_all_used() -> None:
+    """A dump nobody reads is a file, not a test."""
+    assert {name for name, _, _ in RECORDED} == {
+        path.name for path in FIXTURES.glob("*.json")
+    }

--- a/tests/test_repair_issues.py
+++ b/tests/test_repair_issues.py
@@ -5,6 +5,8 @@ are otherwise invisible: one is a log line written once at migration, the other
 is a component that has gone unavailable for good.
 """
 
+from aiosolarfocus import ComponentId
+
 from custom_components.solarfocus.const import (
     CONF_BOILER,
     CONF_BUFFER,
@@ -15,7 +17,7 @@ from custom_components.solarfocus.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, issue_registry as ir
 
-from .conftest import build_config_entry
+from .conftest import build_config_entry, revive
 
 
 def _issue(hass: HomeAssistant, issue_id: str):
@@ -31,7 +33,7 @@ async def _setup(hass: HomeAssistant, **options):
 
 
 async def test_no_issue_for_an_entry_that_is_fine(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """A working entry raises nothing, which is what makes the rest mean something."""
     entry = await _setup(hass, heating_circuit=1, boiler=1)
@@ -41,7 +43,7 @@ async def test_no_issue_for_an_entry_that_is_fine(
 
 
 async def test_the_duplicate_the_migration_left_behind_is_reported(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """Two entries on one controller, from before the address identified one.
 
@@ -67,7 +69,7 @@ async def test_the_duplicate_the_migration_left_behind_is_reported(
 
 
 async def test_an_entry_alone_on_its_address_is_not_a_duplicate(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """Having no unique id is only worth reporting while something else has it.
 
@@ -87,7 +89,7 @@ async def test_an_entry_alone_on_its_address_is_not_a_duplicate(
 
 
 async def test_the_duplicate_issue_clears_once_the_other_entry_is_gone(
-    hass: HomeAssistant, enable_custom_integrations, mock_api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """Doing what the issue asks has to be what clears it.
 
@@ -116,7 +118,7 @@ async def test_the_duplicate_issue_clears_once_the_other_entry_is_gone(
 
 
 async def test_removing_an_entry_takes_its_issues_with_it(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """An issue outlives the entry it names, which the registry does not notice.
 
@@ -124,12 +126,12 @@ async def test_removing_an_entry_takes_its_issues_with_it(
     configured, naming an entry the user cannot open, until Home Assistant is
     restarted.
     """
-    api.update_heating.return_value = False
+    mock_client.silence(ComponentId.HEATING_CIRCUITS)
 
     entry = await _setup(hass, heating_circuit=1, boiler=1)
 
     assert _issue(
-        hass, f"component_unavailable_{entry.entry_id}_{CONF_HEATING_CIRCUIT}"
+        hass, f"component_unavailable_{entry.entry_id}_{CONF_HEATING_CIRCUIT}1"
     ) is not None
 
     await hass.config_entries.async_remove(entry.entry_id)
@@ -139,7 +141,7 @@ async def test_removing_an_entry_takes_its_issues_with_it(
 
 
 async def test_switching_a_failing_component_off_clears_its_issue(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The issue asks the user to switch the component off, so that has to work.
 
@@ -147,10 +149,10 @@ async def test_switching_a_failing_component_off_clears_its_issue(
     has never seen the component fail - and one that never reads it again, so
     nothing about the failure changes for it to notice.
     """
-    api.update_boiler.return_value = False
+    mock_client.silence(ComponentId.BOILERS)
 
     entry = await _setup(hass, heating_circuit=1, boiler=1)
-    issue_id = f"component_unavailable_{entry.entry_id}_{CONF_BOILER}"
+    issue_id = f"component_unavailable_{entry.entry_id}_{CONF_BOILER}1"
 
     assert _issue(hass, issue_id) is not None
 
@@ -163,30 +165,30 @@ async def test_switching_a_failing_component_off_clears_its_issue(
 
 
 async def test_a_component_that_answers_nothing_is_reported(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """A register range the firmware does not answer fails on every poll.
 
     The entities of that component are unavailable while it lasts, and nothing
     in the entry says why: the log line that does is written once.
     """
-    api.update_heating.return_value = False
+    mock_client.silence(ComponentId.HEATING_CIRCUITS)
 
     entry = await _setup(hass, heating_circuit=1, boiler=1)
 
     issue = _issue(
-        hass, f"component_unavailable_{entry.entry_id}_{CONF_HEATING_CIRCUIT}"
+        hass, f"component_unavailable_{entry.entry_id}_{CONF_HEATING_CIRCUIT}1"
     )
 
     assert issue is not None
     assert issue.translation_placeholders["component"] == "Heating circuit 1"
     assert issue.translation_placeholders["address"] == "solarfocus.local:502"
     # The component that reads fine has nothing raised against it
-    assert _issue(hass, f"component_unavailable_{entry.entry_id}_{CONF_BOILER}") is None
+    assert _issue(hass, f"component_unavailable_{entry.entry_id}_{CONF_BOILER}1") is None
 
 
 async def test_the_issue_names_the_component_the_way_the_device_page_does(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The option is what the coordinator calls a component, not what a user does.
 
@@ -195,26 +197,33 @@ async def test_the_issue_names_the_component_the_way_the_device_page_does(
     issue naming the option asks the user to recognise their heating system in
     a configuration key.
 
-    Every instance is named, because every instance is behind the issue: the
-    library reads both fresh water modules in one call, so one that answers
-    nothing is both of them as far as anything here can tell.
+    One instance is named, because one instance is what failed. The
+    predecessor read both fresh water modules in one call and stopped at the
+    first that failed, so one that answered nothing was both of them as far as
+    anything here could tell; the library attributes a refused read to the
+    instances whose registers were in it.
     """
-    api.update_fresh_water_modules.return_value = False
+    mock_client.silence(ComponentId.FRESH_WATER_MODULES)
 
     entry = await _setup(hass, heating_circuit=1, fresh_water_module=2)
 
     issue = _issue(
-        hass, f"component_unavailable_{entry.entry_id}_{CONF_FRESH_WATER_MODULE}"
+        hass, f"component_unavailable_{entry.entry_id}_{CONF_FRESH_WATER_MODULE}1"
     )
 
     assert issue is not None
-    assert issue.translation_placeholders["component"] == (
-        "Fresh water module 1, Fresh water module 2"
+    assert issue.translation_placeholders["component"] == "Fresh water module 1"
+    # The other one reads, so it has no issue of its own.
+    assert (
+        _issue(
+            hass, f"component_unavailable_{entry.entry_id}_{CONF_FRESH_WATER_MODULE}2"
+        )
+        is None
     )
 
 
 async def test_the_issue_names_the_component_in_the_language_of_the_system(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The device name is translated, so the issue that borrows it is too.
 
@@ -224,12 +233,12 @@ async def test_the_issue_names_the_component_in_the_language_of_the_system(
     """
     await hass.config.async_update(language="de")
 
-    api.update_heating.return_value = False
+    mock_client.silence(ComponentId.HEATING_CIRCUITS)
 
     entry = await _setup(hass, heating_circuit=1, boiler=1)
 
     issue = _issue(
-        hass, f"component_unavailable_{entry.entry_id}_{CONF_HEATING_CIRCUIT}"
+        hass, f"component_unavailable_{entry.entry_id}_{CONF_HEATING_CIRCUIT}1"
     )
 
     assert issue is not None
@@ -237,14 +246,14 @@ async def test_the_issue_names_the_component_in_the_language_of_the_system(
 
 
 async def test_the_issue_calls_the_component_what_the_user_renamed_it_to(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """A renamed device is the name the user knows that component by.
 
     Nothing else they read says `Boiler 1` any more, so an issue that does is
     about a component they cannot place.
     """
-    api.update_boiler.return_value = False
+    mock_client.silence(ComponentId.BOILERS)
 
     entry = await _setup(hass, heating_circuit=1, boiler=1)
     registry = dr.async_get(hass)
@@ -254,45 +263,43 @@ async def test_the_issue_calls_the_component_what_the_user_renamed_it_to(
     registry.async_update_device(device.id, name_by_user="Dusche")
     await entry.runtime_data.async_refresh()
 
-    issue = _issue(hass, f"component_unavailable_{entry.entry_id}_{CONF_BOILER}")
+    issue = _issue(hass, f"component_unavailable_{entry.entry_id}_{CONF_BOILER}1")
 
     assert issue is not None
     assert issue.translation_placeholders["component"] == "Dusche"
 
 
 async def test_the_issue_links_the_device_pages_of_the_component(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The issue is about a device and there is no device field to say so.
 
     A repair issue takes placeholders and nothing that binds it to a device, so
-    the link is markdown in the description - one per instance, because the
-    issue covers all of them. What it has to point at is a device that is in
-    the registry: a link to a page that does not exist is worse than no link.
+    the link is markdown in the description - one per issue, and an issue is
+    about one instance. What it has to point at is a device that is in the
+    registry: a link to a page that does not exist is worse than no link.
     """
-    api.update_buffer.return_value = False
+    mock_client.silence(ComponentId.BUFFERS, index=2)
 
     entry = await _setup(hass, heating_circuit=1, buffer=2)
     registry = dr.async_get(hass)
 
-    issue = _issue(hass, f"component_unavailable_{entry.entry_id}_{CONF_BUFFER}")
+    issue = _issue(hass, f"component_unavailable_{entry.entry_id}_{CONF_BUFFER}2")
 
     assert issue is not None
 
-    devices = [
-        registry.async_get_device({(DOMAIN, f"{entry.entry_id}_bu{index}")})
-        for index in (1, 2)
-    ]
+    device = registry.async_get_device({(DOMAIN, f"{entry.entry_id}_bu2")})
 
-    assert all(device is not None for device in devices)
-    assert issue.translation_placeholders["devices"] == ", ".join(
-        f"[Buffer {index}](/config/devices/device/{device.id})"
-        for index, device in enumerate(devices, start=1)
+    assert device is not None
+    assert issue.translation_placeholders["devices"] == (
+        f"[Buffer 2](/config/devices/device/{device.id})"
     )
+    # The buffer that reads is not linked from anywhere.
+    assert _issue(hass, f"component_unavailable_{entry.entry_id}_{CONF_BUFFER}1") is None
 
 
 async def test_an_issue_raised_before_the_devices_exist_is_named_once_they_do(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The first refresh of a new entry is the one that has no devices to name.
 
@@ -301,12 +308,12 @@ async def test_an_issue_raised_before_the_devices_exist_is_named_once_they_do(
     that register the devices exist. Without a second look the user would be
     left with the option name and no link until the next poll.
     """
-    api.update_heating.return_value = False
+    mock_client.silence(ComponentId.HEATING_CIRCUITS)
 
     entry = await _setup(hass, heating_circuit=1, boiler=1)
 
     issue = _issue(
-        hass, f"component_unavailable_{entry.entry_id}_{CONF_HEATING_CIRCUIT}"
+        hass, f"component_unavailable_{entry.entry_id}_{CONF_HEATING_CIRCUIT}1"
     )
     device = dr.async_get(hass).async_get_device({(DOMAIN, f"{entry.entry_id}_hc1")})
 
@@ -319,25 +326,25 @@ async def test_an_issue_raised_before_the_devices_exist_is_named_once_they_do(
 
 
 async def test_a_component_coming_back_clears_only_its_own_issue(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """One issue per component, so a recovery leaves the others standing.
 
     The buffer reads fine throughout: every configured component failing is an
     outage rather than a partial failure, and fails the refresh instead.
     """
-    api.update_heating.return_value = False
-    api.update_boiler.return_value = False
+    mock_client.silence(ComponentId.HEATING_CIRCUITS)
+    mock_client.silence(ComponentId.BOILERS)
 
     entry = await _setup(hass, heating_circuit=1, boiler=1, buffer=1)
 
-    heating = f"component_unavailable_{entry.entry_id}_{CONF_HEATING_CIRCUIT}"
-    boiler = f"component_unavailable_{entry.entry_id}_{CONF_BOILER}"
+    heating = f"component_unavailable_{entry.entry_id}_{CONF_HEATING_CIRCUIT}1"
+    boiler = f"component_unavailable_{entry.entry_id}_{CONF_BOILER}1"
 
     assert _issue(hass, heating) is not None
     assert _issue(hass, boiler) is not None
 
-    api.update_heating.return_value = True
+    revive(mock_client.instance, ComponentId.HEATING_CIRCUITS)
     await entry.runtime_data.async_refresh()
 
     assert _issue(hass, heating) is None
@@ -345,7 +352,7 @@ async def test_a_component_coming_back_clears_only_its_own_issue(
 
 
 async def test_an_outage_takes_the_component_issues_down_with_it(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The issue says every other component reads fine, so it has to go.
 
@@ -353,26 +360,26 @@ async def test_an_outage_takes_the_component_issues_down_with_it(
     Assistant is retrying, which is not a component the user should be asked
     to check their configuration for. It comes back with the system.
     """
-    api.update_boiler.return_value = False
+    mock_client.silence(ComponentId.BOILERS)
 
     entry = await _setup(hass, heating_circuit=1, boiler=1)
-    issue_id = f"component_unavailable_{entry.entry_id}_{CONF_BOILER}"
+    issue_id = f"component_unavailable_{entry.entry_id}_{CONF_BOILER}1"
 
     assert _issue(hass, issue_id) is not None
 
-    api.update_heating.return_value = False
+    mock_client.silence(ComponentId.HEATING_CIRCUITS)
     await entry.runtime_data.async_refresh()
 
     assert _issue(hass, issue_id) is None
 
-    api.update_heating.return_value = True
+    revive(mock_client.instance, ComponentId.HEATING_CIRCUITS)
     await entry.runtime_data.async_refresh()
 
     assert _issue(hass, issue_id) is not None
 
 
 async def test_nothing_is_raised_when_the_whole_system_is_unreachable(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """That is not a repair, it is an outage.
 
@@ -380,9 +387,7 @@ async def test_nothing_is_raised_when_the_whole_system_is_unreachable(
     the entities unavailable and has Home Assistant retry. Asking the user to
     check their component selection for it would be wrong.
     """
-    api.update_heating.return_value = False
-    api.connect.return_value = False
-    api.is_connected = False
+    mock_client.offline()
 
     entry = build_config_entry(heating_circuit=1)
     entry.add_to_hass(hass)

--- a/tests/test_sensor_enum_options.py
+++ b/tests/test_sensor_enum_options.py
@@ -16,6 +16,7 @@ option without a translation merely renders as a raw number.
 import json
 import pathlib
 
+from aiosolarfocus import ComponentId
 import pytest
 
 from custom_components.solarfocus import sensor
@@ -125,7 +126,7 @@ def test_options_are_strings(translation_key: str, options: list[str]) -> None:
 
 
 async def test_the_state_of_an_enum_sensor_is_one_of_its_options(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """Regression test for #193.
 
@@ -134,7 +135,7 @@ async def test_the_state_of_an_enum_sensor_is_one_of_its_options(
     options were numbers and the state was the string of one, no condition built
     that way could ever match.
     """
-    api.heatpump.vampair_state.scaled_value = 3
+    mock_client.reads(ComponentId.HEAT_PUMP, "vampair_state", 3)
     entry = build_config_entry(heatpump=True)
     entry.add_to_hass(hass)
 
@@ -148,7 +149,7 @@ async def test_the_state_of_an_enum_sensor_is_one_of_its_options(
 
 
 async def test_an_enum_sensor_survives_a_register_holding_a_bool(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """A bool left in a register must not cost the entity its state.
 
@@ -157,7 +158,7 @@ async def test_an_enum_sensor_survives_a_register_holding_a_bool(
     the coordinator tolerates on purpose, whatever was written stays in the
     component until the next poll: str(True) is "True", not an option.
     """
-    api.boilers[0].single_charge.scaled_value = True
+    mock_client.reads(ComponentId.BOILERS, "single_charge", 1)
     entry = build_config_entry(boiler=1)
     entry.add_to_hass(hass)
 

--- a/tests/test_service_menu.py
+++ b/tests/test_service_menu.py
@@ -187,7 +187,7 @@ async def test_the_number_writes_nothing_to_the_heating_system(
 
 
 async def test_the_number_survives_a_restart(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, entity_registry,
+    hass: HomeAssistant, enable_custom_integrations, mock_client, entity_registry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """The display keeps showing the number, so Home Assistant keeps it too.
@@ -226,7 +226,7 @@ async def test_the_number_survives_a_restart(
 
 
 async def test_the_number_takes_the_four_digits_the_display_shows(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, entity_registry,
+    hass: HomeAssistant, enable_custom_integrations, mock_client, entity_registry,
 ) -> None:
     """The installer menu shows up to four digits, so 9999 is the highest there is."""
     entry = build_config_entry()
@@ -321,7 +321,7 @@ def test_they_stay_available_when_a_component_cannot_be_read(
 
 
 async def test_the_registry_agrees_where_they_belong(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, device_registry,
+    hass: HomeAssistant, enable_custom_integrations, mock_client, device_registry,
     entity_registry,
 ) -> None:
     """The registry is what puts them on the page of the controller.
@@ -355,7 +355,7 @@ async def test_the_registry_agrees_where_they_belong(
 
 
 async def test_the_codes_change_at_midnight(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, entity_registry,
+    hass: HomeAssistant, enable_custom_integrations, mock_client, entity_registry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """A code a day old opens nothing, and nothing polls these entities."""

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -16,7 +16,7 @@ import json
 import pathlib
 import re
 
-from pysolarfocus import ApiVersions, Systems
+from aiosolarfocus import ApiVersion, ComponentId, Systems
 import pytest
 
 from custom_components.solarfocus import (
@@ -48,7 +48,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.translation import async_get_translations
 
-from .conftest import build_config_entry, build_coordinator
+from .conftest import (
+    build_config_entry,
+    build_coordinator,
+    every_component,
+    set_reading,
+)
 
 COMPONENT_DIR = pathlib.Path(sensor.__file__).parent
 
@@ -155,17 +160,8 @@ async def _translation_keys(hass: HomeAssistant) -> dict[str, set[str]]:
         for system in Systems:
             entry = build_config_entry(
                 system,
-                api_version=ApiVersions.V_26_020.value,
-                heating_circuit=1,
-                buffer=1,
-                boiler=1,
-                fresh_water_module=1,
-                circulation=1,
-                differential_module=1,
-                solar=1,
-                heatpump=True,
-                biomassboiler=True,
-                photovoltaic=True,
+                api_version=ApiVersion.V_26_020.label,
+                **every_component(system),
             )
             entry.add_to_hass(hass)
             entry.runtime_data = build_coordinator(entry)
@@ -277,6 +273,7 @@ def test_something_raises_a_translated_exception() -> None:
         "cannot_connect",
         "cannot_read",
         "cannot_set_up",
+        "invalid_configuration",
     }
 
 
@@ -380,17 +377,17 @@ async def _descriptions(hass: HomeAssistant):
         for system in Systems:
             entry = build_config_entry(
                 system,
-                api_version=ApiVersions.V_26_020.value,
-                heating_circuit=2,
-                buffer=2,
-                boiler=2,
-                fresh_water_module=2,
-                circulation=2,
-                differential_module=2,
-                solar=2,
-                heatpump=True,
-                biomassboiler=True,
-                photovoltaic=True,
+                api_version=ApiVersion.V_26_020.label,
+                **every_component(
+                    system,
+                    heating_circuit=2,
+                    buffer=2,
+                    boiler=2,
+                    fresh_water_module=2,
+                    circulation=2,
+                    differential_module=2,
+                    solar=2,
+                ),
             )
             entry.add_to_hass(hass)
             entry.runtime_data = build_coordinator(entry)
@@ -483,20 +480,23 @@ async def test_no_entity_name_repeats_its_component(
 
 
 async def test_home_assistant_shows_the_translated_name(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The one that fails if the placeholder never reaches the translation.
 
     Everything above reads the file. This reads the name off a running entity,
     which is where a `{idx}` that nothing substitutes would show up literally.
     """
-    api.heating_circuits[0].room_temperature.scaled_value = 21
-    api.solar[0].collector_temperature_1.scaled_value = 61
-
     entry = build_config_entry(heating_circuit=2, solar=1)
     entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    client = mock_client.instance
+    set_reading(client, ComponentId.HEATING_CIRCUITS, "room_temperature", 21)
+    set_reading(client, ComponentId.SOLAR, "collector_temperature_1", 61)
+    await entry.runtime_data.async_refresh()
     await hass.async_block_till_done()
 
     second = hass.states.get("sensor.heating_circuit_2_room_temperature")
@@ -513,7 +513,7 @@ async def test_home_assistant_shows_the_translated_name(
 
 
 async def test_a_german_installation_keeps_the_english_entity_ids(
-    hass: HomeAssistant, enable_custom_integrations, mock_api, api
+    hass: HomeAssistant, enable_custom_integrations, mock_client
 ) -> None:
     """The reading an entity id names stays English in every language.
 
@@ -529,12 +529,16 @@ async def test_a_german_installation_keeps_the_english_entity_ids(
     """
     await hass.config.async_update(language="de")
 
-    api.heating_circuits[0].room_temperature.scaled_value = 21
-
     entry = build_config_entry(heating_circuit=1)
     entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    set_reading(
+        mock_client.instance, ComponentId.HEATING_CIRCUITS, "room_temperature", 21
+    )
+    await entry.runtime_data.async_refresh()
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.heizkreis_1_room_temperature")

--- a/uv.lock
+++ b/uv.lock
@@ -187,6 +187,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosolarfocus"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pymodbus" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/ec/240b5bf10ea14261007e4ac2c28cb05de31e14f7222ebcef4a1bc8253474/aiosolarfocus-0.2.0.tar.gz", hash = "sha256:34f3f13fef90ad35dd4f5ec5abd55bcabffde250a38f56ab23cbe500f55b22c7", size = 99793, upload-time = "2026-08-24T05:15:42.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/de/b364f34a76c482d9c8c8047ddffa9acf83816bcdd312d62af69ff8723c3e/aiosolarfocus-0.2.0-py3-none-any.whl", hash = "sha256:a23e3e023bced6e651675cecad1de4ad5f66eb8e13dc40a47f4db93910d019e4", size = 83658, upload-time = "2026-08-24T05:15:41.89Z" },
+]
+
+[[package]]
 name = "aiozoneinfo"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2015,19 +2027,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/08/64/a99f27d3b4347486c7bfc0aa516016c46dc4c0f380ffccbd742a61af1eda/PyRIC-0.1.6.3.tar.gz", hash = "sha256:b539b01cafebd2406c00097f94525ea0f8ecd1dd92f7731f43eac0ef16c2ccc9", size = 870401, upload-time = "2016-12-04T07:54:48.374Z" }
 
 [[package]]
-name = "pysolarfocus"
-version = "5.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "pymodbus" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/30/b9/a9e046eb721ea90be3e1938143fa52162134ecb4c09f3ffed85e805ae933/pysolarfocus-5.3.0.tar.gz", hash = "sha256:979f56d37d7f3ddcc37ad75c03bcc4626b2a9c57767356ad78f3c6bd40e1166b", size = 744343, upload-time = "2026-08-20T09:38:25.064Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/be/d53e744fbd2dc60823c94e22e5a926688bd082cdcda33b60829ec1e03278/pysolarfocus-5.3.0-py3-none-any.whl", hash = "sha256:43d5be978a6d66bd48335011bd50c9c9d22d58ebad8a022722d73def7f6e4c68", size = 32351, upload-time = "2026-08-20T09:38:23.961Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2441,14 +2440,14 @@ wheels = [
 
 [[package]]
 name = "solarfocus"
-version = "6.0.0"
+version = "7.0.0rc1"
 source = { editable = "." }
 dependencies = [
+    { name = "aiosolarfocus" },
     { name = "homeassistant" },
     { name = "packaging" },
     { name = "pydantic-settings" },
     { name = "pylint" },
-    { name = "pysolarfocus" },
     { name = "pytest-homeassistant-custom-component" },
     { name = "pytest-socket" },
 ]
@@ -2461,11 +2460,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosolarfocus", specifier = ">=0.2.0,<1" },
     { name = "homeassistant", specifier = ">=2026.8.0,<2027" },
     { name = "packaging", specifier = "~=24.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pylint", specifier = ">=3.3.3" },
-    { name = "pysolarfocus", specifier = ">=5.3.0,<6" },
     { name = "pytest-homeassistant-custom-component", specifier = ">=0.13.355,<0.14" },
     { name = "pytest-socket", specifier = ">=0.8.0,<0.9" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -188,14 +188,14 @@ wheels = [
 
 [[package]]
 name = "aiosolarfocus"
-version = "0.2.0"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pymodbus" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/ec/240b5bf10ea14261007e4ac2c28cb05de31e14f7222ebcef4a1bc8253474/aiosolarfocus-0.2.0.tar.gz", hash = "sha256:34f3f13fef90ad35dd4f5ec5abd55bcabffde250a38f56ab23cbe500f55b22c7", size = 99793, upload-time = "2026-08-24T05:15:42.853Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/59/9e14e063cb1e75e346616a4cb5ab095b7420481e3c6665e895ed0e7d4f6f/aiosolarfocus-0.2.1.tar.gz", hash = "sha256:dc1f695cda765944437e75c9061767531e0ae1c26e797b514ecd3b33970b8b6c", size = 102791, upload-time = "2026-08-26T08:42:17.992Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/de/b364f34a76c482d9c8c8047ddffa9acf83816bcdd312d62af69ff8723c3e/aiosolarfocus-0.2.0-py3-none-any.whl", hash = "sha256:a23e3e023bced6e651675cecad1de4ad5f66eb8e13dc40a47f4db93910d019e4", size = 83658, upload-time = "2026-08-24T05:15:41.89Z" },
+    { url = "https://files.pythonhosted.org/packages/85/dc/b097c740ea7a338bb5a5467bdd4c093ad39f162ab24e67c1ff580e77add7/aiosolarfocus-0.2.1-py3-none-any.whl", hash = "sha256:7a71662b81f7f1f0e88f9c29c372cc946a2442ce56f4274c64cca4af5711c22a", size = 84104, upload-time = "2026-08-26T08:42:17.006Z" },
 ]
 
 [[package]]
@@ -2460,7 +2460,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiosolarfocus", specifier = ">=0.2.0,<1" },
+    { name = "aiosolarfocus", specifier = ">=0.2.1,<1" },
     { name = "homeassistant", specifier = ">=2026.8.0,<2027" },
     { name = "packaging", specifier = "~=24.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },


### PR DESCRIPTION
## Summary

Closes the migration #237 said was "a separate migration, for later". `pysolarfocus` is synchronous and ships no `py.typed`, which is precisely what the last two Platinum rules named as their blocker — so this **reaches Platinum** on the quality scale.

`aiosolarfocus` is [not a drop-in replacement](https://github.com/LavermanJJ/aiosolarfocus/blob/main/docs/porting-from-pysolarfocus.md); this is `7.0.0-rc1`.

### The seam

| Before | After |
|---|---|
| `SolarfocusAPI(ip=…, heating_circuit_count=…, …)` | `SolarfocusClient(SolarfocusConfig(…))` |
| ten `update_*` calls in a loop, each returning `bool` | one `await client.update()` returning `UpdateResult` |
| `not api.is_connected` after a `False` | `except SolarfocusConnectionError` |
| `getattr(component, key).scaled_value` | `getattr(component, key)` |
| `set_unscaled_value` → `commit` → `component.update()` | `await component.write(register, value)` |
| two's-complement arithmetic in `entity.py` | the library encodes it |
| `min_required_version` / `unsupported_systems` | `component.supports()` |
| `vars(component)` + `isinstance(…, Part)` | `client.snapshot()` |

**Nothing blocks the event loop any more.** `async_add_executor_job` is gone from the integration entirely, and so are the two Modbus calls that never went through it in the first place — `commit()` and the whole-component re-read after every single write. A climate service call was four blocking writes and four full re-reads; it is now one grouped write under one hold of the transport lock, which is what the register document asks for. `async_unload_entry` closes the socket, which nothing did before.

**Availability is per component instance.** `UpdateResult.failed` is keyed by instance, so one buffer that answers nothing is one buffer — the predecessor read all four in one call and stopped at the first failure, greying out all of them. One repair issue per failing instance, linking that instance's device page.

### Behaviour changes

I diffed the old gating against the library's across **all five systems × all eleven firmware versions** while both were still in the tree. 292 disagreements, of three kinds:

- **Firmware 20.110 gains ~50 entities** (271 of the 292). Every description defaulted to `min_required_version = "21.140"` — a floor the integration picked, never a claim about any register. 20.110 is selectable, so an entry set to it showed almost nothing.
- **Two entities go away, both correctly** (11). EcoTop `bu*_x35_temperature` (buffer 1902 is the Therminator's per the register document — one of the four registers #217 was about) and Therminator `bb_log_wood` on 21.140 only (2412 arrived in 22.090, and a read spanning an unmapped address is compacted, not padded).
- **Octoplus `bb_door_contact` stays out** (10), deliberately. The library maps 2405 on every biomass boiler and is right to — the register is there and answers. What is unmeasured is *which way round* on an Octoplus, and #91/#79/#80 is the history of getting that wrong. Kept out through a new `unverified_systems` field that says what it actually means, rather than reversing a decision made from measurement. It is the only use.

**Entity ids do not change.** The library renamed the heat pump's `performance_overall*` to `seasonal_performance*`; the descriptions keep `performance_overall*` as their key and name the register separately, so those three sensors keep their ids, their history and anything set on them. A test pins that no other description does this.

**Values that used to be numbers can be `None`.** The five coefficients of performance report `None` on an idle heat pump rather than `0.0` — which Home Assistant was recording as a measurement. Sentinel readings (`-1 %` cleaning, `-999.9 °C` outdoor, a flag register of `0xFFFF`) decode to `None` instead of being published as real values.

**Bugs fixed in the library rather than carried over**: #217's misread return flow temperature, the fresh water module cascade that raised `AttributeError` on every controller from 23.040 on, a Therminator/EcoTop heating circuit resolving every register at a default firmware version, and readings carrying floating-point noise into whatever recorded them.

No config entry migration: `Systems` values are byte-compatible with what entries already store, and `ApiVersion.parse` reads the stored `"25.030"` form (and clamps a firmware newer than the library knows instead of raising).

### Tests

The fixtures drive a **real `SolarfocusClient` over `aiosolarfocus.testing.FakeController`** rather than a `MagicMock`, so the suite exercises real decoding, real gating and real wire values — including the controller's refusals and its gap compaction. Two defects fell out of that immediately: unload crashed on an entry that never set up, and an impossible entry (a Vampair with a biomass boiler) that the old library built silently is now refused.

New: **`tests/test_recorded_controllers.py`**. The four `dump --json` files contributed to #237 — a real EcoTop, two Pellet Elegances and a Therminator — ship as fixtures, and each sets an entry up end to end. #217 is pinned directly on them: register 2410 reports 25.7 / 21.1 / 30.4 °C, not 270.0. This is the only coverage those four systems will get without hardware.

## Test plan

- [x] `uv run pytest` — 691 passed, 2 skipped
- [x] `make check` (pylint, ruff, mypy strict) — clean
- [x] Gating parity diffed across 5 systems × 11 firmware versions before deleting the annotations
- [x] Entry set up end to end against four recorded real controllers
- [x] No `async_add_executor_job` and no `pysolarfocus` left in `custom_components/`
- [ ] **Against real hardware** — only the vampair is available to me; the other four systems are the recorded dumps above
