### PR TITLE
Give the solar heat meter flow the unit the controller gives it

### DIFF
--- a/custom_components/solarfocus/manifest.json
+++ b/custom_components/solarfocus/manifest.json
@@ -9,7 +9,7 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/lavermanjj/home-assistant-solarfocus/issues",
-  "requirements": ["aiosolarfocus==0.2.2"],
+  "requirements": ["aiosolarfocus==0.2.3"],
   "ssdp": [],
   "version": "7.0.0-rc2",
   "zeroconf": []

--- a/custom_components/solarfocus/sensor.py
+++ b/custom_components/solarfocus/sensor.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
     UnitOfMass,
     UnitOfPower,
     UnitOfTemperature,
-    UnitOfVolume,
     UnitOfVolumeFlowRate,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -792,7 +791,7 @@ SOLAR_SENSOR_TYPES = [
     ),
     SolarfocusSensorEntityDescription(
         key="flow_heat_meter",
-        native_unit_of_measurement=UnitOfVolume.LITERS,
+        native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_HOUR,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SolarfocusSensorEntityDescription(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.8.0,<2027",
-    "aiosolarfocus>=0.2.2,<1",
+    "aiosolarfocus>=0.2.3,<1",
     "packaging~=24.0",
     "pylint>=3.3.3",
     "pytest-homeassistant-custom-component>=0.13.355,<0.14",

--- a/uv.lock
+++ b/uv.lock
@@ -188,14 +188,14 @@ wheels = [
 
 [[package]]
 name = "aiosolarfocus"
-version = "0.2.2"
+version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pymodbus" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/2f/d5ce1ad986789fe0f89f8a9f1de1cfdb13410ff4e5c340eab6528c40b5c8/aiosolarfocus-0.2.2.tar.gz", hash = "sha256:18f20adb88cda97bd8996c957730b2dc7ed42e038606a7056b6e3785c5d817a5", size = 104544, upload-time = "2026-08-29T14:58:34.94Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/06/2cb61f14418ccd535a5025fa48d51290b9f8c26526bb460cbba0e08715de/aiosolarfocus-0.2.3.tar.gz", hash = "sha256:f2fe694eea256bec8110e2c13e99e5695a2187401039d3e6f932522ec57843f1", size = 104659, upload-time = "2026-08-30T10:45:41.811Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/4c/426078edbd189e38f4bce94ba9b001cfb739774be276210277ea805b9ec5/aiosolarfocus-0.2.2-py3-none-any.whl", hash = "sha256:65dfa6c46ab3d99df0ceb178a24b93493e25060f58e3ba0c739ef4c2149a29dc", size = 85087, upload-time = "2026-08-29T14:58:33.976Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/52/c02804df1b06a54bf80aebd1f1b458e86a594fa0fb08c09a8bd85122efef/aiosolarfocus-0.2.3-py3-none-any.whl", hash = "sha256:94afcf7e4c6e21bb80c4d93d1a7d6925e84a9e03c3763a5de741d997de3581dc", size = 85086, upload-time = "2026-08-30T10:45:40.471Z" },
 ]
 
 [[package]]
@@ -2460,7 +2460,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiosolarfocus", specifier = ">=0.2.2,<1" },
+    { name = "aiosolarfocus", specifier = ">=0.2.3,<1" },
     { name = "homeassistant", specifier = ">=2026.8.0,<2027" },
     { name = "packaging", specifier = "~=24.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },


### PR DESCRIPTION
Closes #239.

The solar flow sensor published input `2104` as **litres**, a volume, for a reading the eco-manager-touch shows as **l/h**. #239 asked for a measurement to settle whether the tenth the library applies is real, and fklein1980's Therminator 2 gave it: **23.3 in Home Assistant, 233 on the controller's own display, at the same moment**. So the register is an unscaled flow rate in litres per hour, and the register document was right to give it no scale factor.

Two commits, because the fix has two halves and only one of them lives here:

- **The unit** — `UnitOfVolume.LITERS` → `UnitOfVolumeFlowRate.LITERS_PER_HOUR`.
- **The tenth**, dropped in aiosolarfocus 0.2.3 (LavermanJJ/aiosolarfocus#8, now released), picked up here as a pin bump in `manifest.json`, `pyproject.toml` and `uv.lock`.

They had to land together: with the unit changed and the old scaling still in the library, the sensor would read a tenth of the real flow under a label that no longer looks wrong.

Worth saying in the release notes: **the solar flow sensor's value becomes ten times what it was, and its unit changes**, so Home Assistant will raise its usual statistics-unit repair for it, and the recorded history is a tenth of the truth.

`make check` and `make test` pass against 0.2.3 (691 passed, 5 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJgqKc1usTviSrXuA2Sn1T