### PR TITLE
Link a component to its controller by a key every core version has

### DIFF
--- a/custom_components/solarfocus/__init__.py
+++ b/custom_components/solarfocus/__init__.py
@@ -134,7 +134,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolarfocusConfigEntry) -
         ) from coordinator.last_exception
 
     hub = _async_hub_device(hass, entry, client)
-    coordinator.hub_device_id = hub.id
     entry.runtime_data = coordinator
 
     await _async_align_solar_unique_ids(hass, entry)

--- a/custom_components/solarfocus/coordinator.py
+++ b/custom_components/solarfocus/coordinator.py
@@ -91,11 +91,6 @@ class SolarfocusDataUpdateCoordinator(DataUpdateCoordinator[None]):
         self._entry = entry
         self.hass = hass
         self._failed_components: frozenset[tuple[str, str]] = frozenset()
-        # The controller every component device of this entry hangs off, set by
-        # `async_setup_entry` once the device is registered. A component device
-        # points at it by id rather than by identifier, which Home Assistant
-        # deprecates.
-        self.hub_device_id: str | None = None
         # The number the installer menu of the controller shows: typed in on
         # one entity of it and multiplied by another. Not a register, so it
         # lives here, where both platforms can reach it.

--- a/custom_components/solarfocus/entity.py
+++ b/custom_components/solarfocus/entity.py
@@ -199,15 +199,24 @@ class SolarfocusEntity(Entity):
             translation_placeholders={"idx": description.device_idx},
             model=device.model,
             manufacturer=MANUFACTURER,
+            # The controller every component hangs off, named by its
+            # identifiers rather than by its device id.
+            #
+            # `via_device_id` is what Home Assistant asks for now, and it is
+            # what this used to pass - but the key only exists from core
+            # 2026.8, and `hacs.json` offers this integration from 2025.1. On
+            # anything older the device registry refuses the keyword outright,
+            # which takes down the whole entity: every component sensor, number,
+            # select, switch, button, climate and water heater fails to be
+            # added, leaving an installation with the two entities of the
+            # controller and no component devices at all. See #242, where a
+            # Pellet Elegance on core 2026.3.4 lost all 173 of them.
+            #
+            # `via_device` is deprecated in favour of it and is removed in core
+            # 2027.8, so this has to become `via_device_id` before then -
+            # together with a minimum core version that has the key.
+            via_device=(DOMAIN, self._entry_id),
         )
-
-        # `async_setup_entry` registers the controller before it forwards the
-        # entry to the platforms, so this is set by the time an entity is asked
-        # for its device. Left out rather than passed as `None` if it is not:
-        # an explicit `None` reads as "no via device" and would unlink a
-        # component from the controller it hangs off.
-        if (hub_device_id := self.coordinator.hub_device_id) is not None:
-            device_info["via_device_id"] = hub_device_id
 
         return device_info
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -141,7 +141,6 @@ def test_device_info_puts_the_entity_on_its_own_component() -> None:
     """
     entry = build_config_entry(**FULLY_EQUIPPED)
     coordinator = build_coordinator(entry, build_client(entry))
-    coordinator.hub_device_id = "hub"
     entity = SolarfocusSensor(
         coordinator,
         create_description(
@@ -159,15 +158,17 @@ def test_device_info_puts_the_entity_on_its_own_component() -> None:
     assert device_info["translation_placeholders"] == {"idx": " 2"}
     assert device_info["model"] == BOILER_PREFIX
     assert device_info["manufacturer"] == MANUFACTURER
-    # Every component hangs off the controller
-    assert device_info["via_device_id"] == "hub"
+    # Every component hangs off the controller. `via_device`, not
+    # `via_device_id`: see the note on `device_info` - the newer key does not
+    # exist on the core versions this integration is offered for. See #242.
+    assert device_info["via_device"] == (DOMAIN, entry.entry_id)
+    assert "via_device_id" not in device_info
 
 
 def test_a_component_that_exists_once_is_not_numbered() -> None:
     """There is one heat pump, so its device is `Heat pump`, not `Heat pump 1`."""
     entry = build_config_entry(**FULLY_EQUIPPED)
     coordinator = build_coordinator(entry, build_client(entry))
-    coordinator.hub_device_id = "hub"
     entity = SolarfocusSwitchEntity(
         coordinator,
         create_description(


### PR DESCRIPTION
Fixes #242.

`DeviceInfo["via_device_id"]` **only exists from Home Assistant core 2026.8**. `hacs.json` offers this integration from **2025.1**. On anything older the device registry refuses the keyword outright — and that does not degrade the device link, it takes down the entity:

```
TypeError: DeviceRegistry.async_get_or_create() got an unexpected keyword argument
'via_device_id'. Did you mean 'via_device'?
```

Every component sensor, number, select, switch, button, climate and water heater fails to be added. What is left is the two entities of the controller — `service_code`, and `installer_code` which is disabled by default — and **no component devices at all**.

That is exactly what @CarlosDerSeher reported: a Pellet Elegance on core **2026.3.4**, first on 6.0.0 and again on 7.0.0-rc3, with 173 of these tracebacks in the log and nothing under the hub. His diagnostics looked perfectly healthy — `last_update_success: true`, live values on all four components — because the coordinator was never the problem. Only the log said what was.

Introduced in 6.0.0 (#213), so **every user on core < 2026.8 who took 6.0.0 lost their entities**.

## The fix

`via_device` carries the same link by the controller's identifiers instead of its device id. Checked against every core version I could get:

| core | `via_device` | `via_device_id` |
|---|---|---|
| 2026.3.4 (the reporter's) | ✅ | ❌ |
| 2026.4.0 | ✅ | ❌ |
| 2026.6.0 | ✅ | ❌ |
| 2026.7.0 | ✅ | ❌ |
| 2026.8.1 (this repo's CI) | ✅ deprecated | ✅ |

It also drops the ordering dependency the old code had: `coordinator.hub_device_id` had to be set before the platforms were forwarded, and the identifiers are known without asking the registry, so that attribute is gone.

`via_device` is deprecated in favour of `via_device_id` and is **removed in core 2027.8**, so this has to be switched back before then — together with a minimum core version that has the key. The comment on `device_info` says so, and the test asserts `via_device_id` is *not* used so nobody modernises it back by hand.

## Why the tests did not catch it

**CI runs a single core version.** `pytest-homeassistant-custom-component` pins one, and this repo's is 2026.8.1 — where both keys work. Nothing here would have failed. Worth considering a matrix over the oldest core `hacs.json` claims and the newest, but that is a bigger change than this fix and I have left it out.

I also checked every `homeassistant` import in the integration against the 2026.3.4 wheel; nothing else in the code needs a core newer than advertised.

`make check` and `make test` pass (692 passed, 5 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJgqKc1usTviSrXuA2Sn1T