### PR TITLE
Say which aiosolarfocus a diagnostics download was written from

### DIFF
--- a/custom_components/solarfocus/diagnostics.py
+++ b/custom_components/solarfocus/diagnostics.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from aiosolarfocus import __version__ as aiosolarfocus_version
+
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
@@ -29,6 +31,11 @@ async def async_get_config_entry_diagnostics(
     coordinator = entry.runtime_data
 
     return {
+        # The manifest pins one version, but a report is written from what is
+        # installed rather than from what is pinned - fklein1980 ran a stale
+        # aiosolarfocus against a controller and could not tell from its output
+        # (#237), which is the same trap a diagnostics download falls into.
+        "aiosolarfocus": aiosolarfocus_version,
         "entry": {
             "version": entry.version,
             "data": async_redact_data(entry.data, TO_REDACT),

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -8,6 +8,7 @@ it, and that the address of their controller is not.
 import json
 
 from aiosolarfocus import ApiVersion, ComponentId
+from aiosolarfocus import __version__ as aiosolarfocus_version
 from pytest_homeassistant_custom_component.components.diagnostics import (
     get_diagnostics_for_config_entry,
 )
@@ -43,6 +44,20 @@ async def test_diagnostics_hide_the_address_of_the_controller(
     # The port says nothing on its own and tells a non-standard setup apart
     assert diagnostics["entry"]["data"][CONF_PORT] == 502
     assert "solarfocus.local" not in str(diagnostics)
+
+
+async def test_diagnostics_name_the_library_version_actually_installed(
+    hass: HomeAssistant, enable_custom_integrations, mock_client
+) -> None:
+    """The manifest pins a version; a report has to say what is really there.
+
+    fklein1980 ran a stale aiosolarfocus against a controller and nothing in
+    the output said so (#237). A diagnostics download falls into the same trap,
+    and it is the one artefact an issue is usually written from.
+    """
+    diagnostics = await _diagnostics(hass, heating_circuit=1)
+
+    assert diagnostics["aiosolarfocus"] == aiosolarfocus_version
 
 
 async def test_home_assistant_serves_the_download(


### PR DESCRIPTION
The manifest pins one version, but a report is written from what is *installed* rather than from what is pinned.

fklein1980 ran a stale `aiosolarfocus` against their controller and neither of us could tell from the output they posted (#237). They asked for the command line to print its version, which LavermanJJ/aiosolarfocus#9 does. A diagnostics download is the same artefact for anyone who does not use the command line at all, and it falls into the same trap — so it now carries `aiosolarfocus` at the top level, beside the entry and the component snapshot.

`make check` and `make test` pass (692 passed, 5 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJgqKc1usTviSrXuA2Sn1T